### PR TITLE
Modify chemUCI mechanisms to meet thermal decomp reaction requirements

### DIFF
--- a/components/eam/chem_proc/inputs/pp_chemUCI_linozv3_mam4_resus_mom_soag_tag.in
+++ b/components/eam/chem_proc/inputs/pp_chemUCI_linozv3_mam4_resus_mom_soag_tag.in
@@ -198,11 +198,11 @@ CHEMISTRY
 [HO2NO2f]  NO2 + HO2 + M -> HO2NO2 + M            ; 1.90e-31, 3.4,  4.00e-12, 0.3, 0.6
 [N2O5f]  NO2 + NO3 + M -> N2O5 + M                ; 2.40E-30, 3.0,  1.60E-12,-0.1, 0.6
 [PANf]   CH3CO3 + NO2 + M -> PAN + M              ; 9.70E-29, 5.6,  9.30E-12, 1.5, 0.6
-[uci7]   HO2NO2 -> HO2 + NO2                      ; 2.10E-27, 10900
+[uci7]   HO2NO2 + M -> HO2 + NO2 + M              ; 2.10E-27, 10900
 *     k[uci7] -> k[HO2NO2] / k[uci7]
-[uci8]   N2O5 -> NO2 + NO3                        ; 5.80E-27, 10840
+[uci8]   N2O5 + M -> NO2 + NO3 + M                ; 5.80E-27, 10840
 *     k[uci8] -> k[N2O5] / k[uci8]
-[uci9]   PAN -> CH3CO3 + NO2                      ; 9.00E-29, 14000
+[uci9]   PAN + M -> CH3CO3 + NO2 + M              ; 9.00E-29, 14000
 *     k[uci9] -> k[PAN] / k[uci9]
 [lch3o2_ho2]   CH3O2 + HO2 -> CH3OOH + O2                     ; 4.100E-13, 750
 [lch3o2_no]    CH3O2 + NO -> CH2O + HO2 + NO2                 ; 2.800E-12, 300

--- a/components/eam/chem_proc/inputs/pp_chemUCI_mam4_resus_mom_soag.in
+++ b/components/eam/chem_proc/inputs/pp_chemUCI_mam4_resus_mom_soag.in
@@ -197,11 +197,11 @@ CHEMISTRY
 [HO2NO2f]  NO2 + HO2 + M -> HO2NO2 + M            ; 1.90e-31, 3.4,  4.00e-12, 0.3, 0.6
 [N2O5f]  NO2 + NO3 + M -> N2O5 + M                ; 2.40E-30, 3.0,  1.60E-12,-0.1, 0.6
 [PANf]   CH3CO3 + NO2 + M -> PAN + M              ; 9.70E-29, 5.6,  9.30E-12, 1.5, 0.6
-[uci7]   HO2NO2 -> HO2 + NO2                      ; 2.10E-27, 10900
+[uci7]   HO2NO2 + M -> HO2 + NO2 + M              ; 2.10E-27, 10900
 *     k[uci7] -> k[HO2NO2] / k[uci7]
-[uci8]   N2O5 -> NO2 + NO3                        ; 5.80E-27, 10840
+[uci8]   N2O5 + M -> NO2 + NO3 + M                ; 5.80E-27, 10840
 *     k[uci8] -> k[N2O5] / k[uci8]
-[uci9]   PAN -> CH3CO3 + NO2                      ; 9.00E-29, 14000
+[uci9]   PAN + M -> CH3CO3 + NO2 + M              ; 9.00E-29, 14000
 *     k[uci9] -> k[PAN] / k[uci9]
    CH3O2 + HO2 -> CH3OOH + O2                     ; 4.100E-13, 750
    CH3O2 + NO -> CH2O + HO2 + NO2                 ; 2.800E-12, 300

--- a/components/eam/chem_proc/inputs/pp_chemUCI_mam4_resus_mom_soag_tag.in
+++ b/components/eam/chem_proc/inputs/pp_chemUCI_mam4_resus_mom_soag_tag.in
@@ -197,11 +197,11 @@ CHEMISTRY
 [HO2NO2f]  NO2 + HO2 + M -> HO2NO2 + M            ; 1.90e-31, 3.4,  4.00e-12, 0.3, 0.6
 [N2O5f]  NO2 + NO3 + M -> N2O5 + M                ; 2.40E-30, 3.0,  1.60E-12,-0.1, 0.6
 [PANf]   CH3CO3 + NO2 + M -> PAN + M              ; 9.70E-29, 5.6,  9.30E-12, 1.5, 0.6
-[uci7]   HO2NO2 -> HO2 + NO2                      ; 2.10E-27, 10900
+[uci7]   HO2NO2 + M -> HO2 + NO2 + M              ; 2.10E-27, 10900
 *     k[uci7] -> k[HO2NO2] / k[uci7]
-[uci8]   N2O5 -> NO2 + NO3                        ; 5.80E-27, 10840
+[uci8]   N2O5 + M -> NO2 + NO3 + M                ; 5.80E-27, 10840
 *     k[uci8] -> k[N2O5] / k[uci8]
-[uci9]   PAN -> CH3CO3 + NO2                      ; 9.00E-29, 14000
+[uci9]   PAN + M -> CH3CO3 + NO2 + M              ; 9.00E-29, 14000
 *     k[uci9] -> k[PAN] / k[uci9]
 [lch3o2_ho2]   CH3O2 + HO2 -> CH3OOH + O2                     ; 4.100E-13, 750
 [lch3o2_no]    CH3O2 + NO -> CH2O + HO2 + NO2                 ; 2.800E-12, 300

--- a/components/eam/chem_proc/inputs/pp_chemUCIfastj_linozv3_mam4_resus_mom_soag_tag.in
+++ b/components/eam/chem_proc/inputs/pp_chemUCIfastj_linozv3_mam4_resus_mom_soag_tag.in
@@ -202,11 +202,11 @@ CHEMISTRY
 [HO2NO2f]  NO2 + HO2 + M -> HO2NO2 + M            ; 1.90e-31, 3.4,  4.00e-12, 0.3, 0.6
 [N2O5f]  NO2 + NO3 + M -> N2O5 + M                ; 2.40E-30, 3.0,  1.60E-12,-0.1, 0.6
 [PANf]   CH3CO3 + NO2 + M -> PAN + M              ; 9.70E-29, 5.6,  9.30E-12, 1.5, 0.6
-[uci7]   HO2NO2 -> HO2 + NO2                      ; 2.10E-27, 10900
+[uci7]   HO2NO2 + M -> HO2 + NO2 + M              ; 2.10E-27, 10900
 *     k[uci7] -> k[HO2NO2] / k[uci7]
-[uci8]   N2O5 -> NO2 + NO3                        ; 5.80E-27, 10840
+[uci8]   N2O5 + M -> NO2 + NO3 + M                ; 5.80E-27, 10840
 *     k[uci8] -> k[N2O5] / k[uci8]
-[uci9]   PAN -> CH3CO3 + NO2                      ; 9.00E-29, 14000
+[uci9]   PAN + M -> CH3CO3 + NO2 + M              ; 9.00E-29, 14000
 *     k[uci9] -> k[PAN] / k[uci9]
 [lch3o2_ho2]   CH3O2 + HO2 -> CH3OOH + O2                     ; 4.100E-13, 750
 [lch3o2_no]    CH3O2 + NO -> CH2O + HO2 + NO2                 ; 2.800E-12, 300

--- a/components/eam/chem_proc/inputs/pp_chemUCIfastj_mam4_resus_mom_soag.in
+++ b/components/eam/chem_proc/inputs/pp_chemUCIfastj_mam4_resus_mom_soag.in
@@ -201,11 +201,11 @@ CHEMISTRY
 [HO2NO2f]  NO2 + HO2 + M -> HO2NO2 + M            ; 1.90e-31, 3.4,  4.00e-12, 0.3, 0.6
 [N2O5f]  NO2 + NO3 + M -> N2O5 + M                ; 2.40E-30, 3.0,  1.60E-12,-0.1, 0.6
 [PANf]   CH3CO3 + NO2 + M -> PAN + M              ; 9.70E-29, 5.6,  9.30E-12, 1.5, 0.6
-[uci7]   HO2NO2 -> HO2 + NO2                      ; 2.10E-27, 10900
+[uci7]   HO2NO2 + M -> HO2 + NO2 + M              ; 2.10E-27, 10900
 *     k[uci7] -> k[HO2NO2] / k[uci7]
-[uci8]   N2O5 -> NO2 + NO3                        ; 5.80E-27, 10840
+[uci8]   N2O5 + M -> NO2 + NO3 + M                ; 5.80E-27, 10840
 *     k[uci8] -> k[N2O5] / k[uci8]
-[uci9]   PAN -> CH3CO3 + NO2                      ; 9.00E-29, 14000
+[uci9]   PAN + M -> CH3CO3 + NO2 + M              ; 9.00E-29, 14000
 *     k[uci9] -> k[PAN] / k[uci9]
 [lch3o2_ho2]   CH3O2 + HO2 -> CH3OOH + O2                     ; 4.100E-13, 750
 [lch3o2_no]    CH3O2 + NO -> CH2O + HO2 + NO2                 ; 2.800E-12, 300


### PR DESCRIPTION
The chemistry pre-processor requires "M" (air mass) on both sides of thermal decomposition reactions, which is a non-standard format. This commit changes in all chemUCI mechanism files the reactions of uci7, uci8, and uci9 for HO2NO2, N2O5, and PAN. The PAN reaction rate (uci9) has been verified with the ATom data.

This PR greatly improves the chemistry fields needed by new aerosol features (e.g., nitrate and SOA).

[non-BFB]

(cherry picked from commit f2ed7130003b7c09023b9a5e43a1a3f9c067e346)