### PR TITLE
Change to use mpassi for F2010 and F20TR

### DIFF
--- a/components/eam/cime_config/config_compsets.xml
+++ b/components/eam/cime_config/config_compsets.xml
@@ -68,6 +68,11 @@
 
   <compset>
     <alias>F20TR</alias>
+    <lname>20TR_EAM%CMIP6_ELM%SPBC_MPASSI%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>F20TR-CICE</alias>
     <lname>20TR_EAM%CMIP6_ELM%SPBC_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
@@ -78,6 +83,11 @@
 
   <compset>
     <alias>F2010</alias>
+    <lname>2010_EAM%CMIP6_ELM%SPBC_MPASSI%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>F2010-CICE</alias>
     <lname>2010_EAM%CMIP6_ELM%SPBC_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 


### PR DESCRIPTION
The original compsets are retained as F2010-CICE and F20TR-CICE

[non-BFB] for tests using F2010 or F20TR