### PR TITLE
Add ZM enhancement to v3atm branch

### DIFF
--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -3942,6 +3942,7 @@ add_default($nl, 'zmconv_tp_fac');
 add_default($nl, 'zmconv_alfa');
 add_default($nl, 'zmconv_trigdcape_ull');
 add_default($nl, 'zmconv_microp');
+add_default($nl, 'zmconv_clos_dyn_adj');
 
 # moist convection rainwater coefficients
 # These no more needed for EAM, including uwshcu_rpen. No need to reset for 'cam5'

--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -3943,6 +3943,9 @@ add_default($nl, 'zmconv_alfa');
 add_default($nl, 'zmconv_trigdcape_ull');
 add_default($nl, 'zmconv_microp');
 add_default($nl, 'zmconv_clos_dyn_adj');
+add_default($nl, 'zmconv_auto_fac');
+add_default($nl, 'zmconv_accr_fac');
+add_default($nl, 'zmconv_micro_dcs');
 
 # moist convection rainwater coefficients
 # These no more needed for EAM, including uwshcu_rpen. No need to reset for 'cam5'

--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -3941,6 +3941,7 @@ add_default($nl, 'zmconv_dmpdz');
 add_default($nl, 'zmconv_tp_fac');
 add_default($nl, 'zmconv_alfa');
 add_default($nl, 'zmconv_trigdcape_ull');
+add_default($nl, 'zmconv_microp');
 
 # moist convection rainwater coefficients
 # These no more needed for EAM, including uwshcu_rpen. No need to reset for 'cam5'

--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -3946,7 +3946,13 @@ add_default($nl, 'zmconv_clos_dyn_adj');
 add_default($nl, 'zmconv_auto_fac');
 add_default($nl, 'zmconv_accr_fac');
 add_default($nl, 'zmconv_micro_dcs');
-
+#++ MCSP
+add_default($nl, 'zmconv_MCSP_heat_coeff');
+add_default($nl, 'zmconv_MCSP_moisture_coeff');
+add_default($nl, 'zmconv_MCSP_uwind_coeff');
+add_default($nl, 'zmconv_MCSP_vwind_coeff');
+#-- MCSP
+#
 # moist convection rainwater coefficients
 # These no more needed for EAM, including uwshcu_rpen. No need to reset for 'cam5'
 #add_default($nl, 'hkconv_cmftau');

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -1108,6 +1108,7 @@
 <zmconv_dmpdz                                                         >-1.0E-3 </zmconv_dmpdz>
 <zmconv_tp_fac                                                        >0.D0 </zmconv_tp_fac>
 <zmconv_microp                                                        >.false. </zmconv_microp>
+<zmconv_clos_dyn_adj                                                  >.false. </zmconv_clos_dyn_adj>
 
 <!-- Cloud sedimentation -->
 

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -1112,6 +1112,11 @@
 <zmconv_auto_fac                                                      >7.0D0 </zmconv_auto_fac>
 <zmconv_accr_fac                                                      >1.5D0 </zmconv_accr_fac>
 <zmconv_micro_dcs                                                     >150.E-6</zmconv_micro_dcs>
+<!-- MCSP -->
+<zmconv_MCSP_heat_coeff                                               >0.0</zmconv_MCSP_heat_coeff>
+<zmconv_MCSP_moisture_coeff                                           >0.0</zmconv_MCSP_moisture_coeff>
+<zmconv_MCSP_uwind_coeff                                              >0.0</zmconv_MCSP_uwind_coeff>
+<zmconv_MCSP_vwind_coeff                                              >0.0</zmconv_MCSP_vwind_coeff>
 
 <!-- Cloud sedimentation -->
 

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -1109,6 +1109,9 @@
 <zmconv_tp_fac                                                        >0.D0 </zmconv_tp_fac>
 <zmconv_microp                                                        >.false. </zmconv_microp>
 <zmconv_clos_dyn_adj                                                  >.false. </zmconv_clos_dyn_adj>
+<zmconv_auto_fac                                                      >7.0D0 </zmconv_auto_fac>
+<zmconv_accr_fac                                                      >1.5D0 </zmconv_accr_fac>
+<zmconv_micro_dcs                                                     >150.E-6</zmconv_micro_dcs>
 
 <!-- Cloud sedimentation -->
 

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -1109,6 +1109,7 @@
 <zmconv_tp_fac                                                        >0.D0 </zmconv_tp_fac>
 <zmconv_microp                                                        >.false. </zmconv_microp>
 <zmconv_clos_dyn_adj                                                  >.false. </zmconv_clos_dyn_adj>
+<zmconv_tpert_fix                                                     >.false. </zmconv_tpert_fix>
 <zmconv_auto_fac                                                      >7.0D0 </zmconv_auto_fac>
 <zmconv_accr_fac                                                      >1.5D0 </zmconv_accr_fac>
 <zmconv_micro_dcs                                                     >150.E-6</zmconv_micro_dcs>

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -1107,6 +1107,7 @@
 <zmconv_mx_bot_lyr_adj                                                >0       </zmconv_mx_bot_lyr_adj>
 <zmconv_dmpdz                                                         >-1.0E-3 </zmconv_dmpdz>
 <zmconv_tp_fac                                                        >0.D0 </zmconv_tp_fac>
+<zmconv_microp                                                        >.false. </zmconv_microp>
 
 <!-- Cloud sedimentation -->
 

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -2570,21 +2570,21 @@ Default: set by build-namelist
 </entry>
 
 <entry id="zmconv_auto_fac" type="real" category="conv"
-       group="zmconv_nl" valid_values="" >
+       group="zmconv_nl" valid_values="" >    
 cloud droplet-rain autoconversion enhancement factor in convective microphysics scheme.
-Default: set by build-namelist
+Default: set by build-namelist  
 </entry>
 
 <entry id="zmconv_accr_fac" type="real" category="conv"
-       group="zmconv_nl" valid_values="" >
-cloud droplet-rain accretion enhancement factor in convective microphysics scheme.
-Default: set by build-namelist
+       group="zmconv_nl" valid_values="" >    
+cloud droplet-rain accretion enhancement factor in convective microphysics scheme.      
+Default: set by build-namelist  
 </entry>
 
 <entry id="zmconv_micro_dcs" type="real" category="conv"
-       group="zmconv_nl" valid_values="" >
-Autoconversion size threshold for cloud ice to snow (m)
-Default: set by build-namelist
+       group="zmconv_nl" valid_values="" >    
+Autoconversion size threshold for cloud ice to snow (m)     
+Default: set by build-namelist 
 </entry>
 
 

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -2557,6 +2557,12 @@ Tpert scale factor in ZM deep convection scheme.
 Default: 0.D0
 </entry>
 
+<entry id="zmconv_microp" type="logical" category="conv"
+       group="zmconv_nl" valid_values="" >
+Microphysics option in ZM deep convection scheme.
+Default: set by build-namelist
+</entry>
+
 
 <!-- Cloud sedimentation -->
 

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -2569,6 +2569,13 @@ Apply dynamics adjustment to CAPE closure
 Default: set by build-namelist
 </entry>
 
+<entry id="zmconv_tpert_fix" type="logical" category="conv"
+       group="zmconv_nl" valid_values="" >
+logical switch for tpert impacts in ZM deep convection scheme
+Default: set by build-namelist
+</entry>
+
+
 <entry id="zmconv_auto_fac" type="real" category="conv"
        group="zmconv_nl" valid_values="" >    
 cloud droplet-rain autoconversion enhancement factor in convective microphysics scheme.

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -2563,6 +2563,30 @@ Microphysics option in ZM deep convection scheme.
 Default: set by build-namelist
 </entry>
 
+<entry id="zmconv_clos_dyn_adj" type="logical" category="conv"
+       group="zmconv_nl" valid_values="" >
+Apply dynamics adjustment to CAPE closure
+Default: set by build-namelist
+</entry>
+
+<entry id="zmconv_auto_fac" type="real" category="conv"
+       group="zmconv_nl" valid_values="" >
+cloud droplet-rain autoconversion enhancement factor in convective microphysics scheme.
+Default: set by build-namelist
+</entry>
+
+<entry id="zmconv_accr_fac" type="real" category="conv"
+       group="zmconv_nl" valid_values="" >
+cloud droplet-rain accretion enhancement factor in convective microphysics scheme.
+Default: set by build-namelist
+</entry>
+
+<entry id="zmconv_micro_dcs" type="real" category="conv"
+       group="zmconv_nl" valid_values="" >
+Autoconversion size threshold for cloud ice to snow (m)
+Default: set by build-namelist
+</entry>
+
 
 <!-- Cloud sedimentation -->
 

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -2587,6 +2587,31 @@ Autoconversion size threshold for cloud ice to snow (m)
 Default: set by build-namelist 
 </entry>
 
+<!-- MCSP -->
+<entry id="zmconv_MCSP_heat_coeff" type="real" category="conv"
+       group="zmconv_nl" valid_values="" >
+Multiscale Coherent System Parameterization (MCSP), heating coefficient
+Default: set by build-namelist
+</entry>
+
+<entry id="zmconv_MCSP_moisture_coeff" type="real" category="conv"
+       group="zmconv_nl" valid_values="" >
+Multiscale Coherent System Parameterization (MCSP), moisture coefficient
+Default: set by build-namelist
+</entry>
+
+<entry id="zmconv_MCSP_uwind_coeff" type="real" category="conv"
+       group="zmconv_nl" valid_values="" >
+Multiscale Coherent System Parameterization (MCSP), zonal wind coefficient
+Default: set by build-namelist
+</entry>
+
+<entry id="zmconv_MCSP_vwind_coeff" type="real" category="conv"
+       group="zmconv_nl" valid_values="" >
+Multiscale Coherent System Parameterization (MCSP), meridional wind coefficient
+Default: set by build-namelist
+</entry>
+
 
 <!-- Cloud sedimentation -->
 

--- a/components/eam/src/physics/cam/activate_drop_mam.F90
+++ b/components/eam/src/physics/cam/activate_drop_mam.F90
@@ -1,0 +1,573 @@
+module activate_drop_mam
+
+!---------------------------------------------------------------------------------
+!
+! Routines for droplet activation by modal aerosols
+!
+!---------------------------------------------------------------------------------
+
+use shr_kind_mod,   only: r8 => shr_kind_r8
+#ifndef HAVE_ERF_INTRINSICS
+use shr_spfn_mod,   only: erf => shr_spfn_erf
+#endif
+use wv_saturation,  only: qsat
+
+use cam_abortutils,       only: endrun
+
+implicit none
+private       
+save
+
+public &
+   actdrop_mam_init,  &
+   actdrop_mam_calc
+
+integer :: iulog           ! fortran unit to use for log messages
+
+real(r8) :: pi
+real(r8) :: rair
+real(r8) :: rgas
+real(r8) :: rh2o
+real(r8) :: rhoh2o
+real(r8) :: mwh2o
+real(r8) :: epsilo      ! Ratio of h2o to dry air molecular weights 
+real(r8) :: latvap
+real(r8) :: cpair
+real(r8) :: gravit
+
+real(r8), parameter :: t0       = 273._r8
+real(r8), parameter :: p0       = 1013.25e2_r8    ! reference pressure (Pa)
+real(r8), parameter :: surften  = 0.076_r8
+real(r8), parameter :: zero     = 0._r8
+real(r8), parameter :: third    = 1._r8/3._r8
+real(r8), parameter :: twothird = 2._r8*third
+real(r8), parameter :: sixth    = 1._r8/6._r8
+
+real(r8) :: sq2, alog2, alog3, sqpi
+real(r8) :: aten, alogaten
+
+integer :: nmode
+real(r8), allocatable :: alogsig(:)     ! natl log of geometric standard dev of aerosol
+real(r8), allocatable :: exp45logsig(:)
+real(r8), allocatable :: f1(:)          ! abdul-razzak functions of width
+real(r8), allocatable :: f2(:)          ! abdul-razzak functions of width
+
+!===============================================================================
+contains
+!===============================================================================
+
+subroutine actdrop_mam_init( &
+   iulog_in, pi_in, rair_in, rgas_in, rh2o_in,          &
+   rhoh2o_in, mwh2o_in, epsilo_in, latvap_in, cpair_in, &
+   gravit_in, ntot_amode, sigmag_amode)
+
+   integer,              intent(in)  :: iulog_in         ! fortran unit to use for log messages
+   real(r8),             intent(in)  :: pi_in
+   real(r8),             intent(in)  :: rair_in
+   real(r8),             intent(in)  :: rgas_in
+   real(r8),             intent(in)  :: rh2o_in
+   real(r8),             intent(in)  :: rhoh2o_in
+   real(r8),             intent(in)  :: mwh2o_in
+   real(r8),             intent(in)  :: epsilo_in       ! Ratio of h2o to dry air molecular weights
+   real(r8),             intent(in)  :: latvap_in
+   real(r8),             intent(in)  :: cpair_in
+   real(r8),             intent(in)  :: gravit_in
+   integer,              intent(in)  :: ntot_amode
+   real(r8),             intent(in)  :: sigmag_amode(ntot_amode)
+
+   integer :: m
+
+   character(len=*), parameter :: subname='actdrop_mam_init'
+   !---------------------------------------------------------------------------------
+    
+   iulog  = iulog_in
+
+   pi     = pi_in
+   rair   = rair_in
+   rgas   = rgas_in
+   rh2o   = rh2o_in
+   rhoh2o = rhoh2o_in
+   mwh2o  = mwh2o_in
+   epsilo = epsilo_in
+   latvap = latvap_in
+   cpair  = cpair_in
+   gravit = gravit_in
+
+   sq2    = sqrt(2._r8)
+   alog2  = log(2._r8)
+   alog3  = log(3._r8)
+   sqpi   = sqrt(pi)
+   aten   = 2._r8*mwh2o*surften/(rgas*t0*rhoh2o)
+   alogaten = log(aten)
+
+   allocate( &
+      alogsig(ntot_amode),      &
+      exp45logsig(ntot_amode),  &
+      f1(ntot_amode),           &
+      f2(ntot_amode) )
+
+   do m = 1, ntot_amode
+      ! use only if width of size distribution is prescribed
+      alogsig(m)     = log(sigmag_amode(m))
+      exp45logsig(m) = exp(4.5_r8*alogsig(m)*alogsig(m))
+      f1(m)          = 0.5_r8*exp(2.5_r8*alogsig(m)*alogsig(m))
+      f2(m)          = 1._r8 + 0.25_r8*alogsig(m)
+   end do
+
+end subroutine actdrop_mam_init
+
+!---------------------------------------------------------------------------------
+
+subroutine actdrop_mam_calc(        &
+   wbar, sigw, wdiab, wminf, wmaxf, &
+   tair, rhoair, na, nmode, volume, &
+   hygro, in_cloud, smax_f, fn, fm, &
+   fluxn, fluxm, flux_fullact)
+
+   ! calculates number, surface, and mass fraction of aerosols activated as CCN
+   ! calculates flux of cloud droplets, surface area, and aerosol mass into cloud
+   ! assumes an internal mixture within each of up to nmode multiple aerosol modes
+   ! a gaussiam spectrum of updrafts can be treated.
+   !
+   ! **** NOTE **** The modification to the in-cloud calculation of smax has only
+   !                implemented in the single updraft branch of the sigw conditional
+   !
+   ! mks units
+   !
+   ! Abdul-Razzak and Ghan, A parameterization of aerosol activation.
+   ! 2. Multiple aerosol types. J. Geophys. Res., 105, 6837-6844.
+
+   ! Input Arguments
+   real(r8), intent(in) :: wbar       ! grid cell mean vertical velocity (m/s)
+   real(r8), intent(in) :: sigw       ! subgrid standard deviation of vertical vel (m/s)
+   real(r8), intent(in) :: wdiab      ! diabatic vertical velocity (0 if adiabatic)
+   real(r8), intent(in) :: wminf      ! minimum updraft velocity for integration (m/s)
+   real(r8), intent(in) :: wmaxf      ! maximum updraft velocity for integration (m/s)
+   real(r8), intent(in) :: tair       ! air temperature (K)
+   real(r8), intent(in) :: rhoair     ! air density (kg/m3)
+   real(r8), intent(in) :: na(:)      ! (nmode) aerosol number concentration (/m3)
+   integer,  intent(in) :: nmode      ! number of aerosol modes
+   real(r8), intent(in) :: volume(:)  ! (nmode) aerosol volume concentration (m3/m3)
+   real(r8), intent(in) :: hygro(:)   ! (nmode) hygroscopicity of aerosol mode
+   logical,  intent(in) :: in_cloud   ! switch to modify calculations when above cloud base
+   real(r8), intent(in) :: smax_f     ! droplet and rain size distr factor in the smax calculation
+                                      ! used when in_cloud=.true.
+
+   ! Output Arguments
+   real(r8), intent(out) :: fn(:)      ! (nmode) number fraction of aerosols activated
+   real(r8), intent(out) :: fm(:)      ! (nmode) mass fraction of aerosols activated
+   real(r8), intent(out) :: fluxn(:)   ! (nmode) flux of activated aerosol number fraction into cloud (cm/s)
+   real(r8), intent(out) :: fluxm(:)   ! (nmode) flux of activated aerosol mass fraction into cloud (cm/s)
+   real(r8), intent(out) :: flux_fullact   ! flux of activated aerosol fraction assuming 100% activation (cm/s)
+
+   !    rce-comment
+   !    used for consistency check -- this should match (ekd(k)*zs(k))
+   !    also, fluxm/flux_fullact gives fraction of aerosol mass flux
+   !       that is activated
+
+   !      local
+
+   integer, parameter:: nx=200
+   integer :: m, n
+
+   real(r8), parameter :: eps=0.3_r8, fmax=0.99_r8, sds=3._r8
+
+   real(r8) :: pres ! pressure (Pa)
+   real(r8) :: diff0, conduct0
+
+   real(r8) :: es ! saturation vapor pressure
+   real(r8) :: qs ! water vapor saturation mixing ratio
+   real(r8) :: dqsdt ! change in qs with temperature
+
+   real(r8) :: alpha
+   real(r8) :: gamma
+   real(r8) :: etafactor2(nmode), etafactor2max
+
+   real(r8) :: amcube(nmode) ! cube of dry mode radius (m)
+   real(r8) :: grow, beta
+   real(r8) :: sqrtg(nmode)
+   real(r8) :: smc(nmode)    ! critical supersaturation for number mode radius
+   real(r8) :: lnsm(nmode)   ! ln(smc)
+
+   real(r8) :: wmin, wmax, w, dw, dwmax, dwmin, wnuc, dwnew
+   real(r8) :: dfmin, dfmax
+   real(r8) :: sumflxn(nmode)
+   real(r8) :: sumflxm(nmode)
+   real(r8) :: sumfn(nmode)
+   real(r8) :: sumfm(nmode)
+   real(r8) :: fnold(nmode)   ! number fraction activated
+   real(r8) :: fmold(nmode)   ! mass fraction activated
+   real(r8) :: sumflx_fullact
+   real(r8) :: fold, wold, gold
+   real(r8) :: alw, sqrtalw, etafactor1
+   real(r8) :: zeta(nmode), eta(nmode)
+   real(r8) :: smax
+   real(r8) :: lnsmax ! ln(smax)
+   real(r8) :: x, fnew
+   real(r8) :: g, z, fnmin
+
+   real(r8) :: arg
+   real(r8) :: fnbar, fmbar, wb
+
+   real(r8) :: z1, z2
+   real(r8) :: integ,integf
+   real(r8) :: wf1, wf2, zf1, zf2, gf1, gf2, gf
+
+   character(len=*), parameter :: subname='actdrop_mam_calc'
+   !---------------------------------------------------------------------------------
+
+   fn(:)        = 0._r8
+   fm(:)        = 0._r8
+   fluxn(:)     = 0._r8
+   fluxm(:)     = 0._r8
+   flux_fullact = 0._r8
+
+   if (nmode == 1 .and. na(1) < 1.e-20_r8) return
+
+   if (sigw <= 1.e-5_r8 .and. wbar <= 0._r8) return
+
+   pres     = rair*rhoair*tair
+   diff0    = 0.211e-4_r8*(p0/pres)*(tair/t0)**1.94_r8
+   conduct0 = (5.69_r8 + 0.017_r8*(tair-t0))*4.186e2_r8*1.e-5_r8 ! convert to J/m/s/deg
+!<songxl 2014-11-20---------
+!   es    = estblf(tair)
+!   qs    = epsilo*es/(pres - (1.0_r8 - epsilo)*es)
+   call qsat(tair, pres, es, qs)
+!>songxl 2014-11-20---------
+   dqsdt = latvap/(rh2o*tair*tair)*qs
+   alpha = gravit*(latvap/(cpair*rh2o*tair*tair) - 1._r8/(rair*tair))
+   gamma = (1.0_r8 + latvap/cpair*dqsdt)/(rhoair*qs)
+
+   etafactor2max=1.e10_r8/(alpha*wmaxf)**1.5_r8 ! this should make eta big if na is very small.
+
+   ! growth coefficent Abdul-Razzak & Ghan 1998 eqn 16
+   ! should depend on mean radius of mode to account for gas kinetic effects
+   ! see Fountoukis and Nenes, JGR2005 and Meskhidze et al., JGR2006
+   ! for approriate size to use for effective diffusivity.
+   grow = 1._r8/(rhoh2o/(diff0*rhoair*qs)  &
+          + latvap*rhoh2o/(conduct0*tair)*(latvap/(rh2o*tair) - 1._r8))
+
+   do m = 1, nmode
+
+      sqrtg(m) = sqrt(grow)
+
+      if (volume(m) > 1.e-39_r8 .and. na(m) > 1.e-39_r8) then
+
+         ! number mode radius (m)
+         ! write(iulog,*)'alogsig,volc,na=',alogsig(m),volc(m),na(m)
+         amcube(m) = (3._r8*volume(m)/(4._r8*pi*exp45logsig(m)*na(m)))  ! only if variable size dist
+
+         beta = 2._r8*pi*rhoh2o*grow*gamma
+         etafactor2(m) = 1._r8/(na(m)*beta*sqrtg(m))
+
+         if (hygro(m) > 1.e-10_r8) then
+            smc(m) = 2._r8*aten*sqrt(aten/(27._r8*hygro(m)*amcube(m))) ! only if variable size dist
+         else
+            smc(m) = 100._r8
+         endif
+         ! write(iulog,*)'hygro,amcube=',hygro(m),amcube(m)
+      else
+         etafactor2(m) = etafactor2max ! this should make eta big if na is very small.
+         smc(m) = 1._r8
+      endif
+
+      lnsm(m) = log(smc(m))
+
+      ! write(iulog,'(a,i4,4g12.2)')'m,na,amcube,hygro,sm,lnsm=', &
+      !                   m,na(m),amcube(m),hygro(m),sm(m),lnsm(m)
+   end do
+
+   if (sigw > 1.e-5_r8) then ! spectrum of updrafts
+
+      wmax  = min(wmaxf, wbar+sds*sigw)
+      wmin  = max(wminf, -wdiab)
+      wmin  = max(wmin, wbar-sds*sigw)
+      w     = wmin
+      dwmax = eps*sigw
+      dw    = dwmax
+      dfmax = 0.2_r8
+      dfmin = 0.1_r8
+
+      ! *** return ***
+      if (wmax <= w) return
+
+      sumflxn(:)     = 0._r8
+      sumfn(:)       = 0._r8
+      fnold(:)       = 0._r8
+      sumflxm(:)     = 0._r8
+      sumfm(:)       = 0._r8
+      fmold(:)       = 0._r8
+      sumflx_fullact = 0._r8
+
+      fold = 0._r8
+      wold = 0._r8
+      gold = 0._r8
+
+      dwmin = min(dwmax, 0.01_r8)
+
+      do n = 1, nx
+
+100      wnuc       = w + wdiab
+         ! write(iulog,*)'wnuc=',wnuc
+         alw        = alpha*wnuc
+         sqrtalw    = sqrt(alw)
+         etafactor1 = alw*sqrtalw
+
+         do m = 1, nmode
+            eta(m)  = etafactor1*etafactor2(m)
+            zeta(m) = twothird*sqrtalw*aten/sqrtg(m)
+         enddo
+
+         call maxsat(zeta, eta, nmode, smc, smax)
+         ! write(iulog,*)'w,smax=',w,smax
+
+         lnsmax = log(smax)
+         x      = twothird*(lnsm(nmode) - lnsmax)/(sq2*alogsig(nmode))
+         fnew   = 0.5_r8*(1._r8 - erf(x))
+
+         dwnew = dw
+         if (fnew-fold > dfmax .and. n > 1) then
+            ! reduce updraft increment for greater accuracy in integration
+            if (dw .gt. 1.01_r8*dwmin) then
+               dw = 0.7_r8*dw
+               dw = max(dw, dwmin)
+               w  = wold + dw
+               go to 100
+            else
+               dwnew = dwmin
+            end if
+         end if
+
+         if (fnew-fold < dfmin) then
+            ! increase updraft increment to accelerate integration
+            dwnew = min(1.5_r8*dw, dwmax)
+         end if
+         fold = fnew
+
+         z = (w - wbar)/(sigw*sq2)
+         g = exp(-z*z)
+         fnmin = 1._r8
+
+         do m = 1, nmode
+            ! modal
+            x     = twothird*(lnsm(m) - lnsmax)/(sq2*alogsig(m))
+            fn(m) = 0.5_r8*(1._r8 - erf(x))
+            fnmin = min(fn(m), fnmin)
+            ! integration is second order accurate
+            ! assumes linear variation of f*g with w
+            fnbar = (fn(m)*g + fnold(m)*gold)
+            arg   = x - 1.5_r8*sq2*alogsig(m)
+            fm(m) = 0.5_r8*(1._r8 - erf(arg))
+            fmbar = (fm(m)*g + fmold(m)*gold)
+            wb    = (w + wold)
+            if (w > 0._r8) then
+               sumflxn(m) = sumflxn(m) + sixth*(wb*fnbar           &
+                            + (fn(m)*g*w + fnold(m)*gold*wold))*dw
+               sumflxm(m) = sumflxm(m) + sixth*(wb*fmbar           &
+                            + (fm(m)*g*w + fmold(m)*gold*wold))*dw
+            endif
+            sumfn(m) = sumfn(m) + 0.5_r8*fnbar*dw
+            ! write(iulog,'(a,9g10.2)')'lnsmax,lnsm(m),x,fn(m),fnold(m),g,gold,fnbar,dw=',lnsmax,lnsm(m),x,fn(m),fnold(m),g,gold,fnbar,dw
+            fnold(m) = fn(m)
+            sumfm(m) = sumfm(m) + 0.5_r8*fmbar*dw
+            fmold(m) = fm(m)
+         end do
+
+         ! same form as sumflxm but replace the fm with 1.0
+         sumflx_fullact = sumflx_fullact + sixth*(wb*(g + gold) + (g*w + gold*wold))*dw
+         ! sumg=sumg+0.5_r8*(g+gold)*dw
+
+         gold = g
+         wold = w
+         dw   = dwnew
+
+         if (n > 1 .and. (w > wmax .or. fnmin > fmax)) exit
+
+         w = w + dw
+
+         if (n == nx) then
+            write(iulog,*)'do loop is too short in activate'
+            write(iulog,*)'wmin=',wmin,' w=',w,' wmax=',wmax,' dw=',dw
+            write(iulog,*)'wbar=',wbar,' sigw=',sigw,' wdiab=',wdiab
+            write(iulog,*)'wnuc=',wnuc
+            write(iulog,*)'na=',(na(m),m=1,nmode)
+            write(iulog,*)'fn=',(fn(m),m=1,nmode)
+            !   dump all subr parameters to allow testing with standalone code
+            !   (build a driver that will read input and call activate)
+            write(iulog,*)'wbar,sigw,wdiab,tair,rhoair,nmode='
+            write(iulog,*) wbar,sigw,wdiab,tair,rhoair,nmode
+            write(iulog,*)'na=',na
+            write(iulog,*)'volume=', (volume(m),m=1,nmode)
+            write(iulog,*)'hydro='
+            write(iulog,*) hygro
+            call endrun(subname)
+         end if
+
+      end do  ! n = 1, nx
+
+
+      if (w < wmaxf) then
+
+         ! contribution from all updrafts stronger than wmax
+         ! assuming constant f (close to fmax)
+         wnuc = w + wdiab
+
+         z1 = (w - wbar)/(sigw*sq2)
+         z2 = (wmaxf - wbar)/(sigw*sq2)
+         g  = exp(-z1*z1)
+         integ = sigw*0.5_r8*sq2*sqpi*(erf(z2) - erf(z1))
+         ! consider only upward flow into cloud base when estimating flux
+         wf1 = max(w, zero)
+         zf1 = (wf1 - wbar)/(sigw*sq2)
+         gf1 = exp(-zf1*zf1)
+         wf2 = max(wmaxf, zero)
+         zf2 = (wf2 - wbar)/(sigw*sq2)
+         gf2 = exp(-zf2*zf2)
+         gf  = (gf1 - gf2)
+         integf = wbar*sigw*0.5_r8*sq2*sqpi*(erf(zf2) - erf(zf1)) + sigw*sigw*gf
+
+         do m = 1, nmode
+            sumflxn(m) = sumflxn(m) + integf*fn(m)
+            sumfn(m)   = sumfn(m) + fn(m)*integ
+            sumflxm(m) = sumflxm(m) + integf*fm(m)
+            sumfm(m)   = sumfm(m) + fm(m)*integ
+         end do
+         ! same form as sumflxm but replace the fm with 1.0
+         sumflx_fullact = sumflx_fullact + integf
+         ! sumg=sumg+integ
+      end if
+
+      do m = 1, nmode
+
+         fn(m) = sumfn(m)/(sq2*sqpi*sigw)
+         ! fn(m)=sumfn(m)/(sumg)
+
+         if (fn(m) > 1.01_r8) then
+            write(iulog,*)'fn=',fn(m),' > 1 in activate'
+            write(iulog,*)'w,m,na,amcube=',w,m,na(m),amcube(m)
+            write(iulog,*)'integ,sumfn,sigw=',integ,sumfn(m),sigw
+            call endrun(subname)
+         end if
+
+         fluxn(m) = sumflxn(m)/(sq2*sqpi*sigw)
+         fm(m)    = sumfm(m)/(sq2*sqpi*sigw)
+         ! fm(m)=sumfm(m)/(sumg)
+         if (fm(m) > 1.01_r8) then
+            write(iulog,*)'fm=',fm(m),' > 1 in activate'
+         end if
+         fluxm(m) = sumflxm(m)/(sq2*sqpi*sigw)
+      end do
+      ! same form as fluxm
+      flux_fullact = sumflx_fullact/(sq2*sqpi*sigw)
+
+   else ! single updraft
+
+      wnuc = wbar + wdiab
+
+      if (wnuc > 0._r8) then
+
+         w = wbar
+
+         if (in_cloud) then
+
+            if (smax_f > 0._r8) then
+               smax = alpha*w/(2.0_r8*pi*rhoh2o*grow*gamma*smax_f)
+            else
+               smax = 1.e-20_r8
+            end if
+
+         else ! at cloud base
+
+            alw        = alpha*wnuc
+            sqrtalw    = sqrt(alw)
+            etafactor1 = alw*sqrtalw
+
+            do m = 1, nmode
+               eta(m)  = etafactor1*etafactor2(m)
+               zeta(m) = twothird*sqrtalw*aten/sqrtg(m)
+            end do
+
+            call maxsat(zeta, eta, nmode, smc, smax)
+
+         end if
+
+         lnsmax    = log(smax)
+
+         do m = 1, nmode
+
+            x     = twothird*(lnsm(m) - lnsmax)/(sq2*alogsig(m))
+            fn(m) = 0.5_r8*(1._r8 - erf(x))
+            arg   = x - 1.5_r8*sq2*alogsig(m)
+            fm(m) = 0.5_r8*(1._r8 - erf(arg))
+
+            if (wbar > 0._r8) then
+               fluxn(m) = fn(m)*w
+               fluxm(m) = fm(m)*w
+            end if
+
+         end do
+
+         flux_fullact = w
+
+      end if  ! wnuc>0
+
+   endif  ! single updraft
+
+end subroutine actdrop_mam_calc
+
+!===============================================================================
+
+subroutine maxsat(zeta, eta, nmode, smc, smax)
+
+   ! calculates maximum supersaturation for multiple
+   ! competing aerosol modes.
+   !
+   ! Abdul-Razzak and Ghan, A parameterization of aerosol activation.
+   ! 2. Multiple aerosol types. J. Geophys. Res., 105, 6837-6844.
+
+   integer,  intent(in)  :: nmode       ! number of modes
+   real(r8), intent(in)  :: smc(nmode)  ! critical supersaturation for number mode radius
+   real(r8), intent(in)  :: zeta(nmode)
+   real(r8), intent(in)  :: eta(nmode)
+   real(r8), intent(out) :: smax        ! maximum supersaturation
+
+   integer  :: m
+   real(r8) :: sum, g1, g2, g1sqrt, g2sqrt
+   !---------------------------------------------------------------------------------
+
+   do m = 1, nmode
+      if (zeta(m) > 1.e5_r8*eta(m) .or. smc(m)*smc(m) > 1.e5_r8*eta(m)) then
+         ! weak forcing. essentially none activated
+         smax = 1.e-20_r8
+      else
+         ! significant activation of this mode. calc activation all modes.
+         exit
+      end if
+
+      ! No significant activation in any mode.  Do nothing.
+      if (m == nmode) return
+
+   end do
+
+   sum = 0.0_r8
+   do m = 1, nmode
+      if (eta(m) > 1.e-20_r8) then
+         g1     = zeta(m)/eta(m)
+         g1sqrt = sqrt(g1)
+         g1     = g1sqrt*g1
+         g2     = smc(m)/sqrt(eta(m) + 3._r8*zeta(m))
+         g2sqrt = sqrt(g2)
+         g2     = g2sqrt*g2
+         sum    = sum + (f1(m)*g1 + f2(m)*g2)/(smc(m)*smc(m))
+      else
+         sum = 1.e20_r8
+      end if
+   end do
+
+   smax = 1._r8/sqrt(sum)
+
+end subroutine maxsat
+
+!===============================================================================
+
+end module activate_drop_mam

--- a/components/eam/src/physics/cam/activate_drop_mam.F90
+++ b/components/eam/src/physics/cam/activate_drop_mam.F90
@@ -229,11 +229,7 @@ subroutine actdrop_mam_calc(        &
    pres     = rair*rhoair*tair
    diff0    = 0.211e-4_r8*(p0/pres)*(tair/t0)**1.94_r8
    conduct0 = (5.69_r8 + 0.017_r8*(tair-t0))*4.186e2_r8*1.e-5_r8 ! convert to J/m/s/deg
-!<songxl 2014-11-20---------
-!   es    = estblf(tair)
-!   qs    = epsilo*es/(pres - (1.0_r8 - epsilo)*es)
    call qsat(tair, pres, es, qs)
-!>songxl 2014-11-20---------
    dqsdt = latvap/(rh2o*tair*tair)*qs
    alpha = gravit*(latvap/(cpair*rh2o*tair*tair) - 1._r8/(rair*tair))
    gamma = (1.0_r8 + latvap/cpair*dqsdt)/(rhoair*qs)

--- a/components/eam/src/physics/cam/clubb_intr.F90
+++ b/components/eam/src/physics/cam/clubb_intr.F90
@@ -37,6 +37,8 @@ module clubb_intr
   use shr_kind_mod,     only: core_rknd=>shr_kind_r8
 #endif
 
+  use zm_conv,      only: zm_microp
+
   implicit none
 
   private
@@ -223,6 +225,15 @@ module clubb_intr
     ixvp2 = 0
 
   integer :: cmfmc_sh_idx = 0
+
+! ZM convective microphysics(zm_microp)
+  integer :: &
+    dlfzm_idx  = -1,    & ! index of ZM detrainment of convective cloud water mixing ratio.
+    difzm_idx  = -1,    & ! index of ZM detrainment of convective cloud ice mixing ratio.
+    dsfzm_idx  = -1,    & ! index of ZM detrainment of convective snow mixing ratio.
+    dnlfzm_idx = -1,    & ! index of ZM detrainment of convective cloud water num concen.
+    dnifzm_idx = -1,    & ! index of ZM detrainment of convective cloud ice num concen.
+    dnsfzm_idx = -1       ! index of ZM detrainment of convective snow num concen.
 
   real(r8) :: dp1 !set in namelist; assigned in cloud_fraction.F90
   !  Output arrays for CLUBB statistics
@@ -763,6 +774,15 @@ end subroutine clubb_init_cnst
     iiedsclr_rt  = -1
     iiedsclr_thl = -1
     iiedsclr_CO2 = -1
+
+    if (zm_microp) then
+        dlfzm_idx = pbuf_get_index('DLFZM')
+        difzm_idx = pbuf_get_index('DIFZM')
+        dsfzm_idx = pbuf_get_index('DSFZM')
+        dnlfzm_idx = pbuf_get_index('DNLFZM')
+        dnifzm_idx = pbuf_get_index('DNIFZM')
+        dnsfzm_idx = pbuf_get_index('DNSFZM')
+    end if
 
     ! ----------------------------------------------------------------- !
     ! Define number of tracers for CLUBB to diffuse
@@ -1448,6 +1468,15 @@ end subroutine clubb_init_cnst
    real(r8), pointer, dimension(:,:) :: prer_evap
    real(r8), pointer, dimension(:,:) :: qrl
    real(r8), pointer, dimension(:,:) :: radf_clubb
+
+   ! ZM convective microphysics(zm_microp)
+   real(r8), pointer :: dlfzm(:,:)  ! ZM detrainment of convective cloud water mixing ratio.
+   real(r8), pointer :: difzm(:,:)  ! ZM detrainment of convective cloud ice mixing ratio.
+   real(r8), pointer :: dsfzm(:,:)  ! ZM detrainment of convective snow mixing ratio.
+   real(r8), pointer :: dnlfzm(:,:) ! ZM detrainment of convective cloud water num concen.
+   real(r8), pointer :: dnifzm(:,:) ! ZM detrainment of convective cloud ice num concen.
+   real(r8), pointer :: dnsfzm(:,:) ! ZM detrainment of convective snow num concen.
+
 !PMA
    real(r8)  relvarc(pcols,pver)
    real(r8)  stend(pcols,pver)
@@ -2610,6 +2639,15 @@ end subroutine clubb_init_cnst
 
    call physics_ptend_init(ptend_loc,state%psetcols, 'clubb_det', ls=.true., lq=lqice)
 
+   if (zm_microp) then
+      call pbuf_get_field(pbuf, dlfzm_idx, dlfzm)
+      call pbuf_get_field(pbuf, difzm_idx, difzm)
+      call pbuf_get_field(pbuf, dsfzm_idx, dsfzm)
+      call pbuf_get_field(pbuf, dnlfzm_idx, dnlfzm)
+      call pbuf_get_field(pbuf, dnifzm_idx, dnifzm)
+      call pbuf_get_field(pbuf, dnsfzm_idx, dnsfzm)
+   end if
+
    call t_startf('ice_cloud_detrain_diag')
    do k=1,pver
       do i=1,ncol
@@ -2623,17 +2661,29 @@ end subroutine clubb_init_cnst
             dum1 = ( clubb_tk1 - state1%t(i,k) ) /(clubb_tk1 - clubb_tk2)
          endif
 
-         ptend_loc%q(i,k,ixcldliq) = dlf(i,k) * ( 1._r8 - dum1 )
-         ptend_loc%q(i,k,ixcldice) = dlf(i,k) * dum1
-         ptend_loc%q(i,k,ixnumliq) = 3._r8 * ( max(0._r8, ( dlf(i,k) - dlf2(i,k) )) * ( 1._r8 - dum1 ) ) &
-                                     / (4._r8*3.14_r8* clubb_liq_deep**3*997._r8) + & ! Deep    Convection
-                                     3._r8 * (                         dlf2(i,k)    * ( 1._r8 - dum1 ) ) &
-                                     / (4._r8*3.14_r8*clubb_liq_sh**3*997._r8)     ! Shallow Convection
-         ptend_loc%q(i,k,ixnumice) = 3._r8 * ( max(0._r8, ( dlf(i,k) - dlf2(i,k) )) *  dum1 ) &
-                                     / (4._r8*3.14_r8*clubb_ice_deep**3*500._r8) + & ! Deep    Convection
-                                     3._r8 * (                         dlf2(i,k)    *  dum1 ) &
-                                     / (4._r8*3.14_r8*clubb_ice_sh**3*500._r8)     ! Shallow Convection
-         ptend_loc%s(i,k)          = dlf(i,k) * dum1 * latice
+         if (zm_microp) then
+           ptend_loc%q(i,k,ixcldliq) = dlfzm(i,k) + dlf2(i,k) * ( 1._r8 - dum1 )
+           ptend_loc%q(i,k,ixcldice) = difzm(i,k) + dsfzm(i,k) +  dlf2(i,k) * dum1
+           ptend_loc%q(i,k,ixnumliq) = dnlfzm(i,k) + 3._r8 * ( dlf2(i,k) * ( 1._r8 - dum1 ) )   &
+                                                   / (4._r8*3.14_r8*clubb_liq_sh**3*997._r8)      ! Shallow Convection
+           ptend_loc%q(i,k,ixnumice) = dnifzm(i,k) + dnsfzm(i,k) + 3._r8 * ( dlf2(i,k) * dum1 ) &
+                                                   / (4._r8*3.14_r8*clubb_ice_sh**3*500._r8)      ! Shallow Convection
+           ptend_loc%s(i,k)          = dlf2(i,k) * dum1 * latice
+         else
+
+           ptend_loc%q(i,k,ixcldliq) = dlf(i,k) * ( 1._r8 - dum1 )
+           ptend_loc%q(i,k,ixcldice) = dlf(i,k) * dum1
+           ptend_loc%q(i,k,ixnumliq) = 3._r8 * ( max(0._r8, ( dlf(i,k) - dlf2(i,k) )) * ( 1._r8 - dum1 ) ) &
+                                       / (4._r8*3.14_r8* clubb_liq_deep**3*997._r8) + & ! Deep    Convection
+                                       3._r8 * (                         dlf2(i,k)    * ( 1._r8 - dum1 ) ) &
+                                       / (4._r8*3.14_r8*clubb_liq_sh**3*997._r8)     ! Shallow Convection
+           ptend_loc%q(i,k,ixnumice) = 3._r8 * ( max(0._r8, ( dlf(i,k) - dlf2(i,k) )) *  dum1 ) &
+                                       / (4._r8*3.14_r8*clubb_ice_deep**3*500._r8) + & ! Deep    Convection
+                                       3._r8 * (                         dlf2(i,k)    *  dum1 ) &
+                                       / (4._r8*3.14_r8*clubb_ice_sh**3*500._r8)     ! Shallow Convection
+           ptend_loc%s(i,k)          = dlf(i,k) * dum1 * latice
+
+         end if 
 
          ! Only rliq is saved from deep convection, which is the reserved liquid.  We need to keep
          !   track of the integrals of ice and static energy that is effected from conversion to ice

--- a/components/eam/src/physics/cam/conv_water.F90
+++ b/components/eam/src/physics/cam/conv_water.F90
@@ -23,9 +23,7 @@ module conv_water
 
   use perf_mod
   use cam_logfile,   only: iulog
-!<songxl 2020-01-01---------
   use zm_conv,      only: zm_microp
-!>songxl 2020-01-01---------
 
   implicit none
   private
@@ -36,7 +34,7 @@ module conv_water
 ! pbuf indices
 
   integer :: icwmrsh_idx, icwmrdp_idx, fice_idx, sh_frac_idx, dp_frac_idx, &
-             ast_idx, sh_cldliq1_idx, sh_cldice1_idx, rei_idx,icimrdp_idx   !songxl 2020-01-01
+             ast_idx, sh_cldliq1_idx, sh_cldice1_idx, rei_idx,icimrdp_idx   
 
   integer :: ixcldice, ixcldliq
 
@@ -93,7 +91,7 @@ module conv_water
  
    icwmrsh_idx  = pbuf_get_index('ICWMRSH')
    icwmrdp_idx  = pbuf_get_index('ICWMRDP')
-   icimrdp_idx  = pbuf_get_index('ICIMRDP')    !songxl 2020-01-01
+   icimrdp_idx  = pbuf_get_index('ICIMRDP')    
    fice_idx     = pbuf_get_index('FICE')
    sh_frac_idx  = pbuf_get_index('SH_FRAC')
    dp_frac_idx  = pbuf_get_index('DP_FRAC')
@@ -160,7 +158,7 @@ module conv_water
    real(r8), pointer, dimension(:,:) ::  rei      ! Ice effective drop size (microns)
 
    real(r8), pointer, dimension(:,:) ::  dp_icwmr ! Deep conv. cloud water
-   real(r8), pointer, dimension(:,:) ::  dp_icimr ! Deep conv. cloud ice     songxl 2020-01-01
+   real(r8), pointer, dimension(:,:) ::  dp_icimr ! Deep conv. cloud ice     
    real(r8), pointer, dimension(:,:) ::  sh_icwmr ! Shallow conv. cloud water
    real(r8), pointer, dimension(:,:) ::  fice     ! Ice partitioning ratio
    real(r8), pointer, dimension(:,:) ::  sh_cldliq ! shallow convection gbx liq cld mixing ratio for COSP
@@ -182,7 +180,9 @@ module conv_water
    real(r8) :: kabs, kabsi, kabsl, alpha, dp0, sh0, ic_limit, frac_limit  
    real(r8) :: wrk1         
 
-   real(r8) :: sh_iclmr, sh_icimr, dp_iclmr        !songxl 2020-01-01 
+   real(r8) :: sh_iclmr                           ! Shallow convection in-cloud liquid water 
+   real(r8) :: sh_icimr                           ! Shallow convection in-cloud ice water
+   real(r8) :: dp_iclmr                           ! Deep convection in-cloud liquid water 
 
    integer :: lchnk
    integer :: ncol
@@ -204,7 +204,7 @@ module conv_water
 
    call pbuf_get_field(pbuf, icwmrsh_idx, sh_icwmr )
    call pbuf_get_field(pbuf, icwmrdp_idx, dp_icwmr )
-   call pbuf_get_field(pbuf, icimrdp_idx, dp_icimr )         !songxl2020-01-01
+   call pbuf_get_field(pbuf, icimrdp_idx, dp_icimr )         
    call pbuf_get_field(pbuf, fice_idx,    fice )
 
 
@@ -280,7 +280,6 @@ module conv_water
             kabs  = kabsl * ( 1._r8 - wrk1 ) + kabsi * wrk1
             alpha = -1.66_r8*kabs*state%pdel(i,k)/gravit*1000.0_r8
            if (zm_microp) then
-             ! Selecting cumulus in-cloud water.
              sh_iclmr = sh_icwmr(i,k)*(1-fice(i,k))
              sh_icimr = sh_icwmr(i,k)*fice(i,k)
              dp_iclmr = dp_icwmr(i,k)- dp_icimr(i,k)
@@ -325,7 +324,6 @@ module conv_water
 !               call endrun ('CONV_WATER_4_RAD: Unknown option for conv_water_in_rad - exiting')
             end select
 
-!      end if
       
       !BSINGH - Logic by Phil R. to account for insignificant condensate in large scale clouds
       if (ls_icwmr < 100._r8*ic_limit .and. pergro_mods) then ! if there is virtually  no stratiform condensate
@@ -352,7 +350,7 @@ module conv_water
       totg_ice(i,k) = tot0_frac * tot_icwmr * wrk1
       totg_liq(i,k) = tot0_frac * tot_icwmr * (1._r8-wrk1)
 
-       endif
+       endif  !zm_microp
       endif
    end do
    end do

--- a/components/eam/src/physics/cam/conv_water.F90
+++ b/components/eam/src/physics/cam/conv_water.F90
@@ -23,6 +23,9 @@ module conv_water
 
   use perf_mod
   use cam_logfile,   only: iulog
+!<songxl 2020-01-01---------
+  use zm_conv,      only: zm_microp
+!>songxl 2020-01-01---------
 
   implicit none
   private
@@ -33,7 +36,7 @@ module conv_water
 ! pbuf indices
 
   integer :: icwmrsh_idx, icwmrdp_idx, fice_idx, sh_frac_idx, dp_frac_idx, &
-             ast_idx, sh_cldliq1_idx, sh_cldice1_idx, rei_idx
+             ast_idx, sh_cldliq1_idx, sh_cldice1_idx, rei_idx,icimrdp_idx   !songxl 2020-01-01
 
   integer :: ixcldice, ixcldliq
 
@@ -90,6 +93,7 @@ module conv_water
  
    icwmrsh_idx  = pbuf_get_index('ICWMRSH')
    icwmrdp_idx  = pbuf_get_index('ICWMRDP')
+   icimrdp_idx  = pbuf_get_index('ICIMRDP')    !songxl 2020-01-01
    fice_idx     = pbuf_get_index('FICE')
    sh_frac_idx  = pbuf_get_index('SH_FRAC')
    dp_frac_idx  = pbuf_get_index('DP_FRAC')
@@ -156,6 +160,7 @@ module conv_water
    real(r8), pointer, dimension(:,:) ::  rei      ! Ice effective drop size (microns)
 
    real(r8), pointer, dimension(:,:) ::  dp_icwmr ! Deep conv. cloud water
+   real(r8), pointer, dimension(:,:) ::  dp_icimr ! Deep conv. cloud ice     songxl 2020-01-01
    real(r8), pointer, dimension(:,:) ::  sh_icwmr ! Shallow conv. cloud water
    real(r8), pointer, dimension(:,:) ::  fice     ! Ice partitioning ratio
    real(r8), pointer, dimension(:,:) ::  sh_cldliq ! shallow convection gbx liq cld mixing ratio for COSP
@@ -177,6 +182,8 @@ module conv_water
    real(r8) :: kabs, kabsi, kabsl, alpha, dp0, sh0, ic_limit, frac_limit  
    real(r8) :: wrk1         
 
+   real(r8) :: sh_iclmr, sh_icimr, dp_iclmr        !songxl 2020-01-01 
+
    integer :: lchnk
    integer :: ncol
 
@@ -197,7 +204,9 @@ module conv_water
 
    call pbuf_get_field(pbuf, icwmrsh_idx, sh_icwmr )
    call pbuf_get_field(pbuf, icwmrdp_idx, dp_icwmr )
+   call pbuf_get_field(pbuf, icimrdp_idx, dp_icimr )         !songxl2020-01-01
    call pbuf_get_field(pbuf, fice_idx,    fice )
+
 
  ! Get convective in-cloud fraction    
 
@@ -237,14 +246,24 @@ module conv_water
 
             cu0_frac = 0._r8
             cu_icwmr = 0._r8
-         
+            conv_ice(i,k) = 0._r8
+            conv_liq(i,k) = 0._r8
+
             ls_frac = ast(i,k)
             if( ls_frac < frac_limit ) then
                 ls_frac  = 0._r8
                 ls_icwmr = 0._r8
+                tot_ice(i,k)  = 0._r8
+                tot_liq(i,k)  = 0._r8
+                totg_ice(i,k) = 0._r8
+                totg_liq(i,k) = 0._r8
             else
                 ls_icwmr = ( state%q(i,k,ixcldliq) + state%q(i,k,ixcldice) )/max(frac_limit,ls_frac) ! Convert to IC value.
-            end if
+                tot_ice(i,k)  = state%q(i,k,ixcldice)/max(frac_limit,ls_frac)
+                tot_liq(i,k)  = state%q(i,k,ixcldliq)/max(frac_limit,ls_frac)
+                totg_ice(i,k) = state%q(i,k,ixcldice)
+                totg_liq(i,k) = state%q(i,k,ixcldliq)
+            endif
 
             tot0_frac = ls_frac
             tot_icwmr = ls_icwmr
@@ -260,7 +279,21 @@ module conv_water
             endif
             kabs  = kabsl * ( 1._r8 - wrk1 ) + kabsi * wrk1
             alpha = -1.66_r8*kabs*state%pdel(i,k)/gravit*1000.0_r8
-
+           if (zm_microp) then
+             ! Selecting cumulus in-cloud water.
+             sh_iclmr = sh_icwmr(i,k)*(1-fice(i,k))
+             sh_icimr = sh_icwmr(i,k)*fice(i,k)
+             dp_iclmr = dp_icwmr(i,k)- dp_icimr(i,k)
+        
+             conv_ice(i,k) = ( sh0_frac * sh_icimr + dp0_frac*dp_icimr(i,k))/max(frac_limit,cu0_frac)
+             conv_liq(i,k) = ( sh0_frac * sh_iclmr + dp0_frac*dp_iclmr)/max(frac_limit,cu0_frac)
+             ls_frac   = ast(i,k)
+             tot0_frac = (ls_frac + cu0_frac)
+             tot_ice(i,k) = (state%q(i,k,ixcldice) + cu0_frac*conv_ice(i,k))/max(frac_limit,tot0_frac)
+             tot_liq(i,k) = (state%q(i,k,ixcldliq) + cu0_frac*conv_liq(i,k))/max(frac_limit,tot0_frac)
+             totg_ice(i,k) = tot0_frac * tot_ice(i,k)
+             totg_liq(i,k) = tot0_frac * tot_liq(i,k)
+           else        
           ! Selecting cumulus in-cloud water.            
 
             select case (conv_water_mode) ! Type of average
@@ -292,7 +325,7 @@ module conv_water
 !               call endrun ('CONV_WATER_4_RAD: Unknown option for conv_water_in_rad - exiting')
             end select
 
-      end if
+!      end if
       
       !BSINGH - Logic by Phil R. to account for insignificant condensate in large scale clouds
       if (ls_icwmr < 100._r8*ic_limit .and. pergro_mods) then ! if there is virtually  no stratiform condensate
@@ -319,6 +352,8 @@ module conv_water
       totg_ice(i,k) = tot0_frac * tot_icwmr * wrk1
       totg_liq(i,k) = tot0_frac * tot_icwmr * (1._r8-wrk1)
 
+       endif
+      endif
    end do
    end do
 

--- a/components/eam/src/physics/cam/convect_deep.F90
+++ b/components/eam/src/physics/cam/convect_deep.F90
@@ -49,11 +49,9 @@ module convect_deep
 
    integer     ::  ttend_dp_idx        = 0
 
-!<songxl 2014-11-20-----
    integer     ::  lambdadpcu_idx   = 0
    integer     ::  mudpcu_idx       = 0
    integer     ::  icimrdp_idx      = 0
-!>songxl 2014-11-20-----
 !=========================================================================================
   contains 
 
@@ -106,11 +104,9 @@ subroutine convect_deep_register
   call pbuf_add_field('PREC_DP',    'physpkg',dtype_r8,(/pcols/),     prec_dp_idx)
   call pbuf_add_field('SNOW_DP',   'physpkg',dtype_r8,(/pcols/),      snow_dp_idx)
 
-!<songxl 2014-11-20-------
   call pbuf_add_field('LAMBDADPCU', 'physpkg', dtype_r8,(/pcols,pver/), lambdadpcu_idx)
   call pbuf_add_field('MUDPCU',     'physpkg', dtype_r8,(/pcols,pver/), mudpcu_idx)
   call pbuf_add_field('ICIMRDP',    'physpkg', dtype_r8,(/pcols,pver/), icimrdp_idx)
-!>songxl 2014-11-20--------
 
   ! If WACCM gravity waves are on, output this field.
   if (use_gw_convect) then
@@ -169,12 +165,8 @@ end subroutine convect_deep_init
 
 subroutine convect_deep_tend( &
      mcon    ,cme     ,          &
-!<songxl 2014-11-20--------
      dlf     ,pflx    ,zdu      , &
-!     rliq    , &
-!     pflx    ,zdu      , &
      rliq    ,rice     , &
-!>songxl 2014-11-20-------- 
      ztodt   , &
      state   ,ptend   ,landfrac ,pbuf, mu, eu, &
      du, md, ed, dp, dsubcld, jt, maxg, ideep,lengath ) 
@@ -207,7 +199,6 @@ subroutine convect_deep_tend( &
    real(r8), intent(out) :: zdu(pcols,pver)    ! detraining mass flux
 
    real(r8), intent(out) :: rliq(pcols) ! reserved liquid (not yet in cldliq) for energy integrals
-!songxl 2014-11-20
    real(r8), intent(out) :: rice(pcols) ! reserved ice (not yet in cldice) for energy integrals
 
    real(r8), intent(out):: mu(pcols,pver)
@@ -242,11 +233,9 @@ subroutine convect_deep_tend( &
    real(r8), pointer, dimension(:,:) :: rprd      ! rain production rate
    real(r8), pointer, dimension(:,:,:) :: fracis  ! fraction of transported species that are insoluble
 
-!<songxl 2014-11-20-----
    real(r8), pointer, dimension(:,:) :: mudpcu       ! Droplet size distribution shape parameter for radiation
    real(r8), pointer, dimension(:,:) :: lambdadpcu   ! Droplet size distribution shape parameter for radiation
    real(r8), pointer, dimension(:,:) :: qi           ! wg grid slice of cloud ice.
-!>songxl 2014-11-20-----
 
 
    real(r8), pointer, dimension(:,:) :: evapcdp   ! Evaporation of deep convective precipitation
@@ -259,10 +248,6 @@ subroutine convect_deep_tend( &
 
    real(r8) zero(pcols, pver)
 
-!<songxl 2014-11-20----
-   real(r8) :: mucon                                 ! Convective size distribution shape parameter
-   real(r8) :: dcon                                  ! Convective size distribution effective radius (meters)
-!>songxl 2014-11-20----
 
    integer i, k
 
@@ -279,7 +264,6 @@ subroutine convect_deep_tend( &
     cme = 0
     zdu = 0
     rliq = 0
-!songxl 2014-11-20
     rice = 0   
 
     call physics_ptend_init(ptend, state%psetcols, 'convect_deep')
@@ -294,11 +278,9 @@ subroutine convect_deep_tend( &
     call pbuf_get_field(pbuf, nevapr_dpcu_idx, evapcdp )
     call pbuf_get_field(pbuf, prec_dp_idx,     prec )
     call pbuf_get_field(pbuf, snow_dp_idx,     snow )
-!<songxl 2014-11-20-----------
     call pbuf_get_field(pbuf, mudpcu_idx,      mudpcu)
     call pbuf_get_field(pbuf, lambdadpcu_idx,  lambdadpcu)
     call pbuf_get_field(pbuf, icimrdp_idx,     qi    )
-!>songxl 2014-11-20-----------
 
    !cld = 0  !!HuiWan 2014-05. Bugfix. cld is an input variable to zm_conv_tend.
     ql = 0
@@ -307,11 +289,9 @@ subroutine convect_deep_tend( &
     evapcdp = 0
     prec=0
     snow=0
-!<songxl 2014-11-20------
     mudpcu     = 0.0_r8
     lambdadpcu = 0.0_r8
     qi = 0._r8
-!>songxl 2014-11-20------
 
 
     jctop = pver
@@ -323,12 +303,8 @@ subroutine convect_deep_tend( &
 
      call t_startf('zm_conv_tend')
      call zm_conv_tend( pblh    ,mcon    ,cme     , &
-!<songxl 2014-11-20------
           tpert   ,dlf     ,pflx    ,zdu      , &
-!          rliq    , &
-!          tpert   ,pflx    ,zdu      , &
           rliq    ,rice    , &
-!>songxl 2014-11-20------
           ztodt   , &
           jctop, jcbot , &
           state   ,ptend   ,landfrac, pbuf, mu, eu, &

--- a/components/eam/src/physics/cam/convect_shallow.F90
+++ b/components/eam/src/physics/cam/convect_shallow.F90
@@ -471,6 +471,9 @@ end subroutine convect_shallow_init_cnst
 
    real(r8) :: ntprprd(pcols,pver)                                       ! Net precip production in layer
    real(r8) :: ntsnprd(pcols,pver)                                       ! Net snow   production in layer
+!<songxl 2014-11-20------
+   real(r8) :: sprd(pcols,pver)                                          ! evap infld only for deep conv
+!>songxl 2014-11-20------
    real(r8) :: tend_s_snwprd(pcols,pver)                                 ! Heating rate of snow production
    real(r8) :: tend_s_snwevmlt(pcols,pver)                               ! Heating rate of evap/melting of snow
    real(r8) :: slflx(pcols,pverp)                                        ! Shallow convective liquid water static energy flux
@@ -904,6 +907,10 @@ end subroutine convect_shallow_init_cnst
     call pbuf_get_field(pbuf, sh_cldliq_idx, sh_cldliq  )
     call pbuf_get_field(pbuf, sh_cldice_idx, sh_cldice  )
 
+!<songxl 2014-11-20---
+    sprd = 0._r8
+!>songxl 2014-11-20--
+
     !! clouds have no water... :)
     sh_cldliq(:ncol,:) = 0._r8
     sh_cldice(:ncol,:) = 0._r8
@@ -913,8 +920,10 @@ end subroutine convect_shallow_init_cnst
                        ptend_loc%s, tend_s_snwprd, tend_s_snwevmlt,                  & 
                        ptend_loc%q(:pcols,:pver,1),                                  &
                        rprdsh, cld, ztodt,                                           &
-                       precc, snow, ntprprd, ntsnprd , flxprec, flxsnow )
-
+!<songxl 2014-11-20--------
+!                       precc, snow, ntprprd, ntsnprd , flxprec, flxsnow )
+                       precc, snow, ntprprd, ntsnprd , flxprec, flxsnow, sprd, .true.)
+!>songxl 2014-11-20--------
    ! ------------------------------------------ !
    ! record history variables from zm_conv_evap !
    ! ------------------------------------------ !

--- a/components/eam/src/physics/cam/convect_shallow.F90
+++ b/components/eam/src/physics/cam/convect_shallow.F90
@@ -471,9 +471,7 @@ end subroutine convect_shallow_init_cnst
 
    real(r8) :: ntprprd(pcols,pver)                                       ! Net precip production in layer
    real(r8) :: ntsnprd(pcols,pver)                                       ! Net snow   production in layer
-!<songxl 2014-11-20------
    real(r8) :: sprd(pcols,pver)                                          ! evap infld only for deep conv
-!>songxl 2014-11-20------
    real(r8) :: tend_s_snwprd(pcols,pver)                                 ! Heating rate of snow production
    real(r8) :: tend_s_snwevmlt(pcols,pver)                               ! Heating rate of evap/melting of snow
    real(r8) :: slflx(pcols,pverp)                                        ! Shallow convective liquid water static energy flux
@@ -907,9 +905,7 @@ end subroutine convect_shallow_init_cnst
     call pbuf_get_field(pbuf, sh_cldliq_idx, sh_cldliq  )
     call pbuf_get_field(pbuf, sh_cldice_idx, sh_cldice  )
 
-!<songxl 2014-11-20---
     sprd = 0._r8
-!>songxl 2014-11-20--
 
     !! clouds have no water... :)
     sh_cldliq(:ncol,:) = 0._r8
@@ -920,10 +916,8 @@ end subroutine convect_shallow_init_cnst
                        ptend_loc%s, tend_s_snwprd, tend_s_snwevmlt,                  & 
                        ptend_loc%q(:pcols,:pver,1),                                  &
                        rprdsh, cld, ztodt,                                           &
-!<songxl 2014-11-20--------
-!                       precc, snow, ntprprd, ntsnprd , flxprec, flxsnow )
                        precc, snow, ntprprd, ntsnprd , flxprec, flxsnow, sprd, .true.)
-!>songxl 2014-11-20--------
+
    ! ------------------------------------------ !
    ! record history variables from zm_conv_evap !
    ! ------------------------------------------ !

--- a/components/eam/src/physics/cam/macrop_driver.F90
+++ b/components/eam/src/physics/cam/macrop_driver.F90
@@ -57,9 +57,7 @@ module macrop_driver
   character(len=16) :: shallow_scheme
   logical           :: use_shfrc                       ! Local copy of flag from convect_shallow_use_shfrc
 
-!<songxl 2014-11-20----------
-  logical            :: zmconv_microp = .false.         ! true if ZM microphysics enabled
-!>songxl 2014-11-20----------
+  logical           :: zmconv_microp = .false.         ! true if ZM microphysics enabled
 
   integer :: &
     ixcldliq,     &! cloud liquid amount index
@@ -89,8 +87,6 @@ module macrop_driver
     fice_idx,     &  
     cmeliq_idx,   &  
     shfrc_idx,    &
-!<songxl 2014-11-20----------
-!    naai_idx 
     naai_idx,     &
     dlfzm_idx,    & ! index of ZM detrainment of convective cloud water mixing ratio.
     difzm_idx,    & ! index of ZM detrainment of convective cloud ice mixing ratio.
@@ -98,7 +94,6 @@ module macrop_driver
     dnlfzm_idx,   & ! index of ZM detrainment of convective cloud water num concen.
     dnifzm_idx,   & ! index of ZM detrainment of convective cloud ice num concen.
     dnsfzm_idx      ! index of ZM detrainment of convective snow num concen.
-!>songxl 2014-11-20----------
 
   logical :: liqcf_fix
 
@@ -217,9 +212,7 @@ end subroutine macrop_driver_readnl
                                                  ! liquid budgets.
     integer              :: history_budget_histfile_num ! output history file number for budget fields
     integer :: istat
-!<songxl 2014-11-20----------
     integer :: err
-!>songxl 2014-11-20----------
     character(len=*), parameter :: subname = 'macrop_driver_init'
     !-----------------------------------------------------------------------
 
@@ -337,7 +330,6 @@ end subroutine macrop_driver_readnl
     CC_ni_idx   = pbuf_get_index('CC_ni')
     CC_qlst_idx = pbuf_get_index('CC_qlst')
 
-!<songxl 2014-11-20----------
     dlfzm_idx = pbuf_get_index('DLFZM')
     difzm_idx = pbuf_get_index('DIFZM')
     dsfzm_idx = pbuf_get_index('DSFZM', err)
@@ -345,7 +337,6 @@ end subroutine macrop_driver_readnl
     dnifzm_idx = pbuf_get_index('DNIFZM', err)
     dnsfzm_idx = pbuf_get_index('DNSFZM', err)
     if (dnlfzm_idx > 0) zmconv_microp = .true.
-!>songxl 2014-11-20----------
 
     if (micro_do_icesupersat) then 
        naai_idx      = pbuf_get_index('NAAI')
@@ -484,7 +475,6 @@ end subroutine macrop_driver_readnl
 
   real(r8), pointer, dimension(:,:) :: naai         ! Number concentration of activated ice nuclei
 
-!<songxl 2014-11-20----------
   ! ZM microphysics
   real(r8), pointer :: dlfzm(:,:)  ! ZM detrainment of convective cloud water mixing ratio.
   real(r8), pointer :: difzm(:,:)  ! ZM detrainment of convective cloud ice mixing ratio.
@@ -492,7 +482,6 @@ end subroutine macrop_driver_readnl
   real(r8), pointer :: dnlfzm(:,:) ! ZM detrainment of convective cloud water num concen.
   real(r8), pointer :: dnifzm(:,:) ! ZM detrainment of convective cloud ice num concen.
   real(r8), pointer :: dnsfzm(:,:) ! ZM detrainment of convective snow num concen.  
-!>songxl 2014-11-20----------
  
   real(r8) :: latsub
 
@@ -690,7 +679,6 @@ end subroutine macrop_driver_readnl
      ! This is the key procesure generating upper-level cirrus clouds.
      ! The unit of dlf : [ kg/kg/s ]
 
-!<songxl 2014-11-20------
    if (zmconv_microp) then
       call pbuf_get_field(pbuf, dlfzm_idx, dlfzm)
       call pbuf_get_field(pbuf, difzm_idx, difzm)
@@ -699,7 +687,6 @@ end subroutine macrop_driver_readnl
       call pbuf_get_field(pbuf, dnifzm_idx, dnifzm)
       call pbuf_get_field(pbuf, dnsfzm_idx, dnsfzm)
    end if
-!>songxl 2014-11-20------
 
    det_s(:)   = 0._r8
    det_ice(:) = 0._r8
@@ -790,7 +777,6 @@ end subroutine macrop_driver_readnl
           dpdlft  (i,k)             = 0._r8
           shdlft  (i,k)             = 0._r8
        else
-!<songxl 2014-11-20------------
           if (zmconv_microp) then
              dpdlfliq(i,k) =  dlfzm(i,k)
              dpdlfice(i,k) =  difzm(i,k) + dsfzm(i,k)
@@ -800,12 +786,8 @@ end subroutine macrop_driver_readnl
              dpdlfliq(i,k) = ( dlf(i,k) - dlf2(i,k) ) * ( 1._r8 - dum1 )
              dpdlfice(i,k) = ( dlf(i,k) - dlf2(i,k) ) * ( dum1 )
           end if
-!          dpdlfliq(i,k) = ( dlf(i,k) - dlf2(i,k) ) * ( 1._r8 - dum1 )
-!          dpdlfice(i,k) = ( dlf(i,k) - dlf2(i,k) ) * ( dum1 )
-!>songxl 2014-11-20------------
           shdlfliq(i,k) = dlf2(i,k) * ( 1._r8 - dum1 )
           shdlfice(i,k) = dlf2(i,k) * ( dum1 )
-!songxl 2014-11-20          dpdlft  (i,k) = ( dlf(i,k) - dlf2(i,k) ) * dum1 * latice/cpair
           shdlft  (i,k) = dlf2(i,k) * dum1 * latice/cpair
       endif
    end do

--- a/components/eam/src/physics/cam/ndrop.F90
+++ b/components/eam/src/physics/cam/ndrop.F90
@@ -15,10 +15,8 @@ use spmd_utils,       only: masterproc
 use ppgrid,           only: pcols, pver, pverp
 use physconst,        only: pi, rhoh2o, mwh2o, r_universal, rh2o, &
                             gravit, latvap, cpair, rair
-!<songxl 2014-11-20---
 use physconst,        only: epsilo
 use activate_drop_mam, only: actdrop_mam_init, actdrop_mam_calc
-!>songxl 2014-11-20---
 use constituents,     only: pcnst, cnst_get_ind
 use physics_types,    only: physics_state, physics_ptend, physics_ptend_init
 use physics_buffer,   only: physics_buffer_desc, pbuf_get_index, pbuf_get_field
@@ -262,13 +260,12 @@ subroutine ndrop_init
       end do
    end do
 
-!<songxl 2014-11-20-----------
+   ! convective microphysics
    call actdrop_mam_init( &
       iulog, pi, rair, r_universal, rh2o,   &
       rhoh2o, mwh2o, epsilo, latvap, cpair, &
       gravit, ntot_amode, sigmag_amode)
 
-!>songxl 2014-11-20-----------
 
    call addfld('CCN1',(/ 'lev' /), 'A','1/cm3','CCN concentration at S=0.02%')
    call addfld('CCN2',(/ 'lev' /), 'A','1/cm3','CCN concentration at S=0.05%')

--- a/components/eam/src/physics/cam/ndrop.F90
+++ b/components/eam/src/physics/cam/ndrop.F90
@@ -15,6 +15,10 @@ use spmd_utils,       only: masterproc
 use ppgrid,           only: pcols, pver, pverp
 use physconst,        only: pi, rhoh2o, mwh2o, r_universal, rh2o, &
                             gravit, latvap, cpair, rair
+!<songxl 2014-11-20---
+use physconst,        only: epsilo
+use activate_drop_mam, only: actdrop_mam_init, actdrop_mam_calc
+!>songxl 2014-11-20---
 use constituents,     only: pcnst, cnst_get_ind
 use physics_types,    only: physics_state, physics_ptend, physics_ptend_init
 use physics_buffer,   only: physics_buffer_desc, pbuf_get_index, pbuf_get_field
@@ -257,6 +261,14 @@ subroutine ndrop_init
             
       end do
    end do
+
+!<songxl 2014-11-20-----------
+   call actdrop_mam_init( &
+      iulog, pi, rair, r_universal, rh2o,   &
+      rhoh2o, mwh2o, epsilo, latvap, cpair, &
+      gravit, ntot_amode, sigmag_amode)
+
+!>songxl 2014-11-20-----------
 
    call addfld('CCN1',(/ 'lev' /), 'A','1/cm3','CCN concentration at S=0.02%')
    call addfld('CCN2',(/ 'lev' /), 'A','1/cm3','CCN concentration at S=0.05%')

--- a/components/eam/src/physics/cam/ndrop_bam.F90
+++ b/components/eam/src/physics/cam/ndrop_bam.F90
@@ -67,6 +67,13 @@ real(r8), allocatable :: num_to_mass_aer(:)
 integer :: naer_all      ! number of aerosols affecting climate
 integer :: idxsul   = -1 ! index in aerosol list for sulfate
 
+!<songxl 2014-11-20-----------
+! Both microp_aero_init and zm_conv_init can call ndrop_bam_init.  Use this
+! logical so that it only gets called once.
+logical :: ndrop_bam_init_done = .false.
+
+!>songxl 2014-11-20-----------
+
 !===============================================================================
 contains
 !===============================================================================
@@ -83,6 +90,10 @@ subroutine ndrop_bam_init
    real(r8) :: surften       ! surface tension of water w/respect to air (N/m)
    real(r8) :: arg
    !-------------------------------------------------------------------------------
+
+!<songxl 2014-11-20---------
+   if (ndrop_bam_init_done) return
+!>songxl 2014-11-20---------
 
    ! Access the physical properties of the bulk aerosols that are affecting the climate
    ! by using routines from the rad_constituents module.
@@ -198,6 +209,10 @@ subroutine ndrop_bam_init
       enddo
 
    end do
+
+!<songxl 2014-11-20----
+   ndrop_bam_init_done = .true.
+!>songxl 2014-11-20----
 
 end subroutine ndrop_bam_init
 

--- a/components/eam/src/physics/cam/ndrop_bam.F90
+++ b/components/eam/src/physics/cam/ndrop_bam.F90
@@ -67,12 +67,10 @@ real(r8), allocatable :: num_to_mass_aer(:)
 integer :: naer_all      ! number of aerosols affecting climate
 integer :: idxsul   = -1 ! index in aerosol list for sulfate
 
-!<songxl 2014-11-20-----------
 ! Both microp_aero_init and zm_conv_init can call ndrop_bam_init.  Use this
 ! logical so that it only gets called once.
 logical :: ndrop_bam_init_done = .false.
 
-!>songxl 2014-11-20-----------
 
 !===============================================================================
 contains
@@ -91,9 +89,7 @@ subroutine ndrop_bam_init
    real(r8) :: arg
    !-------------------------------------------------------------------------------
 
-!<songxl 2014-11-20---------
    if (ndrop_bam_init_done) return
-!>songxl 2014-11-20---------
 
    ! Access the physical properties of the bulk aerosols that are affecting the climate
    ! by using routines from the rad_constituents module.
@@ -210,9 +206,7 @@ subroutine ndrop_bam_init
 
    end do
 
-!<songxl 2014-11-20----
    ndrop_bam_init_done = .true.
-!>songxl 2014-11-20----
 
 end subroutine ndrop_bam_init
 

--- a/components/eam/src/physics/cam/nucleate_ice_conv.F90
+++ b/components/eam/src/physics/cam/nucleate_ice_conv.F90
@@ -22,10 +22,7 @@ contains
 
 subroutine nucleati_conv(  &
    wbar, tair, relhum, cldn, qc,              &
-!<songxl 2014-11-20---------
-!   nfice, rhoair, so4_num, dst_num, soot_num, &
    nfice, rhoair, so4_num, dst_num, soot_num, zm_microp, &
-!>songxl 2014-11-20---------
    nuci, onihf, oniimm, onidep, onimey) 
 
    !---------------------------------------------------------------
@@ -51,9 +48,7 @@ subroutine nucleati_conv(  &
    real(r8), intent(in) :: so4_num     ! so4 aerosol number (#/cm^3)
    real(r8), intent(in) :: dst_num     ! total dust aerosol number (#/cm^3)
    real(r8), intent(in) :: soot_num    ! soot (hydrophilic) aerosol number (#/cm^3)
-!<songxl 2014-11-20------
    logical,  intent(in) :: zm_microp   ! true for in ZM convection scheme
-!>songxl 2014-11-20------
 
    ! Output Arguments
    real(r8), intent(out) :: nuci       ! ice number nucleated (#/kg)
@@ -90,14 +85,11 @@ subroutine nucleati_conv(  &
       C = 131.74_r8
       RHw=(A*tc*tc+B*tc+C)*0.01_r8   ! RHi ~ 120-130%
 
-!<songxl 2014-11-20----------
-!      subgrid = 1.2_r8
       if (zm_microp) then
          subgrid = 1.0_r8
       else
          subgrid = 1.2_r8
       end if
-!>songxl 2014-11-20----------
 
       if((tc.le.-35.0_r8) .and. ((relhum*svp_water(tair)/svp_ice(tair)*subgrid).ge.1.2_r8)) then ! use higher RHi threshold
 

--- a/components/eam/src/physics/cam/nucleate_ice_conv.F90
+++ b/components/eam/src/physics/cam/nucleate_ice_conv.F90
@@ -1,0 +1,289 @@
+module nucleate_ice_conv
+
+!---------------------------------------------------------------------------------
+! Purpose:
+!   Ice nucleation code.
+!
+!---------------------------------------------------------------------------------
+
+use shr_kind_mod,   only: r8=>shr_kind_r8
+use wv_saturation,  only: svp_water, svp_ice
+use cam_logfile,    only: iulog
+
+implicit none
+private
+save
+
+public :: nucleati_conv
+
+!===============================================================================
+contains
+!===============================================================================
+
+subroutine nucleati_conv(  &
+   wbar, tair, relhum, cldn, qc,              &
+!<songxl 2014-11-20---------
+!   nfice, rhoair, so4_num, dst_num, soot_num, &
+   nfice, rhoair, so4_num, dst_num, soot_num, zm_microp, &
+!>songxl 2014-11-20---------
+   nuci, onihf, oniimm, onidep, onimey) 
+
+   !---------------------------------------------------------------
+   ! Purpose:
+   !  The parameterization of ice nucleation.
+   !
+   ! Method: The current method is based on Liu & Penner (2005)
+   !  It related the ice nucleation with the aerosol number, temperature and the
+   !  updraft velocity. It includes homogeneous freezing of sulfate, immersion
+   !  freezing of soot, and Meyers et al. (1992) deposition nucleation
+   !
+   ! Authors: Xiaohong Liu, 01/2005, modifications by A. Gettelman 2009-2010
+   !----------------------------------------------------------------
+
+   ! Input Arguments
+   real(r8), intent(in) :: wbar        ! grid cell mean vertical velocity (m/s)
+   real(r8), intent(in) :: tair        ! temperature (K)
+   real(r8), intent(in) :: relhum      ! relative humidity with respective to liquid
+   real(r8), intent(in) :: cldn        ! new value of cloud fraction    (fraction)
+   real(r8), intent(in) :: qc          ! liquid water mixing ratio (kg/kg)
+   real(r8), intent(in) :: nfice       ! ice mass fraction
+   real(r8), intent(in) :: rhoair      ! air density (kg/m3)
+   real(r8), intent(in) :: so4_num     ! so4 aerosol number (#/cm^3)
+   real(r8), intent(in) :: dst_num     ! total dust aerosol number (#/cm^3)
+   real(r8), intent(in) :: soot_num    ! soot (hydrophilic) aerosol number (#/cm^3)
+!<songxl 2014-11-20------
+   logical,  intent(in) :: zm_microp   ! true for in ZM convection scheme
+!>songxl 2014-11-20------
+
+   ! Output Arguments
+   real(r8), intent(out) :: nuci       ! ice number nucleated (#/kg)
+   real(r8), intent(out) :: onihf      ! nucleated number from homogeneous freezing of so4
+   real(r8), intent(out) :: oniimm     ! nucleated number from immersion freezing
+   real(r8), intent(out) :: onidep     ! nucleated number from deposition nucleation
+   real(r8), intent(out) :: onimey     ! nucleated number from deposition nucleation  (meyers: mixed phase)
+
+   ! Local workspace
+   real(r8) :: nihf                      ! nucleated number from homogeneous freezing of so4
+   real(r8) :: niimm                     ! nucleated number from immersion freezing
+   real(r8) :: nidep                     ! nucleated number from deposition nucleation
+   real(r8) :: nimey                     ! nucleated number from deposition nucleation (meyers)
+   real(r8) :: n1, ni                    ! nucleated number
+   real(r8) :: tc, A, B, C, regm, RHw    ! work variable
+   real(r8) :: esl, esi, deles           ! work variable
+   real(r8) :: subgrid
+   !-------------------------------------------------------------------------------
+
+   ni = 0._r8
+   tc = tair - 273.15_r8
+
+   ! initialize
+   niimm = 0._r8
+   nidep = 0._r8
+   nihf  = 0._r8
+
+   if(so4_num.ge.1.0e-10_r8 .and. (soot_num+dst_num).ge.1.0e-10_r8 .and. cldn.gt.0._r8) then
+
+      !-----------------------------
+      ! RHw parameterization for heterogeneous immersion nucleation
+      A = 0.0073_r8
+      B = 1.477_r8
+      C = 131.74_r8
+      RHw=(A*tc*tc+B*tc+C)*0.01_r8   ! RHi ~ 120-130%
+
+!<songxl 2014-11-20----------
+!      subgrid = 1.2_r8
+      if (zm_microp) then
+         subgrid = 1.0_r8
+      else
+         subgrid = 1.2_r8
+      end if
+!>songxl 2014-11-20----------
+
+      if((tc.le.-35.0_r8) .and. ((relhum*svp_water(tair)/svp_ice(tair)*subgrid).ge.1.2_r8)) then ! use higher RHi threshold
+
+         A = -1.4938_r8 * log(soot_num+dst_num) + 12.884_r8
+         B = -10.41_r8  * log(soot_num+dst_num) - 67.69_r8
+         regm = A * log(wbar) + B
+
+         if(tc.gt.regm) then    ! heterogeneous nucleation only
+            if(tc.lt.-40._r8 .and. wbar.gt.1._r8) then ! exclude T<-40 & W>1m/s from hetero. nucleation
+               call hf(tc,wbar,relhum,subgrid,so4_num,nihf)
+               niimm=0._r8
+               nidep=0._r8
+               n1=nihf
+            else
+               call hetero(tc,wbar,soot_num+dst_num,niimm,nidep)
+               nihf=0._r8
+               n1=niimm+nidep
+            endif
+         elseif (tc.lt.regm-5._r8) then ! homogeneous nucleation only
+            call hf(tc,wbar,relhum,subgrid,so4_num,nihf)
+            niimm=0._r8
+            nidep=0._r8
+            n1=nihf
+         else        ! transition between homogeneous and heterogeneous: interpolate in-between
+            if(tc.lt.-40._r8 .and. wbar.gt.1._r8) then ! exclude T<-40 & W>1m/s from hetero. nucleation
+               call hf(tc,wbar,relhum,subgrid,so4_num,nihf)
+               niimm=0._r8
+               nidep=0._r8
+               n1=nihf
+            else
+
+               call hf(regm-5._r8,wbar,relhum,subgrid,so4_num,nihf)
+               call hetero(regm,wbar,soot_num+dst_num,niimm,nidep)
+
+               if(nihf.le.(niimm+nidep)) then
+                  n1=nihf
+               else
+                  n1=(niimm+nidep)*((niimm+nidep)/nihf)**((tc-regm)/5._r8)
+               endif
+            endif
+         endif
+
+         ni=n1
+
+      endif
+   endif
+
+   ! deposition/condensation nucleation in mixed clouds (-40<T<0C) (Meyers, 1992)
+   if(tc.lt.0._r8 .and. tc.gt.-37._r8 .and. qc.gt.1.e-12_r8) then
+      esl = svp_water(tair)     ! over water in mixed clouds
+      esi = svp_ice(tair)     ! over ice
+      deles = (esl - esi)
+      nimey=1.e-3_r8*exp(12.96_r8*deles/esi - 0.639_r8) 
+   else
+      nimey=0._r8
+   endif
+
+   nuci=ni+nimey
+   if(nuci.gt.9999._r8.or.nuci.lt.0._r8) then
+      write(iulog, *) 'Warning: incorrect ice nucleation number (nuci reset =0)'
+      write(iulog, *) ni, tair, relhum, wbar, nihf, niimm, nidep,deles,esi,dst_num,so4_num
+      nuci=0._r8
+   endif
+
+   nuci   = nuci*1.e+6_r8/rhoair    ! change unit from #/cm3 to #/kg
+   onimey = nimey*1.e+6_r8/rhoair
+   onidep = nidep*1.e+6_r8/rhoair
+   oniimm = niimm*1.e+6_r8/rhoair
+   onihf  = nihf*1.e+6_r8/rhoair
+
+end subroutine nucleati_conv
+
+!===============================================================================
+
+subroutine hetero(T,ww,Ns,Nis,Nid)
+
+    real(r8), intent(in)  :: T, ww, Ns
+    real(r8), intent(out) :: Nis, Nid
+
+    real(r8) A11,A12,A21,A22,B11,B12,B21,B22
+    real(r8) A,B,C
+
+!---------------------------------------------------------------------
+! parameters
+
+      A11 = 0.0263_r8
+      A12 = -0.0185_r8
+      A21 = 2.758_r8
+      A22 = 1.3221_r8
+      B11 = -0.008_r8
+      B12 = -0.0468_r8
+      B21 = -0.2667_r8
+      B22 = -1.4588_r8
+
+!     ice from immersion nucleation (cm^-3)
+
+      B = (A11+B11*log(Ns)) * log(ww) + (A12+B12*log(Ns))
+      C =  A21+B21*log(Ns)
+
+      Nis = exp(A22) * Ns**B22 * exp(B*T) * ww**C
+      Nis = min(Nis,Ns)
+
+      Nid = 0.0_r8    ! don't include deposition nucleation for cirrus clouds when T<-37C
+
+end subroutine hetero
+
+!===============================================================================
+
+subroutine hf(T,ww,RH,subgrid,Na,Ni)
+
+      real(r8), intent(in)  :: T, ww, RH, subgrid, Na
+      real(r8), intent(out) :: Ni
+
+      real(r8)    A1_fast,A21_fast,A22_fast,B1_fast,B21_fast,B22_fast
+      real(r8)    A2_fast,B2_fast
+      real(r8)    C1_fast,C2_fast,k1_fast,k2_fast
+      real(r8)    A1_slow,A2_slow,B1_slow,B2_slow,B3_slow
+      real(r8)    C1_slow,C2_slow,k1_slow,k2_slow
+      real(r8)    regm
+      real(r8)    A,B,C
+      real(r8)    RHw
+
+!---------------------------------------------------------------------
+! parameters
+
+      A1_fast  =0.0231_r8
+      A21_fast =-1.6387_r8  !(T>-64 deg)
+      A22_fast =-6.045_r8   !(T<=-64 deg)
+      B1_fast  =-0.008_r8
+      B21_fast =-0.042_r8   !(T>-64 deg)
+      B22_fast =-0.112_r8   !(T<=-64 deg)
+      C1_fast  =0.0739_r8
+      C2_fast  =1.2372_r8
+
+      A1_slow  =-0.3949_r8
+      A2_slow  =1.282_r8
+      B1_slow  =-0.0156_r8
+      B2_slow  =0.0111_r8
+      B3_slow  =0.0217_r8
+      C1_slow  =0.120_r8
+      C2_slow  =2.312_r8
+
+      Ni = 0.0_r8
+
+!----------------------------
+!RHw parameters
+      A = 6.0e-4_r8*log(ww)+6.6e-3_r8
+      B = 6.0e-2_r8*log(ww)+1.052_r8
+      C = 1.68_r8  *log(ww)+129.35_r8
+      RHw=(A*T*T+B*T+C)*0.01_r8
+
+      if((T.le.-37.0_r8) .and. ((RH*subgrid).ge.RHw)) then
+
+        regm = 6.07_r8*log(ww)-55.0_r8
+
+        if(T.ge.regm) then    ! fast-growth regime
+
+          if(T.gt.-64.0_r8) then
+            A2_fast=A21_fast
+            B2_fast=B21_fast
+          else
+            A2_fast=A22_fast
+            B2_fast=B22_fast
+          endif
+
+          k1_fast = exp(A2_fast + B2_fast*T + C2_fast*log(ww))
+          k2_fast = A1_fast+B1_fast*T+C1_fast*log(ww)
+
+          Ni = k1_fast*Na**(k2_fast)
+          Ni = min(Ni,Na)
+
+        else       ! slow-growth regime
+
+          k1_slow = exp(A2_slow + (B2_slow+B3_slow*log(ww))*T + C2_slow*log(ww))
+          k2_slow = A1_slow+B1_slow*T+C1_slow*log(ww)
+
+          Ni = k1_slow*Na**(k2_slow)
+          Ni = min(Ni,Na)
+
+        endif
+
+      end if
+
+end subroutine hf
+
+!===============================================================================
+
+end module nucleate_ice_conv
+

--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -2027,6 +2027,7 @@ subroutine tphysbc (ztodt,               &
     real(r8) :: zero(pcols)                    ! array of zeros
     real(r8) :: zero_sc(pcols*psubcols)        ! array of zeros
     real(r8) :: rliq(pcols)                    ! vertical integral of liquid not yet in q(ixcldliq)
+    real(r8) :: rice(pcols)                    ! vertical integral of ice not yet in q(ixcldice)
     real(r8) :: rliq2(pcols)                   ! vertical integral of liquid from shallow scheme
     real(r8) :: det_s  (pcols)                 ! vertical integral of detrained static energy from ice
     real(r8) :: det_ice(pcols)                 ! vertical integral of detrained ice
@@ -2334,7 +2335,7 @@ end if
     call convect_deep_tend(  &
          cmfmc,      cmfcme,             &
          dlf,        pflx,    zdu,       &
-         rliq,    &
+         rliq,       rice, &
          ztodt,   &
          state,   ptend, cam_in%landfrac, pbuf, mu, eu, du, md, ed, dp,   &
          dsubcld, jt, maxg, ideep, lengath) 
@@ -2360,7 +2361,9 @@ end if
 
     ! Check energy integrals, including "reserved liquid"
     flx_cnd(:ncol) = prec_dp(:ncol) + rliq(:ncol)
+    snow_dp(:ncol) = snow_dp(:ncol) + rice(:ncol)
     call check_energy_chng(state, tend, "convect_deep", nstep, ztodt, zero, flx_cnd, snow_dp, zero)
+    snow_dp(:ncol) = snow_dp(:ncol) - rice(:ncol)    
 
     !
     ! Call Hack (1994) convection scheme to deal with shallow/mid-level convection

--- a/components/eam/src/physics/cam/zm_conv.F90
+++ b/components/eam/src/physics/cam/zm_conv.F90
@@ -72,12 +72,12 @@ module zm_conv
    real(r8) :: zmconv_auto_fac       = unset_r8
    real(r8) :: zmconv_accr_fac       = unset_r8
    real(r8) :: zmconv_micro_dcs      = unset_r8
-!++ MCSP
+
    real(r8) :: zmconv_MCSP_heat_coeff = 0._r8
    real(r8) :: zmconv_MCSP_moisture_coeff = 0._r8
    real(r8) :: zmconv_MCSP_uwind_coeff = 0._r8
    real(r8) :: zmconv_MCSP_vwind_coeff = 0._r8   
-!-- MCSP
+
 
    real(r8) rl         ! wg latent heat of vaporization.
    real(r8) cpres      ! specific heat at constant pressure in j/kg-degk.
@@ -130,13 +130,12 @@ module zm_conv
    real(r8) :: accr_fac = unset_r8
    real(r8) :: micro_dcs= unset_r8
 
-!++ MCSP   
    logical :: MCSP
    real(r8) :: MCSP_heat_coeff = unset_r8
    real(r8) :: MCSP_moisture_coeff = unset_r8
    real(r8) :: MCSP_uwind_coeff = unset_r8
    real(r8) :: MCSP_vwind_coeff = unset_r8
-!-- MCSP
+
 
 contains
 
@@ -156,11 +155,10 @@ subroutine zmconv_readnl(nlfile)
            zmconv_dmpdz, zmconv_alfa, zmconv_tiedke_add,     &
            zmconv_cape_cin, zmconv_mx_bot_lyr_adj, zmconv_tp_fac, zmconv_trigdcape_ull, &
            zmconv_trig_dcape_only, zmconv_trig_ull_only, zmconv_microp, zmconv_auto_fac,&
-           zmconv_accr_fac, zmconv_micro_dcs, zmconv_clos_dyn_adj, zmconv_tpert_fix,    &
-!++ MCSP 
+           zmconv_accr_fac, zmconv_micro_dcs, zmconv_clos_dyn_adj, zmconv_tpert_fix,    & 
            zmconv_MCSP_heat_coeff, zmconv_MCSP_moisture_coeff, &
            zmconv_MCSP_uwind_coeff, zmconv_MCSP_vwind_coeff   
-!-- MCSP
+
    !-----------------------------------------------------------------------------
 
    zmconv_tau = 3600._r8
@@ -196,14 +194,12 @@ subroutine zmconv_readnl(nlfile)
       auto_fac       = zmconv_auto_fac
       accr_fac       = zmconv_accr_fac
       micro_dcs      = zmconv_micro_dcs
-!++ MCSP
       MCSP_heat_coeff = zmconv_MCSP_heat_coeff
       MCSP_moisture_coeff = zmconv_MCSP_moisture_coeff
       MCSP_uwind_coeff = zmconv_MCSP_uwind_coeff
       MCSP_vwind_coeff = zmconv_MCSP_vwind_coeff     
  
       if( abs(MCSP_heat_coeff)+abs(MCSP_moisture_coeff)+abs(MCSP_uwind_coeff)+abs(MCSP_vwind_coeff) > 0._r8 ) MCSP = .true.
-!-- MCSP
 
       if ( zmconv_alfa /= unset_r8 ) then
            alfa_scalar = zmconv_alfa
@@ -245,14 +241,12 @@ subroutine zmconv_readnl(nlfile)
    call mpibcast(tp_fac,            1, mpir8,  0, mpicom)
    call mpibcast(auto_fac,          1, mpir8,  0, mpicom)
    call mpibcast(accr_fac,          1, mpir8,  0, mpicom)
-   call mpibcast(micro_dcs,         1, mpir8,  0, mpicom)
-!++ MCSP   
+   call mpibcast(micro_dcs,         1, mpir8,  0, mpicom)   
    call mpibcast(MCSP,              1, mpilog, 0, mpicom)
    call mpibcast(MCSP_heat_coeff,   1, mpir8,  0, mpicom)
    call mpibcast(MCSP_moisture_coeff,1, mpir8,  0, mpicom)
    call mpibcast(MCSP_uwind_coeff,  1, mpir8,  0, mpicom)
    call mpibcast(MCSP_vwind_coeff,  1, mpir8,  0, mpicom)  
-!-- MCSP   
 #endif
 
 end subroutine zmconv_readnl

--- a/components/eam/src/physics/cam/zm_conv.F90
+++ b/components/eam/src/physics/cam/zm_conv.F90
@@ -1694,52 +1694,54 @@ subroutine zm_convr(lchnk   ,ncol    , &
    end do
 
 !<songxl 2014-11-20------------
-   do k = msg + 1,pver
-      do i = 1,ncol
+   if (zm_microp) then
+      do k = msg + 1,pver
+         do i = 1,ncol
 
-         !Interpolate variable from interface to mid-layer and convert it from units of "kg/kg" to "g/m3"
+            !Interpolate variable from interface to mid-layer and convert it from units of "kg/kg" to "g/m3"
 
-         if(k.lt.pver) then
-            microp_st%qice (i,k) = 0.5_r8*(microp_st%qice(i,k)+microp_st%qice(i,k+1))
-            microp_st%qliq (i,k) = 0.5_r8*(microp_st%qliq(i,k)+microp_st%qliq(i,k+1))
-            microp_st%qrain (i,k) = 0.5_r8*(microp_st%qrain(i,k)+microp_st%qrain(i,k+1))
-            microp_st%qsnow (i,k) = 0.5_r8*(microp_st%qsnow(i,k)+microp_st%qsnow(i,k+1))
-            microp_st%qgraupel(i,k) = 0.5_r8*(microp_st%qgraupel(i,k)+microp_st%qgraupel(i,k+1))
-            microp_st%qni (i,k) = 0.5_r8*(microp_st%qni(i,k)+microp_st%qni(i,k+1))
-            microp_st%qnl (i,k) = 0.5_r8*(microp_st%qnl(i,k)+microp_st%qnl(i,k+1))
-            microp_st%qnr (i,k) = 0.5_r8*(microp_st%qnr(i,k)+microp_st%qnr(i,k+1))
-            microp_st%qns (i,k) = 0.5_r8*(microp_st%qns(i,k)+microp_st%qns(i,k+1))
-            microp_st%qng (i,k) = 0.5_r8*(microp_st%qng(i,k)+microp_st%qng(i,k+1))
-            microp_st%wu(i,k)   = 0.5_r8*(microp_st%wu(i,k)+microp_st%wu(i,k+1))
-         end if
+            if(k.lt.pver) then
+               microp_st%qice (i,k) = 0.5_r8*(microp_st%qice(i,k)+microp_st%qice(i,k+1))
+               microp_st%qliq (i,k) = 0.5_r8*(microp_st%qliq(i,k)+microp_st%qliq(i,k+1))
+               microp_st%qrain (i,k) = 0.5_r8*(microp_st%qrain(i,k)+microp_st%qrain(i,k+1))
+               microp_st%qsnow (i,k) = 0.5_r8*(microp_st%qsnow(i,k)+microp_st%qsnow(i,k+1))
+               microp_st%qgraupel(i,k) = 0.5_r8*(microp_st%qgraupel(i,k)+microp_st%qgraupel(i,k+1))
+               microp_st%qni (i,k) = 0.5_r8*(microp_st%qni(i,k)+microp_st%qni(i,k+1))
+               microp_st%qnl (i,k) = 0.5_r8*(microp_st%qnl(i,k)+microp_st%qnl(i,k+1))
+               microp_st%qnr (i,k) = 0.5_r8*(microp_st%qnr(i,k)+microp_st%qnr(i,k+1))
+               microp_st%qns (i,k) = 0.5_r8*(microp_st%qns(i,k)+microp_st%qns(i,k+1))
+               microp_st%qng (i,k) = 0.5_r8*(microp_st%qng(i,k)+microp_st%qng(i,k+1))
+               microp_st%wu(i,k)   = 0.5_r8*(microp_st%wu(i,k)+microp_st%wu(i,k+1))
+            end if
 
-         if (t(i,k).gt. 273.15_r8 .and. t(i,k-1).le.273.15_r8) then
-             microp_st%qice (i,k-1) = microp_st%qice (i,k-1) + microp_st%qice (i,k)
-             microp_st%qice (i,k) = 0._r8
-             microp_st%qni (i,k-1) = microp_st%qni (i,k-1) + microp_st%qni (i,k)
-             microp_st%qni (i,k) = 0._r8
-             microp_st%qsnow (i,k-1) = microp_st%qsnow (i,k-1) + microp_st%qsnow (i,k)
-             microp_st%qsnow (i,k) = 0._r8
-             microp_st%qns (i,k-1) = microp_st%qns (i,k-1) + microp_st%qns (i,k)
-             microp_st%qns (i,k) = 0._r8
-             microp_st%qgraupel (i,k-1) = microp_st%qgraupel (i,k-1) + microp_st%qgraupel (i,k)
-             microp_st%qgraupel (i,k) = 0._r8
-             microp_st%qng (i,k-1) = microp_st%qng (i,k-1) + microp_st%qng (i,k)
-             microp_st%qng (i,k) = 0._r8
-         end if
+            if (t(i,k).gt. 273.15_r8 .and. t(i,k-1).le.273.15_r8) then
+                microp_st%qice (i,k-1) = microp_st%qice (i,k-1) + microp_st%qice (i,k)
+                microp_st%qice (i,k) = 0._r8
+                microp_st%qni (i,k-1) = microp_st%qni (i,k-1) + microp_st%qni (i,k)
+                microp_st%qni (i,k) = 0._r8
+                microp_st%qsnow (i,k-1) = microp_st%qsnow (i,k-1) + microp_st%qsnow (i,k)
+                microp_st%qsnow (i,k) = 0._r8
+                microp_st%qns (i,k-1) = microp_st%qns (i,k-1) + microp_st%qns (i,k)
+                microp_st%qns (i,k) = 0._r8
+                microp_st%qgraupel (i,k-1) = microp_st%qgraupel (i,k-1) + microp_st%qgraupel (i,k)
+                microp_st%qgraupel (i,k) = 0._r8
+                microp_st%qng (i,k-1) = microp_st%qng (i,k-1) + microp_st%qng (i,k)
+                microp_st%qng (i,k) = 0._r8
+            end if
 
-         microp_st%qice (i,k) = microp_st%qice(i,k) * pap(i,k)/t(i,k)/rgas *1000._r8
-         microp_st%qliq (i,k) = microp_st%qliq(i,k) * pap(i,k)/t(i,k)/rgas *1000._r8
-         microp_st%qrain (i,k) = microp_st%qrain(i,k) * pap(i,k)/t(i,k)/rgas *1000._r8
-         microp_st%qsnow (i,k) = microp_st%qsnow(i,k) * pap(i,k)/t(i,k)/rgas *1000._r8
-         microp_st%qgraupel (i,k) = microp_st%qgraupel(i,k) * pap(i,k)/t(i,k)/rgas *1000._r8
-         microp_st%qni (i,k) = microp_st%qni(i,k) * pap(i,k)/t(i,k)/rgas
-         microp_st%qnl (i,k) = microp_st%qnl(i,k) * pap(i,k)/t(i,k)/rgas
-         microp_st%qnr (i,k) = microp_st%qnr(i,k) * pap(i,k)/t(i,k)/rgas
-         microp_st%qns (i,k) = microp_st%qns(i,k) * pap(i,k)/t(i,k)/rgas
-         microp_st%qng (i,k) = microp_st%qng(i,k) * pap(i,k)/t(i,k)/rgas 
+            microp_st%qice (i,k) = microp_st%qice(i,k) * pap(i,k)/t(i,k)/rgas *1000._r8
+            microp_st%qliq (i,k) = microp_st%qliq(i,k) * pap(i,k)/t(i,k)/rgas *1000._r8
+            microp_st%qrain (i,k) = microp_st%qrain(i,k) * pap(i,k)/t(i,k)/rgas *1000._r8
+            microp_st%qsnow (i,k) = microp_st%qsnow(i,k) * pap(i,k)/t(i,k)/rgas *1000._r8
+            microp_st%qgraupel (i,k) = microp_st%qgraupel(i,k) * pap(i,k)/t(i,k)/rgas *1000._r8
+            microp_st%qni (i,k) = microp_st%qni(i,k) * pap(i,k)/t(i,k)/rgas
+            microp_st%qnl (i,k) = microp_st%qnl(i,k) * pap(i,k)/t(i,k)/rgas
+            microp_st%qnr (i,k) = microp_st%qnr(i,k) * pap(i,k)/t(i,k)/rgas
+            microp_st%qns (i,k) = microp_st%qns(i,k) * pap(i,k)/t(i,k)/rgas
+            microp_st%qng (i,k) = microp_st%qng(i,k) * pap(i,k)/t(i,k)/rgas 
+         end do
       end do
-   end do
+   end if
 
 !>songxl 2014-11-20------------
 

--- a/components/eam/src/physics/cam/zm_conv.F90
+++ b/components/eam/src/physics/cam/zm_conv.F90
@@ -62,6 +62,7 @@ module zm_conv
 
 !<songxl 2014-11-20-----------
    logical  :: zmconv_microp         = .false.   ! switch for ZM microphysics
+   logical  :: zmconv_clos_dyn_adj   = .false.   ! switch for closure dynamics adjustment
 !>songxl 2014-11-20-----------
    integer  :: zmconv_cape_cin       = unset_int
    integer  :: zmconv_mx_bot_lyr_adj = unset_int
@@ -89,6 +90,7 @@ module zm_conv
    real(r8) ::  tiedke_add    = unset_r8
 !<songxl 2014-11-20-----------
    logical  :: zm_microp    ! switch for ZM microphysics
+   logical  :: clos_dyn_adj = .false.   ! true if apply dynamics adjustment to CAPE closure   
 !>songxl 2014-11-20-----------  
    integer  :: num_cin        = unset_int !number of negative buoyancy regions that are allowed before the conv. top and CAPE calc are completed
    integer  :: mx_bot_lyr_adj = unset_int !bottom layer adjustment for setting "launching" level(mx) (to be at maximum moist static energy).
@@ -131,7 +133,7 @@ subroutine zmconv_readnl(nlfile)
    namelist /zmconv_nl/ zmconv_c0_lnd, zmconv_c0_ocn, zmconv_ke, zmconv_tau, & 
            zmconv_dmpdz, zmconv_alfa, zmconv_tiedke_add,     &
            zmconv_cape_cin, zmconv_mx_bot_lyr_adj, zmconv_tp_fac, zmconv_trigdcape_ull, &
-           zmconv_trig_dcape_only, zmconv_trig_ull_only, zmconv_microp     !<songxl------------
+           zmconv_trig_dcape_only, zmconv_trig_ull_only, zmconv_microp, zmconv_clos_dyn_adj   
 
    !-----------------------------------------------------------------------------
 
@@ -159,6 +161,7 @@ subroutine zmconv_readnl(nlfile)
       trig_ull_only  = zmconv_trig_ull_only
 !<songxl----------
       zm_microp      = zmconv_microp
+      clos_dyn_adj   = zmconv_clos_dyn_adj
 !>songxl----------
       tiedke_add     = zmconv_tiedke_add
       num_cin        = zmconv_cape_cin
@@ -199,6 +202,7 @@ subroutine zmconv_readnl(nlfile)
    call mpibcast(trig_ull_only,     1, mpilog, 0, mpicom)
 !<sognxl--------
    call mpibcast(zm_microp,         1, mpilog, 0, mpicom)
+   call mpibcast(clos_dyn_adj,      1, mpilog, 0, mpicom)
 !>songxl--------
    call mpibcast(tiedke_add,        1, mpir8,  0, mpicom)
    call mpibcast(num_cin,           1, mpiint, 0, mpicom)
@@ -259,7 +263,7 @@ end subroutine zm_convi
 subroutine zm_convr(lchnk   ,ncol    , &
                     t       ,qh      ,prec    ,jctop   ,jcbot   , &
                     pblh    ,zm      ,geos    ,zi      ,qtnd    , &
-                    heat    ,pap     ,paph    ,dpp     , &
+                    heat    ,pap     ,paph    ,dpp     ,omega   , &
                     delt    ,mcon    ,cme     ,cape    , &
                     tpert   ,dlf     ,pflx    ,zdu     ,rprd    , &
                     mu      ,md      ,du      ,eu      ,ed      , &
@@ -396,6 +400,7 @@ subroutine zm_convr(lchnk   ,ncol    , &
    real(r8), intent(in) :: pap(pcols,pver)     
    real(r8), intent(in) :: paph(pcols,pver+1)
    real(r8), intent(in) :: dpp(pcols,pver)        ! local sigma half-level thickness (i.e. dshj).
+   real(r8), intent(in) :: omega(pcols,pver)      ! Vertical velocity Pa/s
    real(r8), intent(in) :: zm(pcols,pver)
    real(r8), intent(in) :: geos(pcols)
    real(r8), intent(in) :: zi(pcols,pver+1)
@@ -474,7 +479,7 @@ subroutine zm_convr(lchnk   ,ncol    , &
    real(r8) ql(pcols,pver)                    ! wg grid slice of cloud liquid water.
 
    real(r8) pblt(pcols)           ! i row of pbl top indices.
-
+   real(r8) pbltg(pcols)          ! i row of pbl top indices.
 
 
 
@@ -528,7 +533,8 @@ subroutine zm_convr(lchnk   ,ncol    , &
    real(r8) ug(pcols,pver)             ! wg grid slice of gathered values of u.
    real(r8) vg(pcols,pver)             ! wg grid slice of gathered values of v.
    real(r8) cmeg(pcols,pver)
-
+   real(r8) omegag(pcols,pver)         ! wg grid slice of gathered values of omega.
+   
    real(r8) rprdg(pcols,pver)          ! wg gathered rain production rate
    real(r8) capeg(pcols)               ! wg gathered convective available potential energy.
    real(r8) tlg(pcols)                 ! wg grid slice of gathered values of tl.
@@ -1104,6 +1110,7 @@ subroutine zm_convr(lchnk   ,ncol    , &
          tpg(i,k) = tp(ideep(i),k)
          zfg(i,k) = zf(ideep(i),k)
          qstpg(i,k) = qstp(ideep(i),k)
+         omegag(i,k) = omega(ideep(i),k)
          ug(i,k) = 0._r8
          vg(i,k) = 0._r8
       end do
@@ -1159,6 +1166,7 @@ subroutine zm_convr(lchnk   ,ncol    , &
       maxg(i) = maxi(ideep(i))
       tlg(i) = tl(ideep(i))
       landfracg(i) = landfrac(ideep(i))
+      pbltg(i) = pblt(ideep(i))
       tpertg(i) = tpert(ideep(i))
       if (maxg(i)<nint(pblt(ideep(i)))) tpertg(i)=0._r8  !songxl 2021-04-25
    end do
@@ -1267,6 +1275,13 @@ subroutine zm_convr(lchnk   ,ncol    , &
          mb(i) = 0._r8
       endif
    end do
+
+   if (clos_dyn_adj) then 
+      do i = 1,lengath
+         mb(i) = max(mb(i) - omegag(i,pbltg(i))*0.01_r8, 0._r8)
+      end do
+   end if
+
    ! If no_deep_pbl = .true., don't allow convection entirely 
    ! within PBL (suggestion of Bjorn Stevens, 8-2000)
 

--- a/components/eam/src/physics/cam/zm_conv.F90
+++ b/components/eam/src/physics/cam/zm_conv.F90
@@ -67,6 +67,9 @@ module zm_conv
    integer  :: zmconv_cape_cin       = unset_int
    integer  :: zmconv_mx_bot_lyr_adj = unset_int
    real(r8) :: zmconv_tp_fac         = unset_r8
+   real(r8) :: zmconv_auto_fac       = unset_r8
+   real(r8) :: zmconv_accr_fac       = unset_r8
+   real(r8) :: zmconv_micro_dcs      = unset_r8
 
    real(r8) rl         ! wg latent heat of vaporization.
    real(r8) cpres      ! specific heat at constant pressure in j/kg-degk.
@@ -115,6 +118,9 @@ module zm_conv
    integer  limcnv       ! top interface level limit for convection
 
    real(r8) :: tp_fac = unset_r8  ! PMA tunes tpert
+   real(r8) :: auto_fac = unset_r8
+   real(r8) :: accr_fac = unset_r8
+   real(r8) :: micro_dcs= unset_r8
 
 contains
 
@@ -133,7 +139,8 @@ subroutine zmconv_readnl(nlfile)
    namelist /zmconv_nl/ zmconv_c0_lnd, zmconv_c0_ocn, zmconv_ke, zmconv_tau, & 
            zmconv_dmpdz, zmconv_alfa, zmconv_tiedke_add,     &
            zmconv_cape_cin, zmconv_mx_bot_lyr_adj, zmconv_tp_fac, zmconv_trigdcape_ull, &
-           zmconv_trig_dcape_only, zmconv_trig_ull_only, zmconv_microp, zmconv_clos_dyn_adj   
+           zmconv_trig_dcape_only, zmconv_trig_ull_only, zmconv_microp, zmconv_clos_dyn_adj, &   
+           zmconv_auto_fac, zmconv_accr_fac, zmconv_micro_dcs   
 
    !-----------------------------------------------------------------------------
 
@@ -168,6 +175,9 @@ subroutine zmconv_readnl(nlfile)
       mx_bot_lyr_adj = zmconv_mx_bot_lyr_adj
       dmpdz          = zmconv_dmpdz
       tp_fac         = zmconv_tp_fac
+      auto_fac       = zmconv_auto_fac
+      accr_fac       = zmconv_accr_fac
+      micro_dcs      = zmconv_micro_dcs
      
       if ( zmconv_alfa /= unset_r8 ) then
            alfa_scalar = zmconv_alfa
@@ -208,6 +218,9 @@ subroutine zmconv_readnl(nlfile)
    call mpibcast(num_cin,           1, mpiint, 0, mpicom)
    call mpibcast(mx_bot_lyr_adj,    1, mpiint, 0, mpicom)
    call mpibcast(tp_fac,       1, mpir8,  0, mpicom)
+   call mpibcast(auto_fac,          1, mpir8,  0, mpicom)
+   call mpibcast(accr_fac,          1, mpir8,  0, mpicom)
+   call mpibcast(micro_dcs,         1, mpir8,  0, mpicom)
 #endif
 
 end subroutine zmconv_readnl
@@ -3945,7 +3958,7 @@ subroutine cldprp(lchnk   , &
                     loc_microp_st%accsirn,loc_microp_st%accgln ,loc_microp_st%accgrn ,loc_microp_st%accilm , &
                     loc_microp_st%acciln ,loc_microp_st%fallrm ,loc_microp_st%fallsm ,loc_microp_st%fallgm , &
                     loc_microp_st%fallrn ,loc_microp_st%fallsn ,loc_microp_st%fallgn ,loc_microp_st%fhmrm  , &
-                    dsfm,   dsfn) 
+                    dsfm,   dsfn, auto_fac, accr_fac, micro_dcs) 
 
 
       do k = pver,msg + 2,-1

--- a/components/eam/src/physics/cam/zm_conv.F90
+++ b/components/eam/src/physics/cam/zm_conv.F90
@@ -44,6 +44,11 @@ module zm_conv
 !<songxl 2014-11-20--------
   public zm_microp                ! true if microphysics
 !>songxl 2014-11-20--------
+  public MCSP
+  public MCSP_heat_coeff
+  public MCSP_moisture_coeff
+  public MCSP_uwind_coeff
+  public MCSP_vwind_coeff
 !
 ! Private data
 !
@@ -70,6 +75,12 @@ module zm_conv
    real(r8) :: zmconv_auto_fac       = unset_r8
    real(r8) :: zmconv_accr_fac       = unset_r8
    real(r8) :: zmconv_micro_dcs      = unset_r8
+!++ MCSP
+   real(r8) :: zmconv_MCSP_heat_coeff = 0._r8
+   real(r8) :: zmconv_MCSP_moisture_coeff = 0._r8
+   real(r8) :: zmconv_MCSP_uwind_coeff = 0._r8
+   real(r8) :: zmconv_MCSP_vwind_coeff = 0._r8   
+!-- MCSP
 
    real(r8) rl         ! wg latent heat of vaporization.
    real(r8) cpres      ! specific heat at constant pressure in j/kg-degk.
@@ -122,6 +133,14 @@ module zm_conv
    real(r8) :: accr_fac = unset_r8
    real(r8) :: micro_dcs= unset_r8
 
+!++ MCSP   
+   logical :: MCSP
+   real(r8) :: MCSP_heat_coeff = unset_r8
+   real(r8) :: MCSP_moisture_coeff = unset_r8
+   real(r8) :: MCSP_uwind_coeff = unset_r8
+   real(r8) :: MCSP_vwind_coeff = unset_r8
+!-- MCSP
+
 contains
 
 subroutine zmconv_readnl(nlfile)
@@ -140,8 +159,11 @@ subroutine zmconv_readnl(nlfile)
            zmconv_dmpdz, zmconv_alfa, zmconv_tiedke_add,     &
            zmconv_cape_cin, zmconv_mx_bot_lyr_adj, zmconv_tp_fac, zmconv_trigdcape_ull, &
            zmconv_trig_dcape_only, zmconv_trig_ull_only, zmconv_microp, zmconv_clos_dyn_adj, &   
-           zmconv_auto_fac, zmconv_accr_fac, zmconv_micro_dcs   
-
+           zmconv_auto_fac, zmconv_accr_fac, zmconv_micro_dcs, &   
+!++ MCSP 
+           zmconv_MCSP_heat_coeff, zmconv_MCSP_moisture_coeff, &
+           zmconv_MCSP_uwind_coeff, zmconv_MCSP_vwind_coeff   
+!-- MCSP
    !-----------------------------------------------------------------------------
 
    zmconv_tau = 3600._r8
@@ -178,7 +200,15 @@ subroutine zmconv_readnl(nlfile)
       auto_fac       = zmconv_auto_fac
       accr_fac       = zmconv_accr_fac
       micro_dcs      = zmconv_micro_dcs
-     
+!++ MCSP
+      MCSP_heat_coeff = zmconv_MCSP_heat_coeff
+      MCSP_moisture_coeff = zmconv_MCSP_moisture_coeff
+      MCSP_uwind_coeff = zmconv_MCSP_uwind_coeff
+      MCSP_vwind_coeff = zmconv_MCSP_vwind_coeff     
+ 
+      if( abs(MCSP_heat_coeff)+abs(MCSP_moisture_coeff)+abs(MCSP_uwind_coeff)+abs(MCSP_vwind_coeff) > 0._r8 ) MCSP = .true.
+!-- MCSP
+
       if ( zmconv_alfa /= unset_r8 ) then
            alfa_scalar = zmconv_alfa
       else
@@ -221,6 +251,13 @@ subroutine zmconv_readnl(nlfile)
    call mpibcast(auto_fac,          1, mpir8,  0, mpicom)
    call mpibcast(accr_fac,          1, mpir8,  0, mpicom)
    call mpibcast(micro_dcs,         1, mpir8,  0, mpicom)
+!++ MCSP   
+   call mpibcast(MCSP,              1, mpilog, 0, mpicom)
+   call mpibcast(MCSP_heat_coeff,   1, mpir8,  0, mpicom)
+   call mpibcast(MCSP_moisture_coeff,1, mpir8,  0, mpicom)
+   call mpibcast(MCSP_uwind_coeff,  1, mpir8,  0, mpicom)
+   call mpibcast(MCSP_vwind_coeff,  1, mpir8,  0, mpicom)  
+!-- MCSP   
 #endif
 
 end subroutine zmconv_readnl

--- a/components/eam/src/physics/cam/zm_conv.F90
+++ b/components/eam/src/physics/cam/zm_conv.F90
@@ -12,6 +12,8 @@ module zm_conv
 !
 ! Author: Byron Boville, from code in tphysbc
 !
+! April 2021: X. Song added code for convective microphysics
+! April 2022: X. Song added code for mass flux adjustment
 !---------------------------------------------------------------------------------
   use shr_kind_mod,    only: r8 => shr_kind_r8
   use spmd_utils,      only: masterproc
@@ -21,9 +23,7 @@ module zm_conv
                              cpwv, cpliq, rh2o
   use cam_abortutils,      only: endrun
   use cam_logfile,     only: iulog
-!<songxl 2014-11-20--------
   use zm_microphysics, only: zm_mphy, zm_aero_t, zm_microp_st
-!>songxl 2014-11-20--------
 
   implicit none
 
@@ -41,9 +41,7 @@ module zm_conv
   public trigdcape_ull            ! true if to use dcape-ULL trigger
   public trig_dcape_only          ! true if to use dcape only trigger
   public trig_ull_only            ! true if to ULL along with default CAPE-based trigger
-!<songxl 2014-11-20--------
-  public zm_microp                ! true if microphysics
-!>songxl 2014-11-20--------
+  public zm_microp                ! true for convective microphysics
   public MCSP
   public MCSP_heat_coeff
   public MCSP_moisture_coeff
@@ -65,10 +63,9 @@ module zm_conv
    logical  :: zmconv_trig_dcape_only  = .false.
    logical  :: zmconv_trig_ull_only  = .false.
 
-!<songxl 2014-11-20-----------
-   logical  :: zmconv_microp         = .false.   ! switch for ZM microphysics
-   logical  :: zmconv_clos_dyn_adj   = .false.   ! switch for closure dynamics adjustment
-!>songxl 2014-11-20-----------
+   logical  :: zmconv_microp         = .false.   ! switch for convective microphysics 
+   logical  :: zmconv_clos_dyn_adj   = .false.   ! switch for mass flux adjustment    
+   logical  :: zmconv_tpert_fix      = .false.   ! switch for tpert impacts           
    integer  :: zmconv_cape_cin       = unset_int
    integer  :: zmconv_mx_bot_lyr_adj = unset_int
    real(r8) :: zmconv_tp_fac         = unset_r8
@@ -102,10 +99,10 @@ module zm_conv
    real(r8) :: dmpdz          = unset_r8  ! Parcel fractional mass entrainment rate (/m)
    real(r8) :: alfa_scalar  ! maximum downdraft mass flux fraction  
    real(r8) ::  tiedke_add    = unset_r8
-!<songxl 2014-11-20-----------
-   logical  :: zm_microp    ! switch for ZM microphysics
-   logical  :: clos_dyn_adj = .false.   ! true if apply dynamics adjustment to CAPE closure   
-!>songxl 2014-11-20-----------  
+   logical  :: zm_microp    = .false.   ! switch for convective microphysics                   
+   logical  :: clos_dyn_adj = .false.   ! true if apply mass flux adjustment to CAPE closure   
+   logical  :: tpert_fix    = .false.   ! true if apply tpert only to PBL-rooted convection    
+
    integer  :: num_cin        = unset_int !number of negative buoyancy regions that are allowed before the conv. top and CAPE calc are completed
    integer  :: mx_bot_lyr_adj = unset_int !bottom layer adjustment for setting "launching" level(mx) (to be at maximum moist static energy).
    real(r8) tau   ! convective time scale
@@ -158,8 +155,8 @@ subroutine zmconv_readnl(nlfile)
    namelist /zmconv_nl/ zmconv_c0_lnd, zmconv_c0_ocn, zmconv_ke, zmconv_tau, & 
            zmconv_dmpdz, zmconv_alfa, zmconv_tiedke_add,     &
            zmconv_cape_cin, zmconv_mx_bot_lyr_adj, zmconv_tp_fac, zmconv_trigdcape_ull, &
-           zmconv_trig_dcape_only, zmconv_trig_ull_only, zmconv_microp, zmconv_clos_dyn_adj, &   
-           zmconv_auto_fac, zmconv_accr_fac, zmconv_micro_dcs, &   
+           zmconv_trig_dcape_only, zmconv_trig_ull_only, zmconv_microp, zmconv_auto_fac,&
+           zmconv_accr_fac, zmconv_micro_dcs, zmconv_clos_dyn_adj, zmconv_tpert_fix,    &
 !++ MCSP 
            zmconv_MCSP_heat_coeff, zmconv_MCSP_moisture_coeff, &
            zmconv_MCSP_uwind_coeff, zmconv_MCSP_vwind_coeff   
@@ -188,10 +185,9 @@ subroutine zmconv_readnl(nlfile)
       trigdcape_ull  = zmconv_trigdcape_ull
       trig_dcape_only  = zmconv_trig_dcape_only
       trig_ull_only  = zmconv_trig_ull_only
-!<songxl----------
       zm_microp      = zmconv_microp
       clos_dyn_adj   = zmconv_clos_dyn_adj
-!>songxl----------
+      tpert_fix      = zmconv_tpert_fix
       tiedke_add     = zmconv_tiedke_add
       num_cin        = zmconv_cape_cin
       mx_bot_lyr_adj = zmconv_mx_bot_lyr_adj
@@ -240,14 +236,13 @@ subroutine zmconv_readnl(nlfile)
    call mpibcast(trigdcape_ull,     1, mpilog, 0, mpicom)
    call mpibcast(trig_dcape_only,   1, mpilog, 0, mpicom)
    call mpibcast(trig_ull_only,     1, mpilog, 0, mpicom)
-!<sognxl--------
    call mpibcast(zm_microp,         1, mpilog, 0, mpicom)
    call mpibcast(clos_dyn_adj,      1, mpilog, 0, mpicom)
-!>songxl--------
+   call mpibcast(tpert_fix,         1, mpilog, 0, mpicom)
    call mpibcast(tiedke_add,        1, mpir8,  0, mpicom)
    call mpibcast(num_cin,           1, mpiint, 0, mpicom)
    call mpibcast(mx_bot_lyr_adj,    1, mpiint, 0, mpicom)
-   call mpibcast(tp_fac,       1, mpir8,  0, mpicom)
+   call mpibcast(tp_fac,            1, mpir8,  0, mpicom)
    call mpibcast(auto_fac,          1, mpir8,  0, mpicom)
    call mpibcast(accr_fac,          1, mpir8,  0, mpicom)
    call mpibcast(micro_dcs,         1, mpir8,  0, mpicom)
@@ -320,11 +315,9 @@ subroutine zm_convr(lchnk   ,ncol    , &
                     dp      ,dsubcld ,jt      ,maxg    ,ideep   , &
                     lengath ,ql      ,rliq    ,landfrac, &
                     t_star  ,q_star, dcape,   &
-!<songxl 2014-11-20---------------
                     aero    ,qi      ,dif     ,dnlf    ,dnif    , & 
                     dsf     ,dnsf    ,sprd    ,rice    ,frz     , &
                     mudpcu  ,lambdadpcu, microp_st)
-!>songxl 2014-11-20--------------- 
 !----------------------------------------------------------------------- 
 ! 
 ! Purpose: 
@@ -457,13 +450,11 @@ subroutine zm_convr(lchnk   ,ncol    , &
    real(r8), intent(in) :: pblh(pcols)
    real(r8), intent(in) :: tpert(pcols)
    real(r8), intent(in) :: landfrac(pcols) ! RBN Landfrac
-!<songxl 2014-05-20------------------
    type(zm_aero_t), intent(inout) :: aero         ! aerosol object. intent(inout) because the
                                                   ! gathered arrays are set here
                                                   ! before passing object
                                                   ! to microphysics
    type(zm_microp_st), intent(inout) :: microp_st ! state and tendency of convective microphysics
-!>songxl 2014-05-20------------------
 
 !DCAPE-ULL
    real(r8), intent(in), pointer, dimension(:,:) :: t_star ! intermediate T between n and n-1 time step
@@ -482,7 +473,6 @@ subroutine zm_convr(lchnk   ,ncol    , &
    real(r8), intent(out) :: cape(pcols)        ! w  convective available potential energy.
    real(r8), intent(out) :: zdu(pcols,pver)
    real(r8), intent(out) :: rprd(pcols,pver)     ! rain production rate
-!<songxl 2014-11-20---------
    real(r8), intent(out) :: sprd(pcols,pver)       ! snow production rate
    real(r8), intent(out) :: dif(pcols,pver)        ! detrained convective cloud ice mixing ratio.
    real(r8), intent(out) :: dnlf(pcols,pver)       ! detrained convective cloud water num concen.
@@ -492,8 +482,8 @@ subroutine zm_convr(lchnk   ,ncol    , &
    real(r8), intent(out) :: lambdadpcu(pcols,pver) ! slope of cloud liquid size distr
    real(r8), intent(out) :: mudpcu(pcols,pver)     ! width parameter of droplet size distr
    real(r8), intent(out) :: frz(pcols,pver)        ! freezing heating
- 
-!>songxl 2014-11-20---------
+   real(r8), intent(out) :: rice(pcols)            ! reserved ice (not yet in cldce) for energy integrals
+   real(r8), intent(out) :: qi(pcols,pver)         ! cloud ice mixing ratio. 
 
 ! move these vars from local storage to output so that convective
 ! transports can be done in outside of conv_cam.
@@ -510,10 +500,6 @@ subroutine zm_convr(lchnk   ,ncol    , &
    real(r8), intent(out) :: rliq(pcols)   ! reserved liquid (not yet in cldliq) for energy integrals
    real(r8), intent(out) :: dcape(pcols)           ! output dynamical CAPE
 
-!<songxl 2014-05-20------------------
-   real(r8), intent(out) :: rice(pcols)   ! reserved ice (not yet in cldce) for energy integrals
-   real(r8), intent(out) :: qi(pcols,pver) ! cloud ice.
-!>songxl 2014-05-20------------------
 
    real(r8) zs(pcols)
    real(r8) dlg(pcols,pver)    ! gathrd version of the detraining cld h2o tend
@@ -548,7 +534,6 @@ subroutine zm_convr(lchnk   ,ncol    , &
    real(r8) qstp(pcols,pver)           ! w  grid slice of parcel temp. saturation mixing ratio.
 
    real(r8) tl(pcols)                  ! w  row of parcel temperature at lcl.
-!<songxl 2014-05-20-----------------
    real(r8) tpm1(pcols,pver)           ! w parcel temperatures at n-1 time step. 
    real(r8) qstpm1(pcols,pver)         ! w parcel temp. saturation mixing ratio at n-1 time step
    real(r8) tlm1(pcols)                ! w LCL parcel Temperature at n-1 time step
@@ -557,7 +542,6 @@ subroutine zm_convr(lchnk   ,ncol    , &
    integer lelm1(pcols)                ! w index of highest theoretical convective plume.
    integer lonm1(pcols)                ! w index of onset level for deep convection.
    integer maxim1(pcols)               ! w index of level with largest moist static energy.
-!>songxl 2014-05-20-----------------
 
    logical iclosure                    ! switch on sequence of call to buoyan_dilute to derive DCAPE
    real(r8) capelmt_wk                 ! work capelmt to allow diff values passed to closure with trigdcape
@@ -614,7 +598,6 @@ subroutine zm_convr(lchnk   ,ncol    , &
    real(r8) dvdt(pcols,pver)           ! wg v-wind tendency at gathered points.
 !      real(r8) ud(pcols,pver)
 !      real(r8) vd(pcols,pver)
-!<songxl 2014-11-20--------
    real(r8) :: lambdadpcug(pcols,pver) ! slope of cloud liquid size distr
    real(r8) :: mudpcug(pcols,pver)     ! width parameter of droplet size distr
 
@@ -625,21 +608,18 @@ subroutine zm_convr(lchnk   ,ncol    , &
    real(r8) dnig(pcols,pver)
    real(r8) dnsg(pcols,pver)
 
+   real(r8) qldeg(pcols,pver)          ! cloud water mixing ratio for detrainment (kg/kg)
+   real(r8) qideg(pcols,pver)          ! cloud ice mixing ratio for detrainment (kg/kg)
+   real(r8) qsdeg(pcols,pver)          ! snow mixing ratio for detrainment (kg/kg)
+   real(r8) ncdeg(pcols,pver)          ! cloud water number concentration for detrainment (1/kg)
+   real(r8) nideg(pcols,pver)          ! cloud ice number concentration for detrainment (1/kg)
+   real(r8) nsdeg(pcols,pver)          ! snow concentration for detrainment (1/kg)
 
-   real(r8) qldeg(pcols,pver)     ! cloud water mixing ratio for detrainment (kg/kg)
-   real(r8) qideg(pcols,pver)     ! cloud ice mixing ratio for detrainment (kg/kg)
-   real(r8) qsdeg(pcols,pver)     ! snow mixing ratio for detrainment (kg/kg)
-   real(r8) ncdeg(pcols,pver)     ! cloud water number concentration for detrainment (1/kg)
-   real(r8) nideg(pcols,pver)     ! cloud ice number concentration for detrainment (1/kg)
-   real(r8) nsdeg(pcols,pver)     ! snow concentration for detrainment (1/kg)
-
-   real(r8) dsfmg(pcols,pver)     !mass tendency due to detrainment of snow
-   real(r8) dsfng(pcols,pver)     !num tendency due to detrainment of snow
-   real(r8) frzg(pcols,pver)      ! gathered heating rate due to freezing
+   real(r8) dsfmg(pcols,pver)          ! mass tendency due to detrainment of snow
+   real(r8) dsfng(pcols,pver)          ! num tendency due to detrainment of snow
+   real(r8) frzg(pcols,pver)           ! gathered heating rate due to freezing
 
    type(zm_microp_st)  :: loc_microp_st ! state and tendency of convective microphysics
-
-!>songxl 2014-11-20--------
 
 
    real(r8) mb(pcols)                  ! wg cloud base mass flux.
@@ -659,13 +639,11 @@ subroutine zm_convr(lchnk   ,ncol    , &
    real(r8) qdifr
    real(r8) sdifr
 
-!<songxl 2014-11-20-----------
    integer l, m
    real(r8), parameter :: dcon  = 25.e-6_r8
    real(r8), parameter :: mucon = 5.3_r8
    real(r8) negadq
    logical doliq
-!esongxl 2014-11-20-----------
 !
 !--------------------------Data statements------------------------------
 !
@@ -680,7 +658,7 @@ subroutine zm_convr(lchnk   ,ncol    , &
    heat(:,:) = 0._r8
    mcon(:,:) = 0._r8
    rliq(:ncol)   = 0._r8
-   rice(:ncol)   = 0._r8    !songxl
+   rice(:ncol)   = 0._r8    
 
    if (zm_microp) then
      allocate( &
@@ -778,7 +756,7 @@ subroutine zm_convr(lchnk   ,ncol    , &
          qlg(i,k)   = 0._r8
          dlf(i,k)   = 0._r8
          dlg(i,k)   = 0._r8
-!<songxl 2014-11-20-------
+         ! Convective microphysics
          dif(i,k)   = 0._r8
          dsf(i,k)   = 0._r8
          dnlf(i,k)  = 0._r8
@@ -813,20 +791,19 @@ subroutine zm_convr(lchnk   ,ncol    , &
    if (zm_microp) then
      do k = 1,pver
        do i = 1,ncol
-!< microp_st-------------------------
-  
-         microp_st%wu(i,k)    = 0._r8
+         ! microp_st  
+         microp_st%wu(i,k)     = 0._r8
 
-         microp_st%qliq(i,k)  = 0._r8
-         microp_st%qice(i,k)  = 0._r8
-         microp_st%qrain(i,k) = 0._r8
-         microp_st%qsnow(i,k) = 0._r8
+         microp_st%qliq(i,k)   = 0._r8
+         microp_st%qice(i,k)   = 0._r8
+         microp_st%qrain(i,k)  = 0._r8
+         microp_st%qsnow(i,k)  = 0._r8
          microp_st%qgraupel(i,k) = 0._r8
-         microp_st%qnl(i,k)  = 0._r8
-         microp_st%qni(i,k)  = 0._r8
-         microp_st%qnr(i,k)  = 0._r8
-         microp_st%qns(i,k)  = 0._r8
-         microp_st%qng(i,k) = 0._r8
+         microp_st%qnl(i,k)    = 0._r8
+         microp_st%qni(i,k)    = 0._r8
+         microp_st%qnr(i,k)    = 0._r8
+         microp_st%qns(i,k)    = 0._r8
+         microp_st%qng(i,k)    = 0._r8
 
          microp_st%autolm(i,k) = 0._r8
          microp_st%accrlm(i,k) = 0._r8
@@ -899,9 +876,7 @@ subroutine zm_convr(lchnk   ,ncol    , &
          microp_st%fallgn(i,k) = 0._r8
          microp_st%fhmrm (i,k) = 0._r8
 
-!> microp_st---------------------------
-
-!< loc_microp_st----------------------
+         ! loc_microp_st
          loc_microp_st%wu(i,k)   = 0._r8
 
          loc_microp_st%qliq(i,k) = 0._r8
@@ -986,18 +961,13 @@ subroutine zm_convr(lchnk   ,ncol    , &
          loc_microp_st%fallgn(i,k) = 0._r8
          loc_microp_st%fhmrm (i,k) = 0._r8
 
-!> loc_microp_st-----------------------
-!>songxl 2014-11-20-------
-
       end do
     end do
    end if
-!<songxl 2014-11-20----------
    lambdadpcu  = (mucon + 1._r8)/dcon
    mudpcu      = mucon
    lambdadpcug = lambdadpcu
    mudpcug     = mudpcu
-!>songxl 2014-11-20----------
 
    do i = 1,ncol
       pflx(i,pverp) = 0
@@ -1166,7 +1136,6 @@ subroutine zm_convr(lchnk   ,ncol    , &
       end do
    end do
 
-!<songxl 2014-11-20--------
    if (zm_microp) then
 
       if (aero%scheme == 'modal') then
@@ -1203,7 +1172,6 @@ subroutine zm_convr(lchnk   ,ncol    , &
       end if
 
    end if
-!>songxl 2014-11-20---------
 
 !
    do i = 1,lengath
@@ -1218,7 +1186,6 @@ subroutine zm_convr(lchnk   ,ncol    , &
       landfracg(i) = landfrac(ideep(i))
       pbltg(i) = pblt(ideep(i))
       tpertg(i) = tpert(ideep(i))
-      if (maxg(i)<nint(pblt(ideep(i)))) tpertg(i)=0._r8  !songxl 2021-04-25
    end do
 !
 ! calculate sub-cloud layer pressure "thickness" for use in
@@ -1272,7 +1239,6 @@ subroutine zm_convr(lchnk   ,ncol    , &
                rgas    ,grav    ,cpres   ,msg     , &
                pflxg   ,evpg    ,cug     ,rprdg   ,limcnv  , &
                landfracg, tpertg, &             !PMA adds tpert to the calculation
-!<songxl 2014-11-20------
                aero    ,qhat ,lambdadpcug,mudpcug ,sprdg   ,frzg ,  &
                qldeg   ,qideg   ,qsdeg   ,ncdeg   ,nideg   ,nsdeg,  &
                dsfmg   ,dsfng   ,loc_microp_st )   
@@ -1289,10 +1255,8 @@ subroutine zm_convr(lchnk   ,ncol    , &
          cug  (i,k) = cug  (i,k)* (zfg(i,k)-zfg(i,k+1))/dp(i,k)
          cmeg (i,k) = cmeg (i,k)* (zfg(i,k)-zfg(i,k+1))/dp(i,k)
          rprdg(i,k) = rprdg(i,k)* (zfg(i,k)-zfg(i,k+1))/dp(i,k)
-!<songxl 2014-11-20----------
          sprdg(i,k) = sprdg(i,k)* (zfg(i,k)-zfg(i,k+1))/dp(i,k)
          frzg (i,k) = frzg (i,k)* (zfg(i,k)-zfg(i,k+1))/dp(i,k)
-!>songxl 2014-11-20----------
          evpg (i,k) = evpg (i,k)* (zfg(i,k)-zfg(i,k+1))/dp(i,k)
       end do
    end do
@@ -1355,7 +1319,6 @@ subroutine zm_convr(lchnk   ,ncol    , &
          cug  (i,k)  = cug  (i,k)*mb(i)
          evpg (i,k)  = evpg (i,k)*mb(i)
          pflxg(i,k+1)= pflxg(i,k+1)*mb(i)*100._r8/grav
-!<songxl 2014-11-20----------
          sprdg(i,k)  = sprdg(i,k)*mb(i)
          frzg(i,k)   = frzg(i,k)*mb(i)
 
@@ -1365,7 +1328,6 @@ subroutine zm_convr(lchnk   ,ncol    , &
             dsfmg(i,k) = 0._r8
             dsfng(i,k) = 0._r8 
             frzg (i,k) = 0._r8
-!< loc_microp_st--------------------------
             loc_microp_st%wu(i,k) = 0._r8
             loc_microp_st%qliq (i,k) = 0._r8
             loc_microp_st%qice (i,k) = 0._r8
@@ -1450,8 +1412,6 @@ subroutine zm_convr(lchnk   ,ncol    , &
             loc_microp_st%fallgn(i,k) = 0._r8
             loc_microp_st%fhmrm (i,k) = 0._r8
          end if
-!>songxl 2014-11-20----------
-
       end do
    end do
 !
@@ -1460,21 +1420,15 @@ subroutine zm_convr(lchnk   ,ncol    , &
    call q1q2_pjr(lchnk   , &
                  dqdt    ,dsdt    ,qg      ,qs      ,qu      , &
                  su      ,du      ,qhat    ,shat    ,dp      , &
-!<songxl 2014-11-20---------
-!                 mu      ,md      ,sd      ,qd      ,qlg     , &
                  mu      ,md      ,sd      ,qd      ,qldeg   , &
-!>songxl 2014-11-20--------
                  dsubcld ,jt      ,maxg    ,1       ,lengath , &
                  cpres   ,rl      ,msg     ,          &
-!<songxl 2014-11-20------------ 
-!                 dlg     ,evpg    ,cug     )
                  dlg     ,evpg    ,cug     ,qideg   ,dig     , &
                  ncdeg   ,nideg   ,dnlg    ,dnig    ,frzg    , &
                  qsdeg   ,nsdeg   ,dsg     ,dnsg    )
-!>songxl 2014-11-20------------
 
 !
-! gather back temperature and mixing ratio.
+! Conservation check
 !
   if (zm_microp) then
     do k = msg + 1,pver
@@ -1486,8 +1440,8 @@ subroutine zm_convr(lchnk   ,ncol    , &
             negadq = dqdt(i,k)+0.5_r8*qg(i,k)/delt
             dqdt(i,k) = dqdt(i,k)-negadq
 
-! First evaporate precipitation from k layer to cloud top assuming that the preciptation above will fall down
-! and evaporate at k layer. So dsdt will be applied at k layer.
+            ! First evaporate precipitation from k layer to cloud top assuming that the preciptation 
+            ! above will fall down and evaporate at k layer. So dsdt will be applied at k layer.
             do kk=k,jt(i),-1
               if (negadq<0._r8) then
                  if (rprdg(i,kk)> -negadq*dp(i,k)/dp(i,kk)) then
@@ -1592,7 +1546,6 @@ subroutine zm_convr(lchnk   ,ncol    , &
          pflx(ideep(i),k) = pflxg(i,k)
          ql  (ideep(i),k) = qlg  (i,k)
 
-!<songxl 2014-11-20---------
          sprd(ideep(i),k) = sprdg(i,k)
          dif (ideep(i),k) = dig  (i,k)
          dsf (ideep(i),k) = dsg  (i,k)
@@ -1602,149 +1555,142 @@ subroutine zm_convr(lchnk   ,ncol    , &
          lambdadpcu(ideep(i),k) = lambdadpcug(i,k)
          mudpcu(ideep(i),k)     = mudpcug(i,k)
          frz(ideep(i),k)  = frzg(i,k)*latice/cpres
-       if (zm_microp) then
-         qi  (ideep(i),k) = loc_microp_st%qice  (i,k)
-         microp_st%wu  (ideep(i),k) = loc_microp_st%wu  (i,k)
-         microp_st%qliq(ideep(i),k) = loc_microp_st%qliq (i,k)
-         microp_st%qice(ideep(i),k) = loc_microp_st%qice (i,k)
-         microp_st%qrain(ideep(i),k) = loc_microp_st%qrain (i,k)
-         microp_st%qsnow(ideep(i),k) = loc_microp_st%qsnow (i,k)
-         microp_st%qgraupel(ideep(i),k) = loc_microp_st%qgraupel (i,k)
-         microp_st%qnl(ideep(i),k)  = loc_microp_st%qnl(i,k)
-         microp_st%qni(ideep(i),k)  = loc_microp_st%qni(i,k)
-         microp_st%qnr(ideep(i),k)  = loc_microp_st%qnr(i,k)
-         microp_st%qns(ideep(i),k)  = loc_microp_st%qns(i,k)
-         microp_st%qng(ideep(i),k)  = loc_microp_st%qng(i,k)
+         if (zm_microp) then
+           qi  (ideep(i),k) = loc_microp_st%qice  (i,k)
+           microp_st%wu  (ideep(i),k) = loc_microp_st%wu  (i,k)
+           microp_st%qliq(ideep(i),k) = loc_microp_st%qliq (i,k)
+           microp_st%qice(ideep(i),k) = loc_microp_st%qice (i,k)
+           microp_st%qrain(ideep(i),k) = loc_microp_st%qrain (i,k)
+           microp_st%qsnow(ideep(i),k) = loc_microp_st%qsnow (i,k)
+           microp_st%qgraupel(ideep(i),k) = loc_microp_st%qgraupel (i,k)
+           microp_st%qnl(ideep(i),k)  = loc_microp_st%qnl(i,k)
+           microp_st%qni(ideep(i),k)  = loc_microp_st%qni(i,k)
+           microp_st%qnr(ideep(i),k)  = loc_microp_st%qnr(i,k)
+           microp_st%qns(ideep(i),k)  = loc_microp_st%qns(i,k)
+           microp_st%qng(ideep(i),k)  = loc_microp_st%qng(i,k)
 
-         microp_st%autolm(ideep(i),k) = loc_microp_st%autolm(i,k)
-         microp_st%accrlm(ideep(i),k) = loc_microp_st%accrlm(i,k)
-         microp_st%bergnm(ideep(i),k) = loc_microp_st%bergnm(i,k)
-         microp_st%fhtimm(ideep(i),k) = loc_microp_st%fhtimm(i,k)
-         microp_st%fhtctm(ideep(i),k) = loc_microp_st%fhtctm(i,k)
-         microp_st%fhmlm (ideep(i),k) = loc_microp_st%fhmlm (i,k)
-         microp_st%hmpim (ideep(i),k) = loc_microp_st%hmpim (i,k)
-         microp_st%accslm(ideep(i),k) = loc_microp_st%accslm(i,k)
-         microp_st%dlfm  (ideep(i),k) = loc_microp_st%dlfm  (i,k)
+           microp_st%autolm(ideep(i),k) = loc_microp_st%autolm(i,k)
+           microp_st%accrlm(ideep(i),k) = loc_microp_st%accrlm(i,k)
+           microp_st%bergnm(ideep(i),k) = loc_microp_st%bergnm(i,k)
+           microp_st%fhtimm(ideep(i),k) = loc_microp_st%fhtimm(i,k)
+           microp_st%fhtctm(ideep(i),k) = loc_microp_st%fhtctm(i,k)
+           microp_st%fhmlm (ideep(i),k) = loc_microp_st%fhmlm (i,k)
+           microp_st%hmpim (ideep(i),k) = loc_microp_st%hmpim (i,k)
+           microp_st%accslm(ideep(i),k) = loc_microp_st%accslm(i,k)
+           microp_st%dlfm  (ideep(i),k) = loc_microp_st%dlfm  (i,k)
 
-         microp_st%autoln(ideep(i),k) = loc_microp_st%autoln(i,k)
-         microp_st%accrln(ideep(i),k) = loc_microp_st%accrln(i,k)
-         microp_st%bergnn(ideep(i),k) = loc_microp_st%bergnn(i,k)
-         microp_st%fhtimn(ideep(i),k) = loc_microp_st%fhtimn(i,k)
-         microp_st%fhtctn(ideep(i),k) = loc_microp_st%fhtctn(i,k)
-         microp_st%fhmln (ideep(i),k) = loc_microp_st%fhmln (i,k)
-         microp_st%accsln(ideep(i),k) = loc_microp_st%accsln(i,k)
-         microp_st%activn(ideep(i),k) = loc_microp_st%activn(i,k)
-         microp_st%dlfn  (ideep(i),k) = loc_microp_st%dlfn  (i,k)
-         microp_st%cmel  (ideep(i),k) = loc_microp_st%cmel  (i,k)
+           microp_st%autoln(ideep(i),k) = loc_microp_st%autoln(i,k)
+           microp_st%accrln(ideep(i),k) = loc_microp_st%accrln(i,k)
+           microp_st%bergnn(ideep(i),k) = loc_microp_st%bergnn(i,k)
+           microp_st%fhtimn(ideep(i),k) = loc_microp_st%fhtimn(i,k)
+           microp_st%fhtctn(ideep(i),k) = loc_microp_st%fhtctn(i,k)
+           microp_st%fhmln (ideep(i),k) = loc_microp_st%fhmln (i,k)
+           microp_st%accsln(ideep(i),k) = loc_microp_st%accsln(i,k)
+           microp_st%activn(ideep(i),k) = loc_microp_st%activn(i,k)
+           microp_st%dlfn  (ideep(i),k) = loc_microp_st%dlfn  (i,k)
+           microp_st%cmel  (ideep(i),k) = loc_microp_st%cmel  (i,k)
 
-         microp_st%autoim(ideep(i),k) = loc_microp_st%autoim(i,k)
-         microp_st%accsim(ideep(i),k) = loc_microp_st%accsim(i,k)
-         microp_st%difm  (ideep(i),k) = loc_microp_st%difm  (i,k)
-         microp_st%cmei  (ideep(i),k) = loc_microp_st%cmei  (i,k)
+           microp_st%autoim(ideep(i),k) = loc_microp_st%autoim(i,k)
+           microp_st%accsim(ideep(i),k) = loc_microp_st%accsim(i,k)
+           microp_st%difm  (ideep(i),k) = loc_microp_st%difm  (i,k)
+           microp_st%cmei  (ideep(i),k) = loc_microp_st%cmei  (i,k)
 
-         microp_st%nuclin(ideep(i),k) = loc_microp_st%nuclin(i,k)
-         microp_st%autoin(ideep(i),k) = loc_microp_st%autoin(i,k)
-         microp_st%accsin(ideep(i),k) = loc_microp_st%accsin(i,k)
-         microp_st%hmpin (ideep(i),k) = loc_microp_st%hmpin (i,k)
-         microp_st%difn  (ideep(i),k) = loc_microp_st%difn  (i,k)
+           microp_st%nuclin(ideep(i),k) = loc_microp_st%nuclin(i,k)
+           microp_st%autoin(ideep(i),k) = loc_microp_st%autoin(i,k)
+           microp_st%accsin(ideep(i),k) = loc_microp_st%accsin(i,k)
+           microp_st%hmpin (ideep(i),k) = loc_microp_st%hmpin (i,k)
+           microp_st%difn  (ideep(i),k) = loc_microp_st%difn  (i,k)
 
-         microp_st%trspcm(ideep(i),k) = loc_microp_st%trspcm(i,k)
-         microp_st%trspcn(ideep(i),k) = loc_microp_st%trspcn(i,k)
-         microp_st%trspim(ideep(i),k) = loc_microp_st%trspim(i,k)
-         microp_st%trspin(ideep(i),k) = loc_microp_st%trspin(i,k)
+           microp_st%trspcm(ideep(i),k) = loc_microp_st%trspcm(i,k)
+           microp_st%trspcn(ideep(i),k) = loc_microp_st%trspcn(i,k)
+           microp_st%trspim(ideep(i),k) = loc_microp_st%trspim(i,k)
+           microp_st%trspin(ideep(i),k) = loc_microp_st%trspin(i,k)
 
+           microp_st%accgrm(ideep(i),k) = loc_microp_st%accgrm(i,k)
+           microp_st%accglm(ideep(i),k) = loc_microp_st%accglm(i,k)
+           microp_st%accgslm(ideep(i),k)= loc_microp_st%accgslm(i,k)
+           microp_st%accgsrm(ideep(i),k)= loc_microp_st%accgsrm(i,k)
+           microp_st%accgirm(ideep(i),k)= loc_microp_st%accgirm(i,k)
+           microp_st%accgrim(ideep(i),k)= loc_microp_st%accgrim(i,k)
+           microp_st%accgrsm(ideep(i),k)= loc_microp_st%accgrsm(i,k)
 
-         microp_st%accgrm(ideep(i),k) = loc_microp_st%accgrm(i,k)
-         microp_st%accglm(ideep(i),k) = loc_microp_st%accglm(i,k)
-         microp_st%accgslm(ideep(i),k)= loc_microp_st%accgslm(i,k)
-         microp_st%accgsrm(ideep(i),k)= loc_microp_st%accgsrm(i,k)
-         microp_st%accgirm(ideep(i),k)= loc_microp_st%accgirm(i,k)
-         microp_st%accgrim(ideep(i),k)= loc_microp_st%accgrim(i,k)
-         microp_st%accgrsm(ideep(i),k)= loc_microp_st%accgrsm(i,k)
+           microp_st%accgsln(ideep(i),k)= loc_microp_st%accgsln(i,k)
+           microp_st%accgsrn(ideep(i),k)= loc_microp_st%accgsrn(i,k)
+           microp_st%accgirn(ideep(i),k)= loc_microp_st%accgirn(i,k)
 
-         microp_st%accgsln(ideep(i),k)= loc_microp_st%accgsln(i,k)
-         microp_st%accgsrn(ideep(i),k)= loc_microp_st%accgsrn(i,k)
-         microp_st%accgirn(ideep(i),k)= loc_microp_st%accgirn(i,k)
+           microp_st%accsrim(ideep(i),k)= loc_microp_st%accsrim(i,k)
+           microp_st%acciglm(ideep(i),k)= loc_microp_st%acciglm(i,k)
+           microp_st%accigrm(ideep(i),k)= loc_microp_st%accigrm(i,k)
+           microp_st%accsirm(ideep(i),k)= loc_microp_st%accsirm(i,k)
 
-         microp_st%accsrim(ideep(i),k)= loc_microp_st%accsrim(i,k)
-         microp_st%acciglm(ideep(i),k)= loc_microp_st%acciglm(i,k)
-         microp_st%accigrm(ideep(i),k)= loc_microp_st%accigrm(i,k)
-         microp_st%accsirm(ideep(i),k)= loc_microp_st%accsirm(i,k)
+           microp_st%accigln(ideep(i),k)= loc_microp_st%accigln(i,k)
+           microp_st%accigrn(ideep(i),k)= loc_microp_st%accigrn(i,k)
+           microp_st%accsirn(ideep(i),k)= loc_microp_st%accsirn(i,k)
+           microp_st%accgln(ideep(i),k) = loc_microp_st%accgln(i,k)
+           microp_st%accgrn(ideep(i),k) = loc_microp_st%accgrn(i,k)
 
-         microp_st%accigln(ideep(i),k)= loc_microp_st%accigln(i,k)
-         microp_st%accigrn(ideep(i),k)= loc_microp_st%accigrn(i,k)
-         microp_st%accsirn(ideep(i),k)= loc_microp_st%accsirn(i,k)
-         microp_st%accgln(ideep(i),k) = loc_microp_st%accgln(i,k)
-         microp_st%accgrn(ideep(i),k) = loc_microp_st%accgrn(i,k)
+           microp_st%accilm(ideep(i),k) = loc_microp_st%accilm(i,k)
+           microp_st%acciln(ideep(i),k) = loc_microp_st%acciln(i,k)
 
-         microp_st%accilm(ideep(i),k) = loc_microp_st%accilm(i,k)
-         microp_st%acciln(ideep(i),k) = loc_microp_st%acciln(i,k)
-
-         microp_st%fallrm(ideep(i),k) = loc_microp_st%fallrm(i,k)
-         microp_st%fallsm(ideep(i),k) = loc_microp_st%fallsm(i,k)
-         microp_st%fallgm(ideep(i),k) = loc_microp_st%fallgm(i,k)
-         microp_st%fallrn(ideep(i),k) = loc_microp_st%fallrn(i,k)
-         microp_st%fallsn(ideep(i),k) = loc_microp_st%fallsn(i,k)
-         microp_st%fallgn(ideep(i),k) = loc_microp_st%fallgn(i,k)
-         microp_st%fhmrm (ideep(i),k) = loc_microp_st%fhmrm (i,k)
-       end if
-!>songxl 2014-11-20---------
-
+           microp_st%fallrm(ideep(i),k) = loc_microp_st%fallrm(i,k)
+           microp_st%fallsm(ideep(i),k) = loc_microp_st%fallsm(i,k)
+           microp_st%fallgm(ideep(i),k) = loc_microp_st%fallgm(i,k)
+           microp_st%fallrn(ideep(i),k) = loc_microp_st%fallrn(i,k)
+           microp_st%fallsn(ideep(i),k) = loc_microp_st%fallsn(i,k)
+           microp_st%fallgn(ideep(i),k) = loc_microp_st%fallgn(i,k)
+           microp_st%fhmrm (ideep(i),k) = loc_microp_st%fhmrm (i,k)
+         end if
       end do
    end do
 
-!<songxl 2014-11-20------------
    if (zm_microp) then
-      do k = msg + 1,pver
-         do i = 1,ncol
+     do k = msg + 1,pver
+       do i = 1,ncol
 
-            !Interpolate variable from interface to mid-layer and convert it from units of "kg/kg" to "g/m3"
+         !Interpolate variable from interface to mid-layer and convert it from units of "kg/kg" to "g/m3"
 
-            if(k.lt.pver) then
-               microp_st%qice (i,k) = 0.5_r8*(microp_st%qice(i,k)+microp_st%qice(i,k+1))
-               microp_st%qliq (i,k) = 0.5_r8*(microp_st%qliq(i,k)+microp_st%qliq(i,k+1))
-               microp_st%qrain (i,k) = 0.5_r8*(microp_st%qrain(i,k)+microp_st%qrain(i,k+1))
-               microp_st%qsnow (i,k) = 0.5_r8*(microp_st%qsnow(i,k)+microp_st%qsnow(i,k+1))
-               microp_st%qgraupel(i,k) = 0.5_r8*(microp_st%qgraupel(i,k)+microp_st%qgraupel(i,k+1))
-               microp_st%qni (i,k) = 0.5_r8*(microp_st%qni(i,k)+microp_st%qni(i,k+1))
-               microp_st%qnl (i,k) = 0.5_r8*(microp_st%qnl(i,k)+microp_st%qnl(i,k+1))
-               microp_st%qnr (i,k) = 0.5_r8*(microp_st%qnr(i,k)+microp_st%qnr(i,k+1))
-               microp_st%qns (i,k) = 0.5_r8*(microp_st%qns(i,k)+microp_st%qns(i,k+1))
-               microp_st%qng (i,k) = 0.5_r8*(microp_st%qng(i,k)+microp_st%qng(i,k+1))
-               microp_st%wu(i,k)   = 0.5_r8*(microp_st%wu(i,k)+microp_st%wu(i,k+1))
-            end if
+         if(k.lt.pver) then
+            microp_st%qice (i,k) = 0.5_r8*(microp_st%qice(i,k)+microp_st%qice(i,k+1))
+            microp_st%qliq (i,k) = 0.5_r8*(microp_st%qliq(i,k)+microp_st%qliq(i,k+1))
+            microp_st%qrain (i,k) = 0.5_r8*(microp_st%qrain(i,k)+microp_st%qrain(i,k+1))
+            microp_st%qsnow (i,k) = 0.5_r8*(microp_st%qsnow(i,k)+microp_st%qsnow(i,k+1))
+            microp_st%qgraupel(i,k) = 0.5_r8*(microp_st%qgraupel(i,k)+microp_st%qgraupel(i,k+1))
+            microp_st%qni (i,k) = 0.5_r8*(microp_st%qni(i,k)+microp_st%qni(i,k+1))
+            microp_st%qnl (i,k) = 0.5_r8*(microp_st%qnl(i,k)+microp_st%qnl(i,k+1))
+            microp_st%qnr (i,k) = 0.5_r8*(microp_st%qnr(i,k)+microp_st%qnr(i,k+1))
+            microp_st%qns (i,k) = 0.5_r8*(microp_st%qns(i,k)+microp_st%qns(i,k+1))
+            microp_st%qng (i,k) = 0.5_r8*(microp_st%qng(i,k)+microp_st%qng(i,k+1))
+            microp_st%wu(i,k)   = 0.5_r8*(microp_st%wu(i,k)+microp_st%wu(i,k+1))
+         end if
 
-            if (t(i,k).gt. 273.15_r8 .and. t(i,k-1).le.273.15_r8) then
-                microp_st%qice (i,k-1) = microp_st%qice (i,k-1) + microp_st%qice (i,k)
-                microp_st%qice (i,k) = 0._r8
-                microp_st%qni (i,k-1) = microp_st%qni (i,k-1) + microp_st%qni (i,k)
-                microp_st%qni (i,k) = 0._r8
-                microp_st%qsnow (i,k-1) = microp_st%qsnow (i,k-1) + microp_st%qsnow (i,k)
-                microp_st%qsnow (i,k) = 0._r8
-                microp_st%qns (i,k-1) = microp_st%qns (i,k-1) + microp_st%qns (i,k)
-                microp_st%qns (i,k) = 0._r8
-                microp_st%qgraupel (i,k-1) = microp_st%qgraupel (i,k-1) + microp_st%qgraupel (i,k)
-                microp_st%qgraupel (i,k) = 0._r8
-                microp_st%qng (i,k-1) = microp_st%qng (i,k-1) + microp_st%qng (i,k)
-                microp_st%qng (i,k) = 0._r8
-            end if
+         if (t(i,k).gt. 273.15_r8 .and. t(i,k-1).le.273.15_r8) then
+             microp_st%qice (i,k-1) = microp_st%qice (i,k-1) + microp_st%qice (i,k)
+             microp_st%qice (i,k) = 0._r8
+             microp_st%qni (i,k-1) = microp_st%qni (i,k-1) + microp_st%qni (i,k)
+             microp_st%qni (i,k) = 0._r8
+             microp_st%qsnow (i,k-1) = microp_st%qsnow (i,k-1) + microp_st%qsnow (i,k)
+             microp_st%qsnow (i,k) = 0._r8
+             microp_st%qns (i,k-1) = microp_st%qns (i,k-1) + microp_st%qns (i,k)
+             microp_st%qns (i,k) = 0._r8
+             microp_st%qgraupel (i,k-1) = microp_st%qgraupel (i,k-1) + microp_st%qgraupel (i,k)
+             microp_st%qgraupel (i,k) = 0._r8
+             microp_st%qng (i,k-1) = microp_st%qng (i,k-1) + microp_st%qng (i,k)
+             microp_st%qng (i,k) = 0._r8
+         end if
 
-            microp_st%qice (i,k) = microp_st%qice(i,k) * pap(i,k)/t(i,k)/rgas *1000._r8
-            microp_st%qliq (i,k) = microp_st%qliq(i,k) * pap(i,k)/t(i,k)/rgas *1000._r8
-            microp_st%qrain (i,k) = microp_st%qrain(i,k) * pap(i,k)/t(i,k)/rgas *1000._r8
-            microp_st%qsnow (i,k) = microp_st%qsnow(i,k) * pap(i,k)/t(i,k)/rgas *1000._r8
-            microp_st%qgraupel (i,k) = microp_st%qgraupel(i,k) * pap(i,k)/t(i,k)/rgas *1000._r8
-            microp_st%qni (i,k) = microp_st%qni(i,k) * pap(i,k)/t(i,k)/rgas
-            microp_st%qnl (i,k) = microp_st%qnl(i,k) * pap(i,k)/t(i,k)/rgas
-            microp_st%qnr (i,k) = microp_st%qnr(i,k) * pap(i,k)/t(i,k)/rgas
-            microp_st%qns (i,k) = microp_st%qns(i,k) * pap(i,k)/t(i,k)/rgas
-            microp_st%qng (i,k) = microp_st%qng(i,k) * pap(i,k)/t(i,k)/rgas 
-         end do
-      end do
+         microp_st%qice (i,k) = microp_st%qice(i,k) * pap(i,k)/t(i,k)/rgas *1000._r8
+         microp_st%qliq (i,k) = microp_st%qliq(i,k) * pap(i,k)/t(i,k)/rgas *1000._r8
+         microp_st%qrain (i,k) = microp_st%qrain(i,k) * pap(i,k)/t(i,k)/rgas *1000._r8
+         microp_st%qsnow (i,k) = microp_st%qsnow(i,k) * pap(i,k)/t(i,k)/rgas *1000._r8
+         microp_st%qgraupel (i,k) = microp_st%qgraupel(i,k) * pap(i,k)/t(i,k)/rgas *1000._r8
+         microp_st%qni (i,k) = microp_st%qni(i,k) * pap(i,k)/t(i,k)/rgas
+         microp_st%qnl (i,k) = microp_st%qnl(i,k) * pap(i,k)/t(i,k)/rgas
+         microp_st%qnr (i,k) = microp_st%qnr(i,k) * pap(i,k)/t(i,k)/rgas
+         microp_st%qns (i,k) = microp_st%qns(i,k) * pap(i,k)/t(i,k)/rgas
+         microp_st%qng (i,k) = microp_st%qng(i,k) * pap(i,k)/t(i,k)/rgas 
+       end do
+     end do
    end if
-
-!>songxl 2014-11-20------------
-
 !
 #ifdef CPRCRAY
 !DIR$ CONCURRENT
@@ -1760,10 +1706,7 @@ subroutine zm_convr(lchnk   ,ncol    , &
 ! Compute precip by integrating change in water vapor minus detrained cloud water
    do k = pver,msg + 1,-1
       do i = 1,ncol
-!<songxl 2014-11-20---------
-!         prec(i) = prec(i) - dpp(i,k)* (q(i,k)-qh(i,k)) - dpp(i,k)*dlf(i,k)*2*delt
           prec(i) = prec(i) - dpp(i,k)* (q(i,k)-qh(i,k)) - dpp(i,k)*(dlf(i,k)+dif(i,k)+dsf(i,k))*2._r8*delt
-!>songxl 2014-11-20---------
       end do
    end do
 
@@ -1776,15 +1719,12 @@ subroutine zm_convr(lchnk   ,ncol    , &
 ! Treat rliq as flux out bottom, to be added back later.
    do k = 1, pver
       do i = 1, ncol
-!<songxl 2014-11-20------
-!         rliq(i) = rliq(i) + dlf(i,k)*dpp(i,k)/gravit
           rliq(i) = rliq(i) + (dlf(i,k)+dif(i,k)+dsf(i,k))*dpp(i,k)/gravit
           rice(i) = rice(i) + (dif(i,k)+dsf(i,k))*dpp(i,k)/gravit
-!>songxl 2014-11-20------
       end do
    end do
    rliq(:ncol) = rliq(:ncol) /1000._r8
-   rice(:ncol) = rice(:ncol) /1000._r8    !songxl 2014-11-20
+   rice(:ncol) = rice(:ncol) /1000._r8    
 
    if (zm_microp) then
      deallocate( &
@@ -1869,10 +1809,7 @@ subroutine zm_conv_evap(ncol,lchnk, &
      t,pmid,pdel,q, &
      tend_s, tend_s_snwprd, tend_s_snwevmlt, tend_q, &
      prdprec, cldfrc, deltat,  &
-!<songxl 2014-11-20--------
-!     prec, snow, ntprprd, ntsnprd, flxprec, flxsnow )
      prec, snow, ntprprd, ntsnprd, flxprec, flxsnow, prdsnow, old_snow )
-!>songxl 2014-11-20--------
 !-----------------------------------------------------------------------
 ! Compute tendencies due to evaporation of rain from ZM scheme
 !--
@@ -1905,10 +1842,9 @@ subroutine zm_conv_evap(ncol,lchnk, &
     real(r8), intent(inout) :: prec(pcols)        ! Convective-scale preciptn rate
     real(r8), intent(out)   :: snow(pcols)        ! Convective-scale snowfall rate
 
-!<songxl 2014-11-20-------------
+    ! Convective microphysics
     real(r8), intent(in   ) :: prdsnow(pcols,pver)! snow production (kg/ks/s)
     logical,  intent(in)    :: old_snow           ! true for old estimate of snow production
-!>songxl 2014-11-20-------------
 !
 !---------------------------Local storage-------------------------------
 
@@ -1932,10 +1868,8 @@ subroutine zm_conv_evap(ncol,lchnk, &
     real(r8) :: evplimit               ! temp variable for evaporation limits
     real(r8) :: rlat(pcols)
 
-!<songxl 2014-11-20----
     real(r8) :: dum
     real(r8) :: omsm
-!>songxl 2014-11-20---
     integer :: i,k                     ! longitude,level indices
 
 
@@ -1961,7 +1895,6 @@ subroutine zm_conv_evap(ncol,lchnk, &
        do i = 1, ncol
 
 ! Melt snow falling into layer, if necessary. 
-!<songxl 2014-11-20------------
         if( old_snow ) then
           if (t(i,k) > tmelt) then
              flxsntm(i) = 0._r8
@@ -1991,14 +1924,6 @@ subroutine zm_conv_evap(ncol,lchnk, &
            end if
          end if
 
-!          if (t(i,k) > tmelt) then
-!             flxsntm(i) = 0._r8
-!             snowmlt(i) = flxsnow(i,k) * gravit/ pdel(i,k)
-!          else
-!             flxsntm(i) = flxsnow(i,k)
-!             snowmlt(i) = 0._r8
-!          end if
-!>songxl 2014-10-10--------------------
 
 ! relative humidity depression must be > 0 for evaporation
           evplimit = max(1._r8 - q(i,k)/qs(i,k), 0._r8)
@@ -2025,12 +1950,10 @@ subroutine zm_conv_evap(ncol,lchnk, &
 
           evpprec(i) = min(evplimit, evpprec(i))
 
-!<sognxl 2014-11-20--------
           if( .not.old_snow ) then
             evpprec(i) = max(0._r8, evpprec(i))
             evpprec(i) = evpprec(i)*omsm
           end if
-!>songxl 2014-11-20--------
 
 ! evaporation of snow depends on snow fraction of total precipitation in the top after melting
           if (flxprec(i,k) > 0._r8) then
@@ -2054,9 +1977,7 @@ subroutine zm_conv_evap(ncol,lchnk, &
 ! 1e-36 to 8.64e-11 (1e-5 mm/day).  This causes the temperature based partitioning
 ! scheme to be used for small flxprec amounts.  This is to address error growth problems.
 
-!<songxl 2014-11-20--------
       if( old_snow ) then
-!>songxl 2014-11-20--------
 #ifdef PERGRO
           work1 = min(max(0._r8,flxsnow(i,k)/(flxprec(i,k)+8.64e-11_r8)),1._r8)
 #else
@@ -2072,13 +1993,11 @@ subroutine zm_conv_evap(ncol,lchnk, &
           ntsnprd(i,k) = prdprec(i,k)*work2 - evpsnow(i) - snowmlt(i)
           tend_s_snwprd  (i,k) = prdprec(i,k)*work2*latice
           tend_s_snwevmlt(i,k) = - ( evpsnow(i) + snowmlt(i) )*latice
-!<songxl 2014-11-20----------
        else
           ntsnprd(i,k) = prdsnow(i,k) - min(flxsnow(i,k)*gravit/pdel(i,k), evpsnow(i)+snowmlt(i))
           tend_s_snwprd  (i,k) = prdsnow(i,k)*latice
           tend_s_snwevmlt(i,k) = -min(flxsnow(i,k)*gravit/pdel(i,k), evpsnow(i)+snowmlt(i) )*latice
        end if
-!>songxl 2014-11-20----------
 
 ! precipitation fluxes
           flxprec(i,k+1) = flxprec(i,k) + ntprprd(i,k) * pdel(i,k)/gravit
@@ -2093,14 +2012,11 @@ subroutine zm_conv_evap(ncol,lchnk, &
 ! heating (cooling) and moistening due to evaporation 
 ! - latent heat of vaporization for precip production has already been accounted for
 ! - snow is contained in prec
-!<songxl 2014-11-20--------
-!          tend_s(i,k)   =-evpprec(i)*latvap + ntsnprd(i,k)*latice
           if( old_snow ) then
              tend_s(i,k)   =-evpprec(i)*latvap + ntsnprd(i,k)*latice
           else
              tend_s(i,k)   =-evpprec(i)*latvap + tend_s_snwevmlt(i,k)
           end if
-!>songxl 2014-11-20--------
 
           tend_q(i,k) = evpprec(i)
        end do
@@ -2122,7 +2038,7 @@ subroutine convtran(lchnk   , &
                     doconvtran,q       ,ncnst   ,mu      ,md      , &
                     du      ,eu      ,ed      ,dp      ,dsubcld , &
                     jt      ,mx      ,ideep   ,il1g    ,il2g    , &
-                    nstep   ,fracis  ,dqdt    ,dpdry   ,dt ) !songxl
+                    nstep   ,fracis  ,dqdt    ,dpdry   ,dt ) 
 !----------------------------------------------------------------------- 
 ! 
 ! Purpose: 
@@ -2168,9 +2084,7 @@ subroutine convtran(lchnk   , &
    integer, intent(in) :: nstep             ! Time step index
 
    real(r8), intent(in) :: dpdry(pcols,pver)       ! Delta pressure between interfaces
-!<songxl 2014-11-20-----------
    real(r8), intent(in) :: dt               ! 2 delta t (model time increment)
-!>songxl 2014-11-20-----------
 
 ! input/output
 
@@ -2211,9 +2125,8 @@ subroutine convtran(lchnk   , &
    real(r8) edtmp(pcols,pver)       ! Mass entraining from downdraft
    real(r8) dptmp(pcols,pver)    ! Delta pressure between interfaces
 
-!<songxl 2014-11-20----------
+   ! Conservation check
    real(r8) negadt,qtmp
-!>songxl 2014-11-20----------
 !-----------------------------------------------------------------------
 !
    small = 1.e-36_r8
@@ -2404,7 +2317,7 @@ subroutine convtran(lchnk   , &
             end do
          end do
 
-!<songxl test----------
+       ! Conservation check
        if (zm_microp) then
          do i = il1g,il2g
            do k = jt(i),mx(i)
@@ -2438,14 +2351,13 @@ subroutine convtran(lchnk   , &
                 end do
 
                 if (negadt<0._r8) then
-!                   write(*,*) "can not fix negadt=",negadt
                    dcondt(i,k) = dcondt(i,k) - negadt
                 end if
              end if
            end do
          end do
        end if
-!>songxl test----------
+
 ! Initialize to zero everywhere, then scatter tendency back to full array
          dqdt(:,:,m) = 0._r8
          do k = 1,pver
@@ -3196,15 +3108,12 @@ subroutine cldprp(lchnk   , &
                   cmeg    ,jb      ,lel     ,jt      ,jlcl    , &
                   mx      ,j0      ,jd      ,rl      ,il2g    , &
                   rd      ,grav    ,cp      ,msg     , &
-!<songxl 2014-05-20-------
-!                  pflx    ,evp     ,cu      ,rprd    ,limcnv  ,landfrac)
-                  pflx    ,evp     ,cu      ,rprd    ,limcnv  ,landfrac,  &
-                  tpertg  , &
+                  pflx    ,evp     ,cu      ,rprd    ,limcnv  , &
+                  landfrac,tpertg  , &
                   aero    ,qhat ,lambdadpcu ,mudpcu  ,sprd   ,frz1 , &
                   qcde    ,qide   ,qsde     ,ncde    ,nide   ,nsde , &
                   dsfm    ,dsfn   ,loc_microp_st )
 
-!>songxl 2014-05-20-------
 !----------------------------------------------------------------------- 
 ! 
 ! Purpose: 
@@ -3259,10 +3168,8 @@ subroutine cldprp(lchnk   , &
    real(r8), intent(in) :: shat(pcols,pver)      ! interface values of dry stat energy
    real(r8), intent(in) :: tpertg(pcols)
 
-!<songxl 2014-11-20-----------
    real(r8), intent(in) :: qhat(pcols,pver)      ! wg grid slice of upper interface mixing ratio.
    type(zm_aero_t), intent(in) :: aero           ! aerosol object
-!>songxl 2014-11-20-----------
 
 !
 ! output
@@ -3284,9 +3191,9 @@ subroutine cldprp(lchnk   , &
    real(r8), intent(out) :: sd(pcols,pver)       ! normalized dry stat energy of downdraft
    real(r8), intent(out) :: su(pcols,pver)       ! normalized dry stat energy of updraft
 
-
+   ! Convective microphysics
    type(zm_microp_st)  :: loc_microp_st ! state and tendency of convective microphysics
-!<songxl 2014-11-20------------
+
    real(r8), intent(out) :: qcde(pcols,pver)     ! cloud water mixing ratio for detrainment (kg/kg)
    real(r8), intent(out) :: qide(pcols,pver)     ! cloud ice mixing ratio for detrainment (kg/kg)
    real(r8), intent(out) :: qsde(pcols,pver)     ! snow mixing ratio for detrainment (kg/kg)
@@ -3295,7 +3202,6 @@ subroutine cldprp(lchnk   , &
    real(r8), intent(out) :: nsde(pcols,pver)     ! snow number concentration for detrainment (1/kg)
    real(r8), intent(out) :: sprd(pcols,pver)     ! rate of production of snow at that layer
 
-
    ! tendency for output
 
    real(r8), intent(out) :: dsfm  (pcols,pver)   !mass tendency due to detrainment of snow
@@ -3303,7 +3209,6 @@ subroutine cldprp(lchnk   , &
 
    real(r8), intent(inout) :: lambdadpcu(pcols,pver) ! slope of cloud liquid size distr
    real(r8), intent(inout) :: mudpcu(pcols,pver)     ! width parameter of droplet size distr
-!>songxl 2014-11-20------------
 
    real(r8) rd                   ! gas constant for dry air
    real(r8) grav                 ! gravity
@@ -3357,7 +3262,7 @@ subroutine cldprp(lchnk   , &
    real(r8) small
    real(r8) mdt
 
-!<songxl 2014-11-20---------
+   ! Convective microphysics
    real(r8) fice(pcols,pver)        ! ice fraction in precip production
    real(r8) tug(pcols,pver)
 
@@ -3369,8 +3274,6 @@ subroutine cldprp(lchnk   , &
 
    integer  iter, itnum
    integer  m
-!>songxl 2014-11-20---------
-
 
    integer khighest
    integer klowest
@@ -3382,7 +3285,6 @@ subroutine cldprp(lchnk   , &
 
 !
 !------------------------------------------------------------------------------
-!<songxl 2014-11-20---------
    dsfm  (:il2g,:) = 0._r8
    dsfn  (:il2g,:) = 0._r8
    if (zm_microp) then
@@ -3460,7 +3362,6 @@ subroutine cldprp(lchnk   , &
        end do
       end do
    end if
-!>songxl 2014-11-20---------
 !
    do i = 1,il2g
       ftemp(i) = 0._r8
@@ -3517,24 +3418,24 @@ subroutine cldprp(lchnk   , &
          hu(i,k) = hmn(i,k)
          hd(i,k) = hmn(i,k)
          rprd(i,k) = 0._r8
-!<songxl 2014-11-20----------------
+         ! Convective microphysics
          sprd(i,k) = 0._r8
          fice(i,k) = 0._r8
          tug(i,k)  = 0._r8
-         qcde(i,k)   = 0._r8
-         qide(i,k)   = 0._r8
-         qsde(i,k)   = 0._r8
-         ncde(i,k)  = 0._r8
-         nide(i,k)  = 0._r8
-         nsde(i,k)  = 0._r8
+         qcde(i,k) = 0._r8
+         qide(i,k) = 0._r8
+         qsde(i,k) = 0._r8
+         ncde(i,k) = 0._r8
+         nide(i,k) = 0._r8
+         nsde(i,k) = 0._r8
          frz(i,k)  = 0._r8
          frz1(i,k) = 0._r8
          if (zm_microp) then
            loc_microp_st%cmel(i,k) = 0._r8
            loc_microp_st%cmei(i,k) = 0._r8
            loc_microp_st%wu(i,k)   = 0._r8
-           loc_microp_st%qliq(i,k)   = 0._r8
-           loc_microp_st%qice(i,k)   = 0._r8
+           loc_microp_st%qliq(i,k) = 0._r8
+           loc_microp_st%qice(i,k) = 0._r8
            loc_microp_st%qrain(i,k)= 0._r8
            loc_microp_st%qsnow(i,k)= 0._r8
            loc_microp_st%qgraupel(i,k) = 0._r8
@@ -3542,9 +3443,8 @@ subroutine cldprp(lchnk   , &
            loc_microp_st%qni(i,k)  = 0._r8
            loc_microp_st%qnr(i,k)  = 0._r8
            loc_microp_st%qns(i,k)  = 0._r8
-           loc_microp_st%qng(i,k) = 0._r8
+           loc_microp_st%qng(i,k)  = 0._r8
          end if
-!>songxl 2014-11-20----------------
       end do
    end do
 !
@@ -3591,7 +3491,7 @@ subroutine cldprp(lchnk   , &
 !jr changed hard-wired 4 to limcnv+1 (not to exceed pver)
 !
    jt(:) = pver
-   jto(:) = pver              !songxl 2014-11-20
+   jto(:)= pver              
    do i = 1,il2g
       jt(i) = max(lel(i),limcnv+1)
       jt(i) = min(jt(i),pver)
@@ -3625,8 +3525,20 @@ subroutine cldprp(lchnk   , &
    do k = msg + 1,pver
       do i = 1,il2g
          if (k >= jt(i) .and. k <= jb(i)) then
-            hu(i,k) = hmn(i,mx(i)) + cp*(tiedke_add+tp_fac*tpertg(i)) !PMA
-            su(i,k) = s(i,mx(i)) + tiedke_add+tp_fac*tpertg(i)
+           ! Tunable temperature perturbation (tiedke_add) was already added to parcel hu/su to 
+           ! represent subgrid temperature perturbation. If PBL temperature perturbation (tpert)
+           ! is used to represent subgrid temperature perturbation, tiedke_add may need to be 
+           ! removed. In addition, current calculation of PBL temperature perturbation is not 
+           ! accurate enough so that a new tunable parameter tp_fac was introduced. This introduced
+           ! new uncertainties into the ZM scheme. The original code of ZM scheme will be used 
+           ! when tpert_fix=.true.  
+           if(tpert_fix) then
+             hu(i,k) = hmn(i,mx(i)) + cp*tiedke_add 
+             su(i,k) = s(i,mx(i)) + tiedke_add
+           else
+             hu(i,k) = hmn(i,mx(i)) + cp*(tiedke_add+tp_fac*tpertg(i)) !PMA
+             su(i,k) = s(i,mx(i)) + tiedke_add+tp_fac*tpertg(i)
+           end if
          end if
       end do
    end do
@@ -3722,7 +3634,8 @@ subroutine cldprp(lchnk   , &
          if (k < j0(i) .and. k >= jt(i)) eps(i,k) = f(i,k)
       end do
    end do
-!<songxl 2014-11-20---------------------------
+
+
    itnum = 1
    if (zm_microp) itnum = 2
 
@@ -3752,20 +3665,15 @@ subroutine cldprp(lchnk   , &
          mu(i,jb(i)) = 1._r8
          eu(i,jb(i)) = mu(i,jb(i))/dz(i,jb(i))
       end if
-!<songxl 2014-11-20---------
       if (zm_microp) then
         tmplel(i) = lel(i)
       else
         tmplel(i) = jt(i)
       end if
-!>songxl 2014-11-20---------
    end do
    do k = pver,msg + 1,-1
       do i = 1,il2g
-!<songxl 2014-11-20---------
-!         if (eps0(i) > 0._r8 .and. (k >= jt(i) .and. k < jb(i))) then
           if (eps0(i) > 0._r8 .and. (k >= tmplel(i) .and. k < jb(i))) then
-!>songxl 2014-11-20---------
             zuef(i) = zf(i,k) - zf(i,jb(i))
             rmue(i) = (1._r8/eps0(i))* (exp(eps(i,k+1)*zuef(i))-1._r8)/zuef(i)
             mu(i,k) = (1._r8/eps0(i))* (exp(eps(i,k  )*zuef(i))-1._r8)/zuef(i)
@@ -3791,16 +3699,13 @@ subroutine cldprp(lchnk   , &
                eu(i,k) = 0._r8
                du(i,k) = mu(i,k+1)/dz(i,k)
             else
-!<songxl 2014-05-20-------------
-               if (zm_microp) then
+              if (zm_microp) then
                 hu(i,k) = (mu(i,k+1)*hu(i,k+1) + dz(i,k)*(eu(i,k)*hmn(i,k) +   &
                             latice*frz(i,k)))/(mu(i,k)+ dz(i,k)*du(i,k))
-               else
+              else
                 hu(i,k) = mu(i,k+1)/mu(i,k)*hu(i,k+1) + &
                          dz(i,k)/mu(i,k)* (eu(i,k)*hmn(i,k)- du(i,k)*hsat(i,k))
-               end if
-
-!>songxl 2014-05-20--------------
+              end if
             end if
          end if
       end do
@@ -3812,13 +3717,10 @@ subroutine cldprp(lchnk   , &
 !
    do i=1,il2g
       doit(i) = .true.
-!<songxl 2014-10-10-------------
       totfrz(i)= 0._r8
       do k = pver,msg + 1,-1
          totfrz(i)= totfrz(i)+ frz(i,k)*dz(i,k)
       end do
-!>songxl 2014-10-10--------------
-
    end do
    do k=klowest-2,khighest-1,-1
       do i=1,il2g
@@ -3831,10 +3733,7 @@ subroutine cldprp(lchnk   , &
                   jt(i) = k
                   doit(i) = .false.
                end if
-!<songxl 2014-11-20----------
-!              else if (hu(i,k) > hu(i,jb(i)) .or. mu(i,k) < 0.02_r8) then
              else if ( (hu(i,k) > hu(i,jb(i)) .and. totfrz(i)<=0._r8) .or. mu(i,k) < 0.02_r8) then
-!>songxl 2014-11-20----------
                jt(i) = k + 1
                doit(i) = .false.
             end if
@@ -3842,11 +3741,9 @@ subroutine cldprp(lchnk   , &
       end do
    end do
 
-!<songxl 2014-11-20------
    do i = 1,il2g
       if (iter == 1)  jto(i) = jt(i)
    end do
-!>songxl 2014-11-20------
 
    do k = pver,msg + 1,-1
       do i = 1,il2g
@@ -3863,10 +3760,6 @@ subroutine cldprp(lchnk   , &
          end if
       end do
    end do
-
-!>songxl 2014-11-20------------
-!
-
 !
    do i = 1,il2g
       done(i) = .false.
@@ -3905,7 +3798,6 @@ subroutine cldprp(lchnk   , &
       end do
    end do
 
-!<songxl 2014-11-20-------------
    do i = 1,il2g
      if (zm_microp) then
         tmplel(i) = jlcl(i)+1
@@ -3913,13 +3805,10 @@ subroutine cldprp(lchnk   , &
         tmplel(i) = jb(i)
      end if
    end do
-!>songxl 2014-11-20-------------
 
 ! compute condensation in updraft
    do k = pver,msg + 2,-1
       do i = 1,il2g
-!<songxl 2014-11-20------------------
-!         if (k >= jt(i) .and. k < jb(i) .and. eps0(i) > 0._r8) then
         if (k >= jt(i) .and. k < tmplel(i) .and. eps0(i) > 0._r8) then
           if (zm_microp) then
              cu(i,k) = ((mu(i,k)*su(i,k)-mu(i,k+1)*su(i,k+1))/ &
@@ -3930,14 +3819,11 @@ subroutine cldprp(lchnk   , &
             cu(i,k) = ((mu(i,k)*su(i,k)-mu(i,k+1)*su(i,k+1))/ &
                       dz(i,k)- (eu(i,k)-du(i,k))*s(i,k))/(rl/cp)
           end if
-!songxl 2014-11-20--------------------
             if (k == jt(i)) cu(i,k) = 0._r8
             cu(i,k) = max(0._r8,cu(i,k))
          end if
       end do
    end do
-
-!<songxl 2014-11-20----------
 
    if (zm_microp) then
 
@@ -4002,8 +3888,12 @@ subroutine cldprp(lchnk   , &
 
       do k = pver,msg + 2,-1
          do i = 1,il2g
+            ! In the original ZM scheme, which does not consider ice phase, ql actually represents total cloud 
+            ! water. With convective microphysics, loc_microp_st%qliq and loc_microp_st%qice represent cloud
+            ! liquid water and cloud ice, respectively. Since ql is still used in other subroutines as total
+            ! cloud water, here ql is calculated as total cloud water for consistency.   
             ql(i,k) = loc_microp_st%qliq(i,k)+ loc_microp_st%qice(i,k)
-            frz1(i,k) = frz(i,k)         !songxl2014-11-20
+            frz1(i,k) = frz(i,k)         
          end do
       end do
 
@@ -4024,9 +3914,6 @@ subroutine cldprp(lchnk   , &
          end do
       end do
 
-
-!>songxl 2014-10-10--------------
-
    else  ! no microphysics
 
 ! compute condensed liquid, rain production rate
@@ -4036,8 +3923,8 @@ subroutine cldprp(lchnk   , &
 ! consistently applied.
 !    mu, ql are interface quantities
 !    cu, du, eu, rprd are midpoint quantites
-   do k = pver,msg + 2,-1
-      do i = 1,il2g
+     do k = pver,msg + 2,-1
+       do i = 1,il2g
          rprd(i,k) = 0._r8
          if (k >= jt(i) .and. k < jb(i) .and. eps0(i) > 0._r8 .and. mu(i,k) >= 0.0_r8) then
             if (mu(i,k) > 0._r8) then
@@ -4049,25 +3936,22 @@ subroutine cldprp(lchnk   , &
             end if
             totpcp(i) = totpcp(i) + dz(i,k)*(cu(i,k)-du(i,k)*ql(i,k+1))
             rprd(i,k) = c0mask(i)*mu(i,k)*ql(i,k)
-!<songxl 2014-11-20------
-               qcde(i,k) = ql(i,k)
-               qide(i,k) = 0._r8
-               qsde(i,k) = 0._r8
-               ncde(i,k) = 0._r8
-               nide(i,k) = 0._r8
-               nsde(i,k) = 0._r8
-               sprd(i,k) = 0._r8
-               frz1(i,k) = 0._r8
-!>songxl 2014-11-20------
+            ! reset convective microphysics variables
+            qcde(i,k) = ql(i,k)
+            qide(i,k) = 0._r8
+            qsde(i,k) = 0._r8
+            ncde(i,k) = 0._r8
+            nide(i,k) = 0._r8
+            nsde(i,k) = 0._r8
+            sprd(i,k) = 0._r8
+            frz1(i,k) = 0._r8
          end if
-      end do
-   end do
-!<songxl 2014-11-20-------
-    end if  ! zm_microp
+       end do
+     end do
+   end if  ! zm_microp
 
  end do   !iter
 
-!<songxl 2014-11-20----------
 ! specify downdraft properties (no downdrafts if jd.ge.jb).
 ! scale down downward mass flux profile so that net flux
 ! (up-down) at cloud base in not negative.
@@ -4124,8 +4008,6 @@ subroutine cldprp(lchnk   , &
          end if
       end do
    end do
-!>songxl 2014-11-20--------------
-
 !
    do i = 1,il2g
       qd(i,jd(i)) = qds(i,jd(i))
@@ -4139,7 +4021,6 @@ subroutine cldprp(lchnk   , &
             evp(i,k) = -ed(i,k)*q(i,k) + (md(i,k)*qd(i,k)-md(i,k+1)*qd(i,k+1))/dz(i,k)
             evp(i,k) = max(evp(i,k),0._r8)
             mdt = min(md(i,k+1),-small)
-!<songxl 2014-11-20------------
             if (zm_microp) then
               evp(i,k) = min(evp(i,k),rprd(i,k))
               if (rprd(i,k)> 0._r8) then
@@ -4150,8 +4031,6 @@ subroutine cldprp(lchnk   , &
             else
               sd(i,k+1) = ((rl/cp*evp(i,k)-ed(i,k)*s(i,k))*dz(i,k) + md(i,k)*sd(i,k))/mdt
             end if
-!>songxl 2014-11-20-------------
-!            sd(i,k+1) = ((rl/cp*evp(i,k)-ed(i,k)*s(i,k))*dz(i,k) + md(i,k)*sd(i,k))/mdt
             totevp(i) = totevp(i) - dz(i,k)*ed(i,k)*q(i,k)
          end if
       end do
@@ -4213,33 +4092,33 @@ subroutine cldprp(lchnk   , &
    do i = 1,il2g
      if (jt(i)>=jlcl(i)) then
        do k = msg + 1,pver  
-          mu(i,k) = 0._r8
-          eu(i,k) = 0._r8
-          du(i,k) = 0._r8
-          ql(i,k) = 0._r8
-          cu(i,k) = 0._r8
-          evp(i,k) = 0._r8
+          mu(i,k)   = 0._r8
+          eu(i,k)   = 0._r8
+          du(i,k)   = 0._r8
+          ql(i,k)   = 0._r8
+          cu(i,k)   = 0._r8
+          evp(i,k)  = 0._r8
           cmeg(i,k) = 0._r8
-          md(i,k) = 0._r8
-          ed(i,k) = 0._r8
-          mc(i,k) = 0._r8
+          md(i,k)   = 0._r8
+          ed(i,k)   = 0._r8
+          mc(i,k)   = 0._r8
           rprd(i,k) = 0._r8
           sprd(i,k) = 0._r8
           fice(i,k) = 0._r8
-          qcde(i,k)   = 0._r8
-          qide(i,k)   = 0._r8
-          qsde(i,k)   = 0._r8
-          ncde(i,k)  = 0._r8
-          nide(i,k)  = 0._r8
-          nsde(i,k)  = 0._r8
+          qcde(i,k) = 0._r8
+          qide(i,k) = 0._r8
+          qsde(i,k) = 0._r8
+          ncde(i,k) = 0._r8
+          nide(i,k) = 0._r8
+          nsde(i,k) = 0._r8
           frz(i,k)  = 0._r8
           frz1(i,k) = 0._r8
           if (zm_microp) then            
             loc_microp_st%wu(i,k)   = 0._r8      
             loc_microp_st%cmel(i,k) = 0._r8
             loc_microp_st%cmei(i,k) = 0._r8
-            loc_microp_st%qliq(i,k)   = 0._r8
-            loc_microp_st%qice(i,k)   = 0._r8
+            loc_microp_st%qliq(i,k) = 0._r8
+            loc_microp_st%qice(i,k) = 0._r8
             loc_microp_st%qrain(i,k)= 0._r8
             loc_microp_st%qsnow(i,k)= 0._r8
             loc_microp_st%qgraupel(i,k) = 0._r8
@@ -4247,7 +4126,7 @@ subroutine cldprp(lchnk   , &
             loc_microp_st%qni(i,k)  = 0._r8
             loc_microp_st%qnr(i,k)  = 0._r8
             loc_microp_st%qns(i,k)  = 0._r8
-            loc_microp_st%qng(i,k) = 0._r8
+            loc_microp_st%qng(i,k)  = 0._r8
           end if   
        end do
      end if
@@ -4477,12 +4356,9 @@ subroutine q1q2_pjr(lchnk   , &
                     mu      ,md      ,sd      ,qd      ,ql      , &
                     dsubcld ,jt      ,mx      ,il1g    ,il2g    , &
                     cp      ,rl      ,msg     ,          &
-!<songxl 2014-11-20----------
-!                    dl      ,evp     ,cu      )
                     dl      ,evp     ,cu      ,qice    ,dice    , &
                     qnl     ,qni     ,dnl     ,dni     ,frz     , &
                     qsde    ,nsde    ,dsnow   ,dns    )
-!>songxl 2014-11-20----------
 
    implicit none
 
@@ -4524,26 +4400,24 @@ subroutine q1q2_pjr(lchnk   , &
    real(r8), intent(in) :: cu(pcols,pver)
    real(r8), intent(in) :: dsubcld(pcols)
 
-!<songxl 2014-11-20------------
+   ! Convective microphysics
    real(r8), intent(in) :: frz(pcols,pver)
    real(r8), intent(in) :: qice(pcols,pver)
    real(r8), intent(in) :: qnl(pcols,pver)
    real(r8), intent(in) :: qni(pcols,pver)
    real(r8), intent(in) :: qsde(pcols,pver)
    real(r8), intent(in) :: nsde(pcols,pver)
-!>songxl 2014-11-20------------
 
    real(r8),intent(out) :: dqdt(pcols,pver),dsdt(pcols,pver)
    real(r8),intent(out) :: dl(pcols,pver)
 
-!<songxl 2014-11-20------------
+   ! Convective microphysics
    real(r8),intent(out) :: dice(pcols,pver)
    real(r8),intent(out) :: dnl(pcols,pver)
    real(r8),intent(out) :: dni(pcols,pver)
    real(r8),intent(out) :: dsnow(pcols,pver)
    real(r8),intent(out) :: dns(pcols,pver)
 
-!>songxl 2014-11-20------------
 
    integer kbm
    integer ktm
@@ -4563,13 +4437,12 @@ subroutine q1q2_pjr(lchnk   , &
          dsdt(i,k) = 0._r8
          dqdt(i,k) = 0._r8
          dl(i,k) = 0._r8
-!<songxl 2014-11-20------
+         ! Convective microphysics
          dice(i,k) = 0._r8
          dnl(i,k)  = 0._r8
          dni(i,k)  = 0._r8
          dsnow(i,k) = 0._r8
          dns(i,k)  = 0._r8
-!>songxl 2014-11-20------
       end do
    end do
 !
@@ -4594,9 +4467,7 @@ subroutine q1q2_pjr(lchnk   , &
                         -md(i,k)*   (sd(i,k)-shat(i,k)) &
                        )/dp(i,k)
 
-!>songxl 2014-11-20-------------
          if (zm_microp) dsdt(i,k) = dsdt(i,k) + latice/cp*frz(i,k)
-!<songxl 2014-11-20--------------
 
          dqdt(i,k) = emc + &
                     (+mu(i,k+1)* (qu(i,k+1)-qhat(i,k+1)) &
@@ -4606,7 +4477,6 @@ subroutine q1q2_pjr(lchnk   , &
                     )/dp(i,k)
 
          dl(i,k) = du(i,k)*ql(i,k+1)
-!<songxl 2014-11-20------------
          if (zm_microp) then
            dice(i,k) = du(i,k)*qice(i,k+1)
            dnl(i,k)  = du(i,k)*qnl(i,k+1)
@@ -4614,7 +4484,6 @@ subroutine q1q2_pjr(lchnk   , &
            dsnow(i,k) = du(i,k)*qsde(i,k+1)
            dns(i,k)  = du(i,k)*nsde(i,k+1)
          end if
-!>songxl 2014-11-20------------
 
       end do
    end do
@@ -4649,7 +4518,7 @@ subroutine buoyan_dilute(lchnk   ,ncol    , &
                   tp      ,qstp    ,tl      ,rl      ,cape    , &
                   pblt    ,lcl     ,lel     ,lon     ,mx      , &
                   rd      ,grav    ,cp      ,msg     , &
-                  tpert   ,iclosure) !,lel_n)
+                  tpert   ,iclosure) 
 !----------------------------------------------------------------------- 
 ! 
 ! Purpose: 
@@ -4709,18 +4578,6 @@ subroutine buoyan_dilute(lchnk   ,ncol    , &
    real(r8) tv(pcols,pver)       !
    real(r8) tpv(pcols,pver)      !
    real(r8) buoy(pcols,pver)
-!<songxl 2020-01-01---------------------------
-!   real(r8) tpv_n(pcols,pver)      !
-!   real(r8) buoy_n(pcols,pver)
-!   real(r8) pl_n(pcols)
-!   real(r8) tp_n(pcols,pver)       ! parcel temperature
-!   real(r8) qstp_n(pcols,pver)     ! saturation mixing ratio of parcel (only above lcl, just q below).
-!   real(r8) tl_n(pcols)            ! parcel temperature at lcl
-!   integer lcl_n(pcols)
-!   integer lel_n(pcols)
-!   logical plge600_n(pcols)
-!   logical findit(pcols)
-!>songxl 2020-01-01--------------------------
    real(r8) a1(pcols)
    real(r8) a2(pcols)
    real(r8) estp(pcols)
@@ -4769,7 +4626,6 @@ subroutine buoyan_dilute(lchnk   ,ncol    , &
       mx(i) = lon(i)
       cape(i) = 0._r8
       hmax(i) = 0._r8
-!      lel_n(i) = pver         !songxl 2020-01-01
    end do
 
    tp(:ncol,:) = t(:ncol,:)
@@ -4790,12 +4646,6 @@ subroutine buoyan_dilute(lchnk   ,ncol    , &
    tv(:ncol,:) = t(:ncol,:) *(1._r8+1.608_r8*q(:ncol,:))/ (1._r8+q(:ncol,:))
    tpv(:ncol,:) = tv(:ncol,:)
    buoy(:ncol,:) = 0._r8
-!<songxl 2020-01-01-------------------
-!   tp_n(:ncol,:) = tp(:ncol,:)
-!   qstp_n(:ncol,:) = qstp(:ncol,:)
-!   tpv_n(:ncol,:)  =  tpv(:ncol,:) 
-!   buoy_n(:ncol,:) = buoy(:ncol,:)
-!>songxl 2020-01-01-------------------
 !
 ! set "launching" level(mx) to be at maximum moist static energy.
 ! search for this level stops at planetary boundary layer top.
@@ -4861,11 +4711,6 @@ subroutine buoyan_dilute(lchnk   ,ncol    , &
       lcl(i) = mx(i)
       tl(i) = t(i,mx(i))
       pl(i) = p(i,mx(i))
-!<songxl 2020-01-01-----------------
-!      lcl_n(i) = lcl(i) 
-!      tl_n(i) = tl(i)
-!      pl_n(i) = pl(i)
-!>songxl 2020-01-01-----------------
    end do
 
 !
@@ -4874,12 +4719,8 @@ subroutine buoyan_dilute(lchnk   ,ncol    , &
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!! DILUTE PLUME CALCULATION USING ENTRAINING PLUME !!!
 !!!   RBN 9/9/04   !!!
-!<songxl 2020-01-01----------------
-!   call parcel_dilute(lchnk, ncol, msg, mx, p, t, q, tpert, tp, tpv, qstp, pl, tl, lcl)
-!    call parcel_dilute(lchnk, ncol, msg, mx, p, t, q, tpert, pblt, tp_n, tpv_n, qstp_n, pl_n, tl_n, lcl_n, .false.)  
-    call parcel_dilute(lchnk, ncol, msg, mx, p, t, q, tpert, pblt, tp, tpv, qstp, pl, tl, lcl) !, .true.)
+    call parcel_dilute(lchnk, ncol, msg, mx, p, t, q, tpert, pblt, tp, tpv, qstp, pl, tl, lcl) 
     
-!>songxl 2020-01-01----------------
 
 ! If lcl is above the nominal level of non-divergence (600 mbs),
 ! no deep convection is permitted (ensuing calculations
@@ -4887,7 +4728,6 @@ subroutine buoyan_dilute(lchnk   ,ncol    , &
 !
    do i = 1,ncol
       plge600(i) = pl(i).ge.600._r8 ! Just change to always allow buoy calculation.
-!      plge600_n(i) = pl_n(i).ge.600._r8
    end do
 
 !
@@ -4898,15 +4738,11 @@ subroutine buoyan_dilute(lchnk   ,ncol    , &
          if (k <= mx(i) .and. plge600(i)) then   ! Define buoy from launch level to cloud top.
             tv(i,k) = t(i,k)* (1._r8+1.608_r8*q(i,k))/ (1._r8+q(i,k))
             buoy(i,k) = tpv(i,k) - tv(i,k) + tiedke_add  ! +0.5K or not?
-!            buoy_n(i,k) = tpv_n(i,k) - tv(i,k) + tiedke_add    !songxl 2020-01-01
          else
             qstp(i,k) = q(i,k)
             tp(i,k)   = t(i,k)            
             tpv(i,k)  = tv(i,k)
          endif
-!         if (k <= mx(i) .and. plge600_n(i)) then
-!            buoy_n(i,k) = tpv_n(i,k) - tv(i,k) + tiedke_add    !songxl 2020-01-01
-!         end if
       end do
    end do
 
@@ -4916,7 +4752,6 @@ subroutine buoyan_dilute(lchnk   ,ncol    , &
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-!   findit(:)=.true.
 
 !
    do k = msg + 2,pver
@@ -4926,19 +4761,7 @@ subroutine buoyan_dilute(lchnk   ,ncol    , &
                knt(i) = min(num_cin,knt(i) + 1)
                lelten(i,knt(i)) = k
             end if
-!<songxl 2020-01-01---------
-!            if (buoy_n(i,k+1) > 0._r8 .and. buoy_n(i,k) <= 0._r8) then
-!               lel_n(i) = k
-!            end if
-!>songxl 2020-01-01--------
          end if
-!         if (k < lcl_n(i) .and. plge600_n(i) .and. findit(i)) then
-!           if (buoy_n(i,k+1) > 0._r8 .and. buoy_n(i,k) <= 0._r8) then
-!               lel_n(i) = k
-!               findit(i)= .false.
-!           end if
-!         end if
-
       end do
    end do
 !
@@ -4973,16 +4796,10 @@ subroutine buoyan_dilute(lchnk   ,ncol    , &
       cape(i) = max(cape(i), 0._r8)
    end do
 !
-!   do i = 1,ncol
-!     if(lel_n(i).gt.lel(i)) then
-!        lel_n(i) = lel(i)
-!     end if
-!   end do
-!
    return
 end subroutine buoyan_dilute
 
-subroutine parcel_dilute (lchnk, ncol, msg, klaunch, p, t, q, tpert, pblt, tp, tpv, qstp, pl, tl, lcl) !, do_entr)
+subroutine parcel_dilute (lchnk, ncol, msg, klaunch, p, t, q, tpert, pblt, tp, tpv, qstp, pl, tl, lcl) 
 ! Routine  to determine 
 !   1. Tp   - Parcel temperature
 !   2. qstp - Saturated mixing ratio at the parcel temperature.
@@ -4991,7 +4808,6 @@ subroutine parcel_dilute (lchnk, ncol, msg, klaunch, p, t, q, tpert, pblt, tp, t
 implicit none
 !--------------------
 
-!logical, intent(in) :: do_entr          !songxl 2020-01-01
 integer, intent(in) :: lchnk
 integer, intent(in) :: ncol
 integer, intent(in) :: msg
@@ -5002,9 +4818,7 @@ real(r8), intent(in), dimension(pcols,pver) :: p
 real(r8), intent(in), dimension(pcols,pver) :: t
 real(r8), intent(in), dimension(pcols,pver) :: q
 real(r8), intent(in), dimension(pcols) :: tpert ! PBL temperature perturbation.
-!<<songxl 2021-04-25
 real(r8), intent(in), dimension(pcols) :: pblt          ! index of pbl depth 
-!>>songxl 2021-04-25
 
 real(r8), intent(inout), dimension(pcols,pver) :: tp    ! Parcel temp.
 real(r8), intent(inout), dimension(pcols,pver) :: qstp  ! Parcel water vapour (sat value above lcl).
@@ -5104,13 +4918,17 @@ mp = 0._r8
 new_q = 0._r8
 new_s = 0._r8
 
-!<<songxl 2021-04-25
-! do not add PBL temperatue perturbation to the mid-level convection(i.e. launch level is above PBL).
+
+! The original ZM scheme only treats PBL-rooted convection. PBL temperature perturbation (tpert) was  
+! used to increase the parcel temperatue at launch level, which is in PBL.
+! The dcape_ull or ull triggr enables ZM scheme to treat elevated convection with launch level above PBL.
+! If parcel launch level is above PBL top, tempeature perturbation in PBL should not be able to influence 
+! it. In this situation, the temporary varaible tpertg is reset to zero.  
 do i=1,ncol
   tpertg(i)=tpert(i)
-  if (klaunch(i)<nint(pblt(i))) tpertg(i)=0._r8
+  if ( tpert_fix .and. klaunch(i)<nint(pblt(i))) tpertg(i)=0._r8
 end do
-!>>songxl 2021-04-25
+
 
 ! **** Begin loops ****
 
@@ -5147,14 +4965,7 @@ do k = pver, msg+1, -1
 
          dpdz = -(penv*grav)/(rgas*tenv) ! in mb/m since  p in mb.
          dzdp = 1._r8/dpdz                  ! in m/mb
-!<songxl 2020-01-01-------------------         
          dmpdp = dmpdz*dzdp              ! /mb Fractional entrainment
-!         if (do_entr)  then
-!           dmpdp = dmpdz*dzdp              ! /mb Fractional entrainment
-!         else 
-!           dmpdp = 0._r8 
-!         end if        
-!>songxl 2020-01-01-------------------
 ! Sum entrainment to current level
 ! entrains q,s out of intervening dp layers, in which linear variation is assumed
 ! so really it entrains the mean of the 2 stored values.

--- a/components/eam/src/physics/cam/zm_conv_intr.F90
+++ b/components/eam/src/physics/cam/zm_conv_intr.F90
@@ -939,7 +939,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    call zm_convr(   lchnk   ,ncol    , &
                     state%t       ,state%q(:,:,1)     ,prec    ,jctop   ,jcbot   , &
                     pblh    ,state%zm      ,state%phis    ,state%zi      ,ptend_loc%q(:,:,1)    , &
-                    ptend_loc%s    ,state%pmid     ,state%pint    ,state%pdel     , &
+                    ptend_loc%s    ,state%pmid     ,state%pint    ,state%pdel     ,state%omega  , &
                     .5_r8*ztodt    ,mcon    ,cme     , cape,      &
                     tpert   ,dlf     ,pflx    ,zdu     ,rprd    , &
                     mu,md,du,eu,ed      , &

--- a/components/eam/src/physics/cam/zm_conv_intr.F90
+++ b/components/eam/src/physics/cam/zm_conv_intr.F90
@@ -12,9 +12,20 @@ module zm_conv_intr
 ! July 2015 B. Singh Added code for unified convective trasport
 !---------------------------------------------------------------------------------
    use shr_kind_mod, only: r8=>shr_kind_r8
-   use physconst,    only: cpair
+   use physconst,    only: cpair                              
    use ppgrid,       only: pver, pcols, pverp, begchunk, endchunk
    use zm_conv,      only: zm_conv_evap, zm_convr, convtran, momtran, trigdcape_ull, trig_dcape_only
+!<songxl---------------
+   use zm_conv,      only: zm_microp
+   use zm_microphysics,  only: zm_aero_t, zm_microp_st
+   use rad_constituents, only: rad_cnst_get_info, rad_cnst_get_mode_num, rad_cnst_get_aer_mmr, &
+                               rad_cnst_get_aer_props, rad_cnst_get_mode_props  
+
+   use ndrop_bam,        only: ndrop_bam_init
+   use cam_abortutils,   only: endrun
+   use physconst,        only: pi
+   use spmd_utils,       only: masterproc
+!>songxl---------------
    use cam_history,  only: outfld, addfld, horiz_only, add_default
    use perf_mod
    use cam_logfile,  only: iulog
@@ -37,6 +48,14 @@ module zm_conv_intr
       dp_flxsnw_idx, &
       dp_cldliq_idx, &
       dp_cldice_idx, &
+!<songxl 2014-11-20------------
+      dlfzm_idx,     &     ! detrained convective cloud water mixing ratio.
+      difzm_idx,     &     ! detrained convective cloud ice mixing ratio.
+      dsfzm_idx,     &     ! detrained convective snow mixing ratio. 
+      dnlfzm_idx,    &     ! detrained convective cloud water num concen.
+      dnifzm_idx,    &     ! detrained convective cloud ice num concen.
+      dnsfzm_idx,    &     ! detrained convective snow num concen.
+!>songxl 2014-11-20------------
       prec_dp_idx,   &
       snow_dp_idx
 
@@ -53,6 +72,21 @@ module zm_conv_intr
    logical  ::    convproc_do_aer 
    logical  ::    convproc_do_gas 
    logical  ::    clim_modal_aero
+
+!<songxl 2014-11-20-----------
+   integer  ::    dgnum_idx        = 0
+   integer  ::    lambdadpcu_idx   = 0
+   integer  ::    mudpcu_idx       = 0
+   integer  ::    icimrdp_idx      = 0
+
+
+   logical :: old_snow  = .true.   ! set true to use old estimate of snow production in zm_conv_evap
+                                   ! set false to use snow production from zm
+                                   ! microphysics
+   integer :: nmodes
+   integer :: nbulk
+
+   type(zm_aero_t), allocatable :: aero(:)   ! object contains information about the aerosols
 
 !=========================================================================================
 contains
@@ -88,9 +122,32 @@ subroutine zm_conv_register
    if (trigdcape_ull .or. trig_dcape_only) then
     ! temperature from physics in n-1 time step
     call pbuf_add_field('T_STAR','global',dtype_r8,(/pcols,pver/), t_star_idx)
-    ! moisturetendency from physics in n-1 time step 
+    ! moisturetendency from physics in n-1 time step
     call pbuf_add_field('Q_STAR','global',dtype_r8,(/pcols,pver/), q_star_idx)
    endif
+
+!<songxl 2014-11-20---------
+   ! detrained convective cloud water mixing ratio.
+   call pbuf_add_field('DLFZM', 'physpkg', dtype_r8, (/pcols,pver/), dlfzm_idx)
+   ! detrained convective cloud ice mixing ratio.
+   call pbuf_add_field('DIFZM', 'physpkg', dtype_r8, (/pcols,pver/), difzm_idx)
+
+   if (zm_microp) then
+      ! Only add the number conc fields if the microphysics is active.
+
+      ! detrained convective cloud water num concen.
+      call pbuf_add_field('DNLFZM', 'physpkg', dtype_r8, (/pcols,pver/), dnlfzm_idx)
+      ! detrained convective cloud ice num concen.
+      call pbuf_add_field('DNIFZM', 'physpkg', dtype_r8, (/pcols,pver/), dnifzm_idx)
+      ! detrained convective snow num concen.
+      call pbuf_add_field('DNSFZM', 'physpkg', dtype_r8, (/pcols,pver/), dnsfzm_idx)
+      ! detrained convective snow mixing ratio.
+      call pbuf_add_field('DSFZM', 'physpkg', dtype_r8, (/pcols,pver/), dsfzm_idx)
+       
+   end if
+
+!>songxl 2014-11-20---------
+
 
 end subroutine zm_conv_register
 
@@ -111,6 +168,9 @@ subroutine zm_conv_init(pref_edge)
   use phys_control,   only: phys_deepconv_pbl, phys_getopts, cam_physpkg_is
   use physics_buffer, only: pbuf_get_index
   use rad_constituents, only: rad_cnst_get_info 
+!<songxl 2014-11-20------
+  use zm_microphysics, only: zm_mphyi
+!>songxl 2014-11-20------
 
   implicit none
 
@@ -124,7 +184,13 @@ subroutine zm_conv_init(pref_edge)
                             ! temperature, water vapor, cloud ice and cloud
                             ! liquid budgets.
   integer :: history_budget_histfile_num ! output history file number for budget fields
-  integer :: nmodes 
+!<songxl 2014-11-20----------
+!  integer :: nmodes 
+
+  ! Aerosols
+  integer :: i
+  character(len=*), parameter :: routine = 'zm_conv_init'
+!>songxl 2014-11-20----------
 
 ! 
 ! Register fields with the output buffer
@@ -156,6 +222,7 @@ subroutine zm_conv_init(pref_edge)
     call addfld ('MAXI',horiz_only , 'A','level'    ,'model level of launching parcel')
 
     call addfld ('CAPE',       horiz_only, 'A',   'J/kg', 'Convectively available potential energy')
+    call addfld ('DCAPE',      horiz_only, 'A',   'J/kg', 'change rate of Convectively available potential energy')
     call addfld ('FREQZM',horiz_only  ,'A','fraction', 'Fractional occurance of ZM convection') 
 
     call addfld ('ZMMTT',     (/ 'lev' /), 'A', 'K/s', 'T tendency - ZM convective momentum transport')
@@ -174,6 +241,134 @@ subroutine zm_conv_init(pref_edge)
     call addfld ('ZMICUD',     (/ 'lev' /), 'A', 'm/s', 'ZM in-cloud U downdrafts')
     call addfld ('ZMICVU',     (/ 'lev' /), 'A', 'm/s', 'ZM in-cloud V updrafts')
     call addfld ('ZMICVD',     (/ 'lev' /), 'A', 'm/s', 'ZM in-cloud V downdrafts')
+
+!<songxl 2014-11-20---------
+
+    if (zm_microp) then
+
+       call addfld ('CLDLIQZM',(/ 'lev' /), 'A', 'g/m3', 'Cloud liquid water - ZM convection')
+       call addfld ('CLDICEZM',(/ 'lev' /), 'A', 'g/m3', 'Cloud ice water - ZM convection')
+       call addfld ('CLIQSNUM',(/ 'lev' /), 'A', '1'   , 'Cloud liquid water sample number - ZM convection')
+       call addfld ('CICESNUM',(/ 'lev' /), 'A', '1'   , 'Cloud ice water sample number - ZM convection')
+       call addfld ('QRAINZM' ,(/ 'lev' /), 'A', 'g/m3', 'rain water - ZM convection')
+       call addfld ('QSNOWZM' ,(/ 'lev' /), 'A', 'g/m3', 'snow - ZM convection')
+       call addfld ('QGRAPZM' ,(/ 'lev' /), 'A', 'g/m3', 'graupel - ZM convection')
+       call addfld ('CRAINNUM',(/ 'lev' /), 'A', '1'   , 'Cloud rain water sample number - ZM convection')
+       call addfld ('CSNOWNUM',(/ 'lev' /), 'A', '1'   , 'Cloud snow sample number - ZM convection')
+       call addfld ('CGRAPNUM',(/ 'lev' /), 'A', '1'   , 'Cloud graupel sample number -ZM convection')
+
+       call addfld ('DIFZM',(/ 'lev' /), 'A','kg/kg/s ', 'Detrained ice water from ZM convection')
+       call addfld ('DLFZM',(/ 'lev' /), 'A','kg/kg/s ', 'Detrained liquid water from ZM convection')
+       call addfld ('DNIFZM',(/ 'lev' /), 'A','1/kg/s ', 'Detrained ice water num concen from ZM convection')
+       call addfld ('DNLFZM',(/ 'lev' /), 'A','1/kg/s ', 'Detrained liquid water num concen from ZM convection')
+       call addfld ('WUZM',(/ 'lev' /)  , 'A','m/s'    , 'vertical velocity - ZM convection')
+       call addfld ('WUZMSNUM',(/ 'lev' /),'A','1'     , 'vertical velocity sample number - ZM convection')
+
+       call addfld ('QNLZM',(/ 'lev' /), 'A','1/m3'    , 'Cloud liquid water number concen - ZM convection')
+       call addfld ('QNIZM',(/ 'lev' /), 'A','1/m3'    , 'Cloud ice number concen - ZM convection')
+       call addfld ('QNRZM',(/ 'lev' /), 'A','1/m3'    , 'Cloud rain water number concen - ZM convection')
+       call addfld ('QNSZM',(/ 'lev' /), 'A','1/m3'    , 'Cloud snow number concen - ZM convection')
+       call addfld ('QNGZM',(/ 'lev' /), 'A','1/m3'    , 'Cloud graupel number concen -ZM convection')
+
+       call addfld ('FRZZM',(/ 'lev' /), 'A','K/s'     , 'heating tendency due to freezing - ZM convection')
+
+       call addfld ('AUTOL_M' ,(/ 'lev' /), 'A', 'kg/kg/m', 'mass tendency due to autoconversion of droplets to rain')
+       call addfld ('ACCRL_M' ,(/ 'lev' /), 'A', 'kg/kg/m', 'mass tendency due to accretion of droplets by rain')
+       call addfld ('BERGN_M' ,(/ 'lev' /), 'A', 'kg/kg/m', 'mass tendency due to Bergeron process')
+       call addfld ('FHTIM_M' ,(/ 'lev' /), 'A', 'kg/kg/m', 'mass tendency due to immersion freezing')
+       call addfld ('FHTCT_M' ,(/ 'lev' /), 'A', 'kg/kg/m', 'mass tendency due to contact freezing')
+       call addfld ('FHML_M'  ,(/ 'lev' /), 'A', 'kg/kg/m', 'mass tendency due to homogeneous freezing of droplet')
+       call addfld ('HMPI_M'  ,(/ 'lev' /), 'A', 'kg/kg/m', 'mass tendency due to HM process')
+       call addfld ('ACCSL_M' ,(/ 'lev' /), 'A', 'kg/kg/m', 'mass tendency due to accretion of droplet by snow')
+       call addfld ('DLF_M'   ,(/ 'lev' /), 'A', 'kg/kg/m', 'mass tendency due to detrainment of droplet')
+       call addfld ('COND_M'  ,(/ 'lev' /), 'A', 'kg/kg/m', 'mass tendency due to condensation')
+
+       call addfld ('AUTOL_N' ,(/ 'lev' /), 'A', '1/kg/m' , 'num tendency due to autoconversion of droplets to rain')
+       call addfld ('ACCRL_N' ,(/ 'lev' /), 'A', '1/kg/m' , 'num tendency due to accretion of droplets by rain')
+       call addfld ('BERGN_N' ,(/ 'lev' /), 'A', '1/kg/m' , 'num tendency due to Bergeron process')
+       call addfld ('FHTIM_N' ,(/ 'lev' /), 'A', '1/kg/m' , 'num tendency due to immersion freezing')
+       call addfld ('FHTCT_N' ,(/ 'lev' /), 'A', '1/kg/m' , 'num tendency due to contact freezing')
+       call addfld ('FHML_N'  ,(/ 'lev' /), 'A', '1/kg/m' , 'num tendency due to homogeneous freezing of droplet')
+       call addfld ('ACCSL_N' ,(/ 'lev' /), 'A', '1/kg/m' , 'num tendency due to accretion of droplet by snow')
+       call addfld ('ACTIV_N' ,(/ 'lev' /), 'A', '1/kg/m' , 'num tendency due to droplets activation')
+       call addfld ('DLF_N'   ,(/ 'lev' /), 'A', '1/kg/m' , 'num tendency due to detrainment of droplet')
+
+       call addfld ('AUTOI_M' ,(/ 'lev' /), 'A', 'kg/kg/m', 'mass tendency due to autoconversion of ice to snow')
+       call addfld ('ACCSI_M' ,(/ 'lev' /), 'A', 'kg/kg/m', 'mass tendency due to accretion of ice by snow')
+       call addfld ('DIF_M'   ,(/ 'lev' /), 'A', 'kg/kg/m', 'mass tendency due to detrainment of cloud ice')
+       call addfld ('DEPOS_M' ,(/ 'lev' /), 'A', 'kg/kg/m', 'mass tendency due to deposition')
+
+       call addfld ('NUCLI_N' ,(/ 'lev' /), 'A', '1/kg/m' , 'num tendency due to ice nucleation')
+       call addfld ('AUTOI_N' ,(/ 'lev' /), 'A', '1/kg/m' , 'num tendency due to autoconversion of ice to snow')
+       call addfld ('ACCSI_N' ,(/ 'lev' /), 'A', '1/kg/m' , 'num tendency due to accretion of ice by snow')
+       call addfld ('HMPI_N'  ,(/ 'lev' /), 'A', '1/kg/s' , 'num tendency due to HM process')
+       call addfld ('DIF_N'   ,(/ 'lev' /), 'A', '1/kg/m' , 'num tendency due to detrainment of cloud ice')
+       call addfld ('TRSPC_M' ,(/ 'lev' /), 'A', 'kg/kg/m', 'mass tendency of droplets due to convective transport')
+       call addfld ('TRSPC_N' ,(/ 'lev' /), 'A', '1/kg/m' , 'num tendency of droplets due to convective transport')
+       call addfld ('TRSPI_M' ,(/ 'lev' /), 'A', 'kg/kg/m', 'mass tendency of ice crystal due to convective transport')
+       call addfld ('TRSPI_N' ,(/ 'lev' /), 'A', '1/kg/m' , 'num tendency of ice crystal due to convective transport')
+
+       call addfld ('ACCGR_M' ,(/ 'lev' /), 'A', 'kg/kg/m', 'mass tendency due to collection of rain by graupel')
+       call addfld ('ACCGL_M' ,(/ 'lev' /), 'A', 'kg/kg/m', 'mass tendency due to collection of droplets by graupel')
+       call addfld ('ACCGSL_M',(/ 'lev' /), 'A', 'kg/kg/m', 'mass tendency of graupel due to collection of droplets by snow')
+       call addfld ('ACCGSR_M',(/ 'lev' /), 'A', 'kg/kg/m', 'mass tendency of graupel due to collection of rain by snow')
+       call addfld ('ACCGIR_M',(/ 'lev' /), 'A', 'kg/kg/m', 'mass tendency of graupel due to collection of rain by ice')
+       call addfld ('ACCGRI_M',(/ 'lev' /), 'A', 'kg/kg/m', 'mass tendency of graupel due to collection of ice by rain')
+       call addfld ('ACCGRS_M',(/ 'lev' /), 'A', 'kg/kg/m', 'mass tendency of graupel due to collection of snow by rain')
+
+       call addfld ('ACCGSL_N',(/ 'lev' /), 'A', '1/kg/m' , 'num tendency of graupel due to collection of droplets by snow')
+       call addfld ('ACCGSR_N',(/ 'lev' /), 'A', '1/kg/m' , 'num tendency of graupel due to collection of rain by snow')
+       call addfld ('ACCGIR_N',(/ 'lev' /), 'A', '1/kg/m' , 'num tendency of graupel due to collection of rain by ice')
+
+       call addfld ('ACCSRI_M',(/ 'lev' /), 'A', 'kg/kg/m', 'mass tendency of snow due to collection of ice by rain')
+       call addfld ('ACCIGL_M',(/ 'lev' /), 'A', 'kg/kg/m', 'mass tendency of ice mult(splintering) due to acc droplets by graupel')
+       call addfld ('ACCIGR_M',(/ 'lev' /), 'A', 'kg/kg/m', 'mass tendency of ice mult(splintering) due to acc rain by graupel')
+       call addfld ('ACCSIR_M',(/ 'lev' /), 'A', 'kg/kg/m', 'mass tendency of snow due to collection of rain by ice')
+
+       call addfld ('ACCIGL_N',(/ 'lev' /), 'A', '1/kg/m' , 'num tendency of ice mult(splintering) due to acc droplets by graupel')
+       call addfld ('ACCIGR_N',(/ 'lev' /), 'A', '1/kg/m' , 'num tendency of ice mult(splintering) due to acc rain by graupel')
+       call addfld ('ACCSIR_N',(/ 'lev' /), 'A', '1/kg/m' , 'num tendency of snow due to collection of rain by ice')
+       call addfld ('ACCGL_N' ,(/ 'lev' /), 'A', '1/kg/m' , 'num tendency due to collection of droplets by graupel')
+       call addfld ('ACCGR_N' ,(/ 'lev' /), 'A', '1/kg/m' , 'num tendency due to collection of rain by graupel')
+       call addfld ('ACCIL_M' ,(/ 'lev' /), 'A', 'kg/kg/m', 'mass tendency of cloud ice due to collection of droplet by cloud ice')
+       call addfld ('ACCIL_N' ,(/ 'lev' /), 'A', '1/kg/m' , 'num tendency of cloud ice due to collection of droplet by cloud ice')
+
+       call addfld ('FALLR_M' ,(/ 'lev' /), 'A', 'kg/kg/m', 'mass tendency of rain fallout')
+       call addfld ('FALLS_M' ,(/ 'lev' /), 'A', 'kg/kg/m', 'mass tendency of snow fallout')
+       call addfld ('FALLG_M' ,(/ 'lev' /), 'A', 'kg/kg/m', 'mass tendency of graupel fallout')
+       call addfld ('FALLR_N' ,(/ 'lev' /), 'A', '1/kg/m' , 'num tendency of rain fallout')
+       call addfld ('FALLS_N' ,(/ 'lev' /), 'A', '1/kg/m' , 'num tendency of snow fallout')
+       call addfld ('FALLG_N' ,(/ 'lev' /), 'A', '1/kg/m' , 'num tendency of graupel fallout')
+       call addfld ('FHMR_M'  ,(/ 'lev' /), 'A', 'kg/kg/m', 'mass tendency due to homogeneous freezing of rain')
+
+       call addfld ('PRECZ_SN',horiz_only , 'A', '#'      , 'sample num of convective precipitation rate from ZM deep')
+
+       call add_default ('CLDLIQZM', 1, ' ')
+       call add_default ('CLDICEZM', 1, ' ')
+       call add_default ('CLIQSNUM', 1, ' ')
+       call add_default ('CICESNUM', 1, ' ')
+       call add_default ('DIFZM',    1, ' ')
+       call add_default ('DLFZM',    1, ' ')
+       call add_default ('DNIFZM',   1, ' ')
+       call add_default ('DNLFZM',   1, ' ')
+       call add_default ('WUZM',     1, ' ')
+       call add_default ('QRAINZM',  1, ' ')
+       call add_default ('QSNOWZM',  1, ' ')
+       call add_default ('QGRAPZM',  1, ' ')
+       call add_default ('CRAINNUM', 1, ' ')
+       call add_default ('CSNOWNUM', 1, ' ')
+       call add_default ('CGRAPNUM', 1, ' ')
+       call add_default ('QNLZM',    1, ' ')
+       call add_default ('QNIZM',    1, ' ')
+       call add_default ('QNRZM',    1, ' ')
+       call add_default ('QNSZM',    1, ' ')
+       call add_default ('QNGZM',    1, ' ')
+       call add_default ('FRZZM',   1, ' ')
+
+    end if
+
+!>songxl 2014-11-20---------
+
     
     call phys_getopts( history_budget_out = history_budget, &
                        history_budget_histfile_num_out = history_budget_histfile_num, &
@@ -229,13 +424,193 @@ subroutine zm_conv_init(pref_edge)
     prec_dp_idx     = pbuf_get_index('PREC_DP')
     snow_dp_idx     = pbuf_get_index('SNOW_DP')
 
+!<songxl 2014-11-20----------
+    lambdadpcu_idx  = pbuf_get_index('LAMBDADPCU')
+    mudpcu_idx      = pbuf_get_index('MUDPCU')
+    icimrdp_idx     = pbuf_get_index('ICIMRDP')
+
+    ! Initialization for the microphysics
+    if (zm_microp) then
+
+       call zm_mphyi()
+
+       ! if zmconv_microp not enabled then use old estimate of snow production in
+       ! zm_conv_evap
+       old_snow = .false. 
+
+       ! Initialize the aerosol object with data from the modes/species
+       ! affecting climate,
+       ! i.e., the list index is hardcoded to 0.
+
+       call rad_cnst_get_info(0, nmodes=nmodes, naero=nbulk)
+
+       allocate(aero(begchunk:endchunk))
+
+       do i = begchunk, endchunk
+          call zm_aero_init(nmodes, nbulk, aero(i))
+       end do
+
+       if (nmodes > 0) then
+
+          dgnum_idx = pbuf_get_index('DGNUM')
+
+       else if (nbulk > 0) then
+
+          ! This call is needed to allow running the ZM microphysics with the
+          ! cam4 physics package.
+          call ndrop_bam_init()
+
+       end if
+
+     end if ! zmconv_microp
+
+    !-------------------------------------------------------------------------------------
+    contains
+    !-------------------------------------------------------------------------------------
+
+    subroutine zm_aero_init(nmodes, nbulk, aero)
+
+       ! Initialize the zm_aero_t object for modal aerosols
+
+       integer,         intent(in)  :: nmodes
+       integer,         intent(in)  :: nbulk
+       type(zm_aero_t), intent(out) :: aero
+
+       integer :: iaer, l, m
+       integer :: nspecmx   ! max number of species in a mode
+
+       character(len=20), allocatable :: aername(:)
+       character(len=32) :: str32
+
+       real(r8) :: sigmag, dgnumlo, dgnumhi
+       real(r8) :: alnsg
+       !----------------------------------------------------------------------------------
+
+       aero%nmodes = nmodes
+       aero%nbulk  = nbulk
+
+       if (nmodes > 0) then
+
+          ! Initialize the modal aerosol information
+
+          aero%scheme = 'modal'
+
+          ! Get number of species in each mode, and find max.
+          allocate(aero%nspec(aero%nmodes))
+          nspecmx = 0
+          do m = 1, aero%nmodes
+
+             call rad_cnst_get_info(0, m, nspec=aero%nspec(m), mode_type=str32)
+
+             nspecmx = max(nspecmx, aero%nspec(m))
+
+             ! save mode index for specified mode types
+             select case (trim(str32))
+             case ('accum')
+                aero%mode_accum_idx = m
+             case ('aitken')
+                aero%mode_aitken_idx = m
+             case ('coarse')
+                aero%mode_coarse_idx = m
+             end select
+
+          end do
+
+          ! Check that required mode types were found
+          if (aero%mode_accum_idx == -1 .or. aero%mode_aitken_idx == -1 .or. aero%mode_coarse_idx == -1) then
+             write(iulog,*) routine//': ERROR required mode type not found - mode idx:', &
+                aero%mode_accum_idx, aero%mode_aitken_idx, aero%mode_coarse_idx
+             call endrun(routine//': ERROR required mode type not found')
+          end if
+
+          ! find indices for the dust and seasalt species in the coarse mode
+          do l = 1, aero%nspec(aero%mode_coarse_idx)
+             call rad_cnst_get_info(0, aero%mode_coarse_idx, l, spec_type=str32)
+             select case (trim(str32))
+             case ('dust')
+                aero%coarse_dust_idx = l
+             case ('seasalt')
+                aero%coarse_nacl_idx = l
+             end select
+          end do
+          ! Check that required modal specie types were found
+          if (aero%coarse_dust_idx == -1 .or. aero%coarse_nacl_idx == -1) then
+             write(iulog,*) routine//': ERROR required mode-species type not found - indicies:', &
+                aero%coarse_dust_idx, aero%coarse_nacl_idx
+             call endrun(routine//': ERROR required mode-species type not found')
+          end if
+
+          allocate( &
+             aero%num_a(nmodes), &
+             aero%mmr_a(nspecmx,nmodes), &
+             aero%numg_a(pcols,pver,nmodes), &
+             aero%mmrg_a(pcols,pver,nspecmx,nmodes), &
+             aero%voltonumblo(nmodes), &
+             aero%voltonumbhi(nmodes), &
+             aero%specdens(nspecmx,nmodes), &
+             aero%spechygro(nspecmx,nmodes), &
+             aero%dgnum(nmodes), &
+             aero%dgnumg(pcols,pver,nmodes) )
+
+          do m = 1, nmodes
+
+             ! Properties of modes
+             call rad_cnst_get_mode_props(0, m, &
+                sigmag=sigmag, dgnumlo=dgnumlo, dgnumhi=dgnumhi)
+
+             alnsg               = log(sigmag)
+             aero%voltonumblo(m) = 1._r8 / ( (pi/6._r8)*(dgnumlo**3._r8)*exp(4.5_r8*alnsg**2._r8) )
+             aero%voltonumbhi(m) = 1._r8 / ( (pi/6._r8)*(dgnumhi**3._r8)*exp(4.5_r8*alnsg**2._r8) )
+
+             ! save sigmag of aitken mode
+             if (m == aero%mode_aitken_idx) aero%sigmag_aitken = sigmag
+
+             ! Properties of modal species
+             do l = 1, aero%nspec(m)
+                call rad_cnst_get_aer_props(0, m, l, density_aer=aero%specdens(l,m), &
+                   hygro_aer=aero%spechygro(l,m))
+             end do
+          end do
+
+       else if (nbulk > 0) then
+
+          aero%scheme = 'bulk'
+
+          ! Props needed for BAM number concentration calcs.
+          allocate( &
+             aername(nbulk),                   &
+             aero%num_to_mass_aer(nbulk),      &
+             aero%mmr_bulk(nbulk),             &
+             aero%mmrg_bulk(pcols,plev,nbulk)  )
+
+          do iaer = 1, aero%nbulk
+             call rad_cnst_get_aer_props(0, iaer, &
+                aername         = aername(iaer), &
+                num_to_mass_aer = aero%num_to_mass_aer(iaer) )
+
+             ! Look for sulfate aerosol in this list (Bulk aerosol only)
+             if (trim(aername(iaer)) == 'SULFATE') aero%idxsul = iaer
+             if (trim(aername(iaer)) == 'DUST1')   aero%idxdst1 = iaer
+             if (trim(aername(iaer)) == 'DUST2')   aero%idxdst2 = iaer
+             if (trim(aername(iaer)) == 'DUST3')   aero%idxdst3 = iaer
+             if (trim(aername(iaer)) == 'DUST4')   aero%idxdst4 = iaer
+             if (trim(aername(iaer)) == 'BCPHI')   aero%idxbcphi = iaer
+          end do
+
+       end if
+
+    end subroutine zm_aero_init
+!>songxl 2014-11-20-------------
+
 end subroutine zm_conv_init
 !=========================================================================================
 !subroutine zm_conv_tend(state, ptend, tdt)
 
 subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
-     tpert   ,dlf     ,pflx    ,zdu      , &
-     rliq    , &
+!<songxl 2014-11-20---
+     tpert   ,dlftot  ,pflx    ,zdu      , &
+     rliq    ,rice    ,&
+!>songxl 2014-11-20---
      ztodt   , &
      jctop   ,jcbot , &
      state   ,ptend_all   ,landfrac,  pbuf, mu, eu, &
@@ -256,8 +631,10 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    use phys_control,  only: cam_physpkg_is
 
    ! Arguments
-
-   type(physics_state), intent(in )   :: state          ! Physics state variables
+!<songxl 2014-11-20--------
+!   type(physics_state), intent(in )   :: state          ! Physics state variables
+   type(physics_state), target, intent(in ) :: state      ! Physics state variables
+!>songxl 2014-11-20---------
    type(physics_ptend), intent(out)   :: ptend_all      ! individual parameterization tendencies
    type(physics_buffer_desc), pointer :: pbuf(:)
 
@@ -267,12 +644,15 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    real(r8), intent(in) :: landfrac(pcols)             ! RBN - Landfrac 
 
    real(r8), intent(out) :: mcon(pcols,pverp)  ! Convective mass flux--m sub c
-   real(r8), intent(out) :: dlf(pcols,pver)    ! scattrd version of the detraining cld h2o tend
+   real(r8), intent(out) :: dlftot(pcols,pver) ! scattrd version of the detraining cld h2o tend
    real(r8), intent(out) :: pflx(pcols,pverp)  ! scattered precip flux at each level
    real(r8), intent(out) :: cme(pcols,pver)    ! cmf condensation - evaporation
    real(r8), intent(out) :: zdu(pcols,pver)    ! detraining mass flux
 
    real(r8), intent(out) :: rliq(pcols) ! reserved liquid (not yet in cldliq) for energy integrals
+!<songxl 11-20---------
+   real(r8), intent(out) :: rice(pcols) ! reserved ice (not yet in cldice) for energy integrals
+!>songxl 11-20--------
    real(r8), intent(out):: mu(pcols,pver) 
    real(r8), intent(out):: eu(pcols,pver) 
    real(r8), intent(out):: du(pcols,pver) 
@@ -297,7 +677,12 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
 
    ! Local variables
 
-   integer :: i,k,m
+!<songxl 11-20---------
+    type(zm_microp_st)        :: microp_st 
+
+!   integer :: i,k,m
+   integer :: i,k,l,m
+!>songxl 11-20--------
    integer :: ilon                      ! global longitude index of a column
    integer :: ilat                      ! global latitude index of a column
    integer :: nstep
@@ -315,8 +700,10 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
 
    ! physics types
    type(physics_state) :: state1        ! locally modify for evaporation to use, not returned
-   type(physics_ptend) :: ptend_loc     ! package tendencies
-
+!<songxl 11-20---------
+!   type(physics_ptend) :: ptend_loc     ! package tendencies
+   type(physics_ptend),target :: ptend_loc     ! package tendencies
+!>songxl 11-20--------
    ! physics buffer fields
    real(r8), pointer, dimension(:)   :: prec         ! total precipitation
    real(r8), pointer, dimension(:)   :: snow         ! snow from ZM convection 
@@ -336,6 +723,18 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    real(r8) :: dcape(pcols)                    ! dynamical cape
    real(r8) :: maxgsav(pcols)                  ! tmp array for recording and outfld to MAXI
 
+!<songxl 2014-11-20-----
+   real(r8), pointer :: dlf(:,:)    ! detrained convective cloud water mixing ratio.
+   real(r8), pointer :: dif(:,:)    ! detrained convective cloud ice mixing ratio.
+   real(r8), pointer :: dsf(:,:)    ! detrained convective snow mixing ratio.
+   real(r8), pointer :: dnlf(:,:)   ! detrained convective cloud water num concen.
+   real(r8), pointer :: dnif(:,:)   ! detrained convective cloud ice num concen.
+   real(r8), pointer :: dnsf(:,:)   ! detrained convective snow num concen.
+
+   real(r8), pointer :: lambdadpcu(:,:) ! slope of cloud liquid size distr
+   real(r8), pointer :: mudpcu(:,:)     ! width parameter of droplet size distr
+   real(r8), pointer :: qi(:,:)         ! wg grid slice of cloud ice.
+!>songxl 2014-11-20-----
 
    real(r8) :: jctop(pcols)  ! o row of top-of-deep-convection indices passed out.
    real(r8) :: jcbot(pcols)  ! o row of base of cloud indices passed out.
@@ -361,6 +760,89 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
 
    logical  :: lq(pcnst)
 
+!<songxl 2014-11-20-----------
+   real(r8) :: sprd(pcols,pver)
+   real(r8) :: frz(pcols,pver)
+   real(r8)  precz_snum(pcols)
+
+
+   if (zm_microp) then
+     allocate( &
+       microp_st%wu(pcols,pver),      &  ! vertical velocity
+       microp_st%qliq(pcols,pver),    &  ! convective cloud liquid water.
+       microp_st%qice(pcols,pver),    &  ! convective cloud ice.
+       microp_st%qrain(pcols,pver),   &  ! convective rain water.
+       microp_st%qsnow(pcols,pver),   &  ! convective snow.
+       microp_st%qgraupel(pcols,pver),&  ! convective graupel
+       microp_st%qnl(pcols,pver),     &  ! convective cloud liquid water num concen.
+       microp_st%qni(pcols,pver),     &  ! convective cloud ice num concen.
+       microp_st%qnr(pcols,pver),     &  ! convective rain water num concen.
+       microp_st%qns(pcols,pver),     &  ! convective snow num concen.
+       microp_st%qng(pcols,pver),     &  ! convective graupel num concen.
+       microp_st%autolm(pcols,pver),  &  !mass tendency due to autoconversion of droplets to rain
+       microp_st%accrlm(pcols,pver),  &  !mass tendency due to accretion of droplets by rain
+       microp_st%bergnm(pcols,pver),  &  !mass tendency due to Bergeron process
+       microp_st%fhtimm(pcols,pver),  &  !mass tendency due to immersion freezing
+       microp_st%fhtctm(pcols,pver),  &  !mass tendency due to contact freezing
+       microp_st%fhmlm (pcols,pver),  &  !mass tendency due to homogeneous freezing
+       microp_st%hmpim (pcols,pver),  &  !mass tendency due to HM process
+       microp_st%accslm(pcols,pver),  &  !mass tendency due to accretion of droplets by snow
+       microp_st%dlfm  (pcols,pver),  &  !mass tendency due to detrainment of droplet
+       microp_st%autoln(pcols,pver),  &  !num tendency due to autoconversion of droplets to rain
+       microp_st%accrln(pcols,pver),  &  !num tendency due to accretion of droplets by rain
+       microp_st%bergnn(pcols,pver),  &  !num tendency due to Bergeron process
+       microp_st%fhtimn(pcols,pver),  &  !num tendency due to immersion freezing
+       microp_st%fhtctn(pcols,pver),  &  !num tendency due to contact freezing
+       microp_st%fhmln (pcols,pver),  &  !num tendency due to homogeneous freezing
+       microp_st%accsln(pcols,pver),  &  !num tendency due to accretion of droplets by snow
+       microp_st%activn(pcols,pver),  &  !num tendency due to droplets activation
+       microp_st%dlfn  (pcols,pver),  &  !num tendency due to detrainment of droplet
+       microp_st%autoim(pcols,pver),  &  !mass tendency due to autoconversion of cloud ice to snow
+       microp_st%accsim(pcols,pver),  &  !mass tendency due to accretion of cloud ice by snow
+       microp_st%difm  (pcols,pver),  &  !mass tendency due to detrainment of cloud ice
+       microp_st%nuclin(pcols,pver),  &  !num tendency due to ice nucleation
+       microp_st%autoin(pcols,pver),  &  !num tendency due to autoconversion of cloud ice to snow
+       microp_st%accsin(pcols,pver),  &  !num tendency due to accretion of cloud ice by snow
+       microp_st%hmpin (pcols,pver),  &  !num tendency due to HM process
+       microp_st%difn  (pcols,pver),  &  !num tendency due to detrainment of cloud ice
+       microp_st%cmel  (pcols,pver),  &  !mass tendency due to condensation
+       microp_st%cmei  (pcols,pver),  &  !mass tendency due to deposition
+       microp_st%trspcm(pcols,pver),  &  !LWC tendency due to convective transport
+       microp_st%trspcn(pcols,pver),  &  !droplet num tendency due to convective transport
+       microp_st%trspim(pcols,pver),  &  !IWC tendency due to convective transport
+       microp_st%trspin(pcols,pver),  &  !ice crystal num tendency due to convective transport
+       microp_st%accgrm(pcols,pver),   & ! mass tendency due to collection of rain by graupel
+       microp_st%accglm(pcols,pver),   & ! mass tendency due to collection of droplets by graupel
+       microp_st%accgslm(pcols,pver),  & ! mass tendency of graupel due to collection of droplets by snow
+       microp_st%accgsrm(pcols,pver),  & ! mass tendency of graupel due to collection of rain by snow
+       microp_st%accgirm(pcols,pver),  & ! mass tendency of graupel due to collection of rain by ice
+       microp_st%accgrim(pcols,pver),  & ! mass tendency of graupel due to collection of ice by rain
+       microp_st%accgrsm(pcols,pver),  & ! mass tendency due to collection of snow by rain
+       microp_st%accgsln(pcols,pver),  & ! num tendency of graupel due to collection of droplets by snow
+       microp_st%accgsrn(pcols,pver),  & ! num tendency of graupel due to collection of rain by snow
+       microp_st%accgirn(pcols,pver),  & ! num tendency of graupel due to collection of rain by ice   
+       microp_st%accsrim(pcols,pver),  & ! mass tendency of snow due to collection of ice by rain
+       microp_st%acciglm(pcols,pver),  & ! mass tendency of ice mult(splintering) due to acc droplets by graupel
+       microp_st%accigrm(pcols,pver),  & ! mass tendency of ice mult(splintering) due to acc rain by graupel
+       microp_st%accsirm(pcols,pver),  & ! mass tendency of snow due to collection of rain by ice
+       microp_st%accigln(pcols,pver),  & ! num tendency of ice mult(splintering) due to acc droplets by graupel
+       microp_st%accigrn(pcols,pver),  & ! num tendency of ice mult(splintering) due to acc rain by graupel
+       microp_st%accsirn(pcols,pver),  & ! num tendency of snow due to collection of rain by ice
+       microp_st%accgln(pcols,pver),   & ! num tendency due to collection of droplets by graupel
+       microp_st%accgrn(pcols,pver),   & ! num tendency due to collection of rain by graupel
+       microp_st%accilm(pcols,pver),   & ! mass tendency of cloud ice due to collection of droplet by cloud ice
+       microp_st%acciln(pcols,pver),   & ! number conc tendency of cloud ice due to collection of droplet by cloud ice
+       microp_st%fallrm(pcols, pver),  & ! mass tendency of rain fallout
+       microp_st%fallsm(pcols, pver),  & ! mass tendency of snow fallout
+       microp_st%fallgm(pcols, pver),  & ! mass tendency of graupel fallout
+       microp_st%fallrn(pcols, pver),  & ! num tendency of rain fallout
+       microp_st%fallsn(pcols, pver),  & ! num tendency of snow fallout
+       microp_st%fallgn(pcols, pver),  & ! num tendency of graupel fallout
+       microp_st%fhmrm (pcols,pver) )    ! mass tendency due to homogeneous freezing of rain
+    end if
+
+!>songxl 2014-11-20-----------
+
    !----------------------------------------------------------------------
 
    ! initialize
@@ -371,6 +853,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    ftem = 0._r8   
    mu_out(:,:) = 0._r8
    md_out(:,:) = 0._r8
+   dlftot(:,:) = 0._r8
    wind_tends(:ncol,:pver,:) = 0.0_r8
 
    call physics_state_copy(state,state1)             ! copy state to local state1.
@@ -392,6 +875,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    call pbuf_get_field(pbuf, prec_dp_idx,     prec )
    call pbuf_get_field(pbuf, snow_dp_idx,     snow )
 
+
 ! DCAPE-ULL
    if(trigdcape_ull .or. trig_dcape_only)then
      call pbuf_get_field(pbuf, t_star_idx,     t_star)
@@ -401,6 +885,52 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
        t_star(:ncol,:pver) = state%t(:ncol,:pver)
      end if
    end if
+
+!<songxl 2014-11-20------------------
+   call pbuf_get_field(pbuf, icimrdp_idx,     qi )
+   call pbuf_get_field(pbuf, dlfzm_idx,  dlf)
+   call pbuf_get_field(pbuf, difzm_idx,  dif)
+
+   if (zm_microp) then
+      call pbuf_get_field(pbuf, dnlfzm_idx, dnlf)
+      call pbuf_get_field(pbuf, dnifzm_idx, dnif)
+      call pbuf_get_field(pbuf, dsfzm_idx,  dsf)
+      call pbuf_get_field(pbuf, dnsfzm_idx, dnsf)
+   else
+      allocate(dnlf(pcols,pver), dnif(pcols,pver),dsf(pcols,pver), dnsf(pcols,pver))
+   end if
+
+   call pbuf_get_field(pbuf, lambdadpcu_idx, lambdadpcu)
+   call pbuf_get_field(pbuf, mudpcu_idx,     mudpcu)
+
+   if (zm_microp) then
+
+      if (nmodes > 0) then
+
+         ! Associate pointers with the modes and species that affect the climate (list 0)
+
+         do m = 1, nmodes
+            call rad_cnst_get_mode_num(0, m, 'a', state, pbuf, aero(lchnk)%num_a(m)%val)
+            call pbuf_get_field(pbuf, dgnum_idx, aero(lchnk)%dgnum(m)%val, start=(/1,1,m/), kount=(/pcols,pver,1/))
+
+            do l = 1, aero(lchnk)%nspec(m)
+               call rad_cnst_get_aer_mmr(0, m, l, 'a', state, pbuf, aero(lchnk)%mmr_a(l,m)%val)
+            end do
+         end do
+
+      else if (nbulk > 0) then
+         ! Associate pointers with the bulk aerosols that affect the climate (list 0)
+
+         do m = 1, nbulk
+            call rad_cnst_get_aer_mmr(0, m, state, pbuf, aero(lchnk)%mmr_bulk(m)%val)
+         end do
+
+      end if
+   end if
+
+
+!>songxl 2014-11-20------------------
+
 
 !
 ! Begin with Zhang-McFarlane (1996) convection parameterization
@@ -415,10 +945,23 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
                     mu,md,du,eu,ed      , &
                     dp ,dsubcld ,jt,maxg,ideep   , &
                     lengath ,ql      ,rliq  ,landfrac,  &
-                    t_star, q_star, dcape)  
+                    t_star, q_star, dcape, &  
+!<songxl 2014-11-20----------------------------
+                    aero(lchnk), qi, dif, dnlf, dnif, dsf, dnsf, sprd, rice, frz, mudpcu, &
+                    lambdadpcu,  microp_st)
+
+   if (zm_microp) then
+     dlftot(:,:) = dlf(:,:) + dif(:,:) + dsf(:,:)
+   else
+     dlftot(:,:) = dlf(:,:)  
+   end if
+
+!>songxl 2014-11-20-------------
+   
    call t_stopf ('zm_convr')
 
    call outfld('CAPE', cape, pcols, lchnk)        ! RBN - CAPE output
+   call outfld('DCAPE', dcape, pcols, lchnk)
 !
 ! Output fractional occurance of ZM convection
 !
@@ -431,6 +974,10 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
 ! Convert mass flux from reported mb/s to kg/m^2/s
 !
    mcon(:ncol,:pver) = mcon(:ncol,:pver) * 100._r8/gravit
+
+!<songxl 2014-11-20-------
+   call outfld('CMFMCDZM', mcon, pcols, lchnk)
+!>songxl 2014-11-20-------
 
    ! Store upward and downward mass fluxes in un-gathered arrays
    ! + convert from mb/s to kg/m^2/s
@@ -455,6 +1002,11 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    call outfld('ZMDT    ',ftem           ,pcols   ,lchnk   )
    call outfld('ZMDQ    ',ptend_loc%q(1,1,1) ,pcols   ,lchnk   )
 
+!<songxl 2014-11-20--------
+   if (zm_microp) call zm_conv_micro_outfld(microp_st, dlf, dif, dnlf, dnif, frz, lchnk, ncol)
+
+!>songxl 2014-11-20--------
+
    maxgsav(:) = 0._r8 ! zero if no convection. true mean to be MAXI/FREQZM
    pcont(:ncol) = state%ps(:ncol)
    pconb(:ncol) = state%ps(:ncol)
@@ -469,6 +1021,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    call outfld('PCONVT  ',pcont          ,pcols   ,lchnk   )
    call outfld('PCONVB  ',pconb          ,pcols   ,lchnk   )
    call outfld('MAXI  ',maxgsav          ,pcols   ,lchnk   )
+
 
   call physics_ptend_init(ptend_all, state%psetcols, 'zm_conv_tend')
 
@@ -502,7 +1055,10 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
          state1%t,state1%pmid,state1%pdel,state1%q(:pcols,:pver,1), &
          ptend_loc%s, tend_s_snwprd, tend_s_snwevmlt, ptend_loc%q(:pcols,:pver,1), &
          rprd, cld, ztodt, &
-         prec, snow, ntprprd, ntsnprd , flxprec, flxsnow)
+!<songxl 2014-11-20--------- 
+!        prec, snow, ntprprd, ntsnprd , flxprec, flxsnow)
+         prec, snow, ntprprd, ntsnprd , flxprec, flxsnow, sprd, old_snow)
+!>songxl 2014-11-20----------
     call t_stopf ('zm_conv_evap')
 
     evapcdp(:ncol,:pver) = ptend_loc%q(:ncol,:pver,1)
@@ -521,12 +1077,24 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    call outfld('ZMNTPRPD', ntprprd, pcols, lchnk)
    call outfld('ZMNTSNPD', ntsnprd, pcols, lchnk)
    call outfld('ZMEIHEAT', ptend_loc%s, pcols, lchnk)
-   call outfld('CMFMCDZM   ',mcon ,  pcols   ,lchnk   )
+!songxl 2014-11-20   call outfld('CMFMCDZM   ',mcon ,  pcols   ,lchnk   )
    call outfld('PRECCDZM   ',prec,  pcols   ,lchnk   )
 
 
 
    call outfld('PRECZ   ', prec   , pcols, lchnk)
+!<songxl 2014-11-20 -----------------
+   if (zm_microp) then
+      do i = 1,ncol
+         if (prec(i) .gt. 0.0_r8) then
+            precz_snum(i) = 1.0_r8
+         else
+            precz_snum(i) = 0.0_r8
+         end if
+      end do
+      call outfld('PRECZ_SN', precz_snum, pcols, lchnk)
+   end if
+!>songxl 2014-11-20 -------------------
 
   ! add tendency from this process to tend from other processes here
   call physics_ptend_sum(ptend_loc,ptend_all, ncol)
@@ -601,7 +1169,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
                   ptend_loc%lq,state1%q, pcnst,  mu, md,   &
                   du, eu, ed, dp, dsubcld,  &
                   jt,maxg, ideep, 1, lengath,  &
-                  nstep,   fracis,  ptend_loc%q, fake_dpdry)
+                  nstep,   fracis,  ptend_loc%q, fake_dpdry, ztodt)  !songxl 2014-11-20
    call t_stopf ('convtran1')
 
    call outfld('ZMDICE ',ptend_loc%q(1,1,ixcldice) ,pcols   ,lchnk   )
@@ -613,6 +1181,82 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    call physics_state_dealloc(state1)
    call physics_ptend_dealloc(ptend_loc)
 
+   if (zm_microp) then
+     deallocate( &
+       microp_st%wu,      &  
+       microp_st%qliq,    &  
+       microp_st%qice,    &  
+       microp_st%qrain,   &  
+       microp_st%qsnow,   &  
+       microp_st%qgraupel,&  
+       microp_st%qnl,     &  
+       microp_st%qni,     &  
+       microp_st%qnr,     &  
+       microp_st%qns,     &  
+       microp_st%qng,     &  
+       microp_st%autolm,  &  
+       microp_st%accrlm,  &  
+       microp_st%bergnm,  &  
+       microp_st%fhtimm,  &  
+       microp_st%fhtctm,  &  
+       microp_st%fhmlm ,  &  
+       microp_st%hmpim ,  &  
+       microp_st%accslm,  &  
+       microp_st%dlfm  ,  &  
+       microp_st%autoln,  &  
+       microp_st%accrln,  &  
+       microp_st%bergnn,  &  
+       microp_st%fhtimn,  &  
+       microp_st%fhtctn,  &  
+       microp_st%fhmln ,  &  
+       microp_st%accsln,  &  
+       microp_st%activn,  &  
+       microp_st%dlfn  ,  &  
+       microp_st%autoim,  &  
+       microp_st%accsim,  &  
+       microp_st%difm  ,  &  
+       microp_st%nuclin,  &  
+       microp_st%autoin,  &  
+       microp_st%accsin,  &  
+       microp_st%hmpin ,  &  
+       microp_st%difn  ,  &  
+       microp_st%cmel  ,  &  
+       microp_st%cmei  ,  &   
+       microp_st%trspcm,  &  
+       microp_st%trspcn,  &  
+       microp_st%trspim,  &  
+       microp_st%trspin,  &  
+       microp_st%accgrm,   & 
+       microp_st%accglm,   & 
+       microp_st%accgslm,  & 
+       microp_st%accgsrm,  & 
+       microp_st%accgirm,  & 
+       microp_st%accgrim,  & 
+       microp_st%accgrsm,  & 
+       microp_st%accgsln,  & 
+       microp_st%accgsrn,  & 
+       microp_st%accgirn,  & 
+       microp_st%accsrim,  & 
+       microp_st%acciglm,  & 
+       microp_st%accigrm,  & 
+       microp_st%accsirm,  & 
+       microp_st%accigln,  & 
+       microp_st%accigrn,  & 
+       microp_st%accsirn,  & 
+       microp_st%accgln,   & 
+       microp_st%accgrn,   & 
+       microp_st%accilm,   & 
+       microp_st%acciln,   & 
+       microp_st%fallrm,  & 
+       microp_st%fallsm,  & 
+       microp_st%fallgm,  & 
+       microp_st%fallrn,  & 
+       microp_st%fallsn,  & 
+       microp_st%fallgn,  & 
+       microp_st%fhmrm )
+    else
+       deallocate(dnlf, dnif, dsf, dnsf)    
+    end if
 end subroutine zm_conv_tend
 !=========================================================================================
 
@@ -711,7 +1355,7 @@ subroutine zm_conv_tend_2( state,  ptend,  ztodt, pbuf,mu, eu, &
                      ptend%lq,state%q, pcnst,  mu, md,   &
                      du, eu, ed, dp, dsubcld,  &
                      jt,maxg,ideep, 1, lengath,  &
-                     nstep,   fracis,  ptend%q, dpdry)
+                     nstep,   fracis,  ptend%q, dpdry,  ztodt)  !songxl 2014-11-20
       call t_stopf ('convtran2')
    end if
 
@@ -727,6 +1371,164 @@ subroutine zm_conv_tend_2( state,  ptend,  ztodt, pbuf,mu, eu, &
 
 end subroutine zm_conv_tend_2
 
+
+subroutine zm_conv_micro_outfld(microp_st, dlf, dif, dnlf, dnif, frz, lchnk, ncol)
+
+   use cam_history,   only: outfld
+
+   type(zm_microp_st),intent(in)  :: microp_st
+   real(r8), intent(in) :: dlf(:,:)    ! detrainment of convective cloud liquid water mixing ratio.
+   real(r8), intent(in) :: dif(:,:)    ! detrainment of convective cloud ice mixing ratio. 
+   real(r8), intent(in) :: dnlf(:,:)   ! detrainment of convective cloud liquid water num concen.
+   real(r8), intent(in) :: dnif(:,:)   ! detrainment of convective cloud ice num concen.
+   real(r8), intent(in) :: frz(:,:)    ! heating rate due to freezing 
+   integer, intent(in)         :: lchnk
+   integer, intent(in)         :: ncol
+
+   integer :: i,k
+
+   real(r8) :: cice_snum(pcols,pver)      ! convective cloud ice sample number.
+   real(r8) :: cliq_snum(pcols,pver)      ! convective cloud liquid sample number.
+   real(r8) :: crain_snum(pcols,pver)     ! convective rain water sample number.
+   real(r8) :: csnow_snum(pcols,pver)     ! convective snow sample number.
+   real(r8) :: cgraupel_snum(pcols,pver)  ! convective graupel sample number.
+   real(r8) :: wu_snum(pcols,pver)        ! vertical velocity sample number
+
+       do k = 1,pver
+          do i = 1,ncol
+             if (microp_st%qice(i,k) .gt. 0.0_r8) then
+                cice_snum(i,k) = 1.0_r8
+             else
+                cice_snum(i,k) = 0.0_r8
+             end if
+             if (microp_st%qliq(i,k) .gt. 0.0_r8) then
+                cliq_snum(i,k) = 1.0_r8
+             else
+                cliq_snum(i,k) = 0.0_r8
+             end if
+             if (microp_st%qsnow(i,k) .gt. 0.0_r8) then
+                csnow_snum(i,k) = 1.0_r8
+             else
+                csnow_snum(i,k) = 0.0_r8
+             end if
+             if (microp_st%qrain(i,k) .gt. 0.0_r8) then
+                crain_snum(i,k) = 1.0_r8
+             else
+                crain_snum(i,k) = 0.0_r8
+             end if
+             if (microp_st%qgraupel(i,k) .gt. 0.0_r8) then
+                cgraupel_snum(i,k) = 1.0_r8
+             else
+                cgraupel_snum(i,k) = 0.0_r8
+             end if
+             if (microp_st%wu(i,k) .gt. 0.0_r8) then
+                wu_snum(i,k) = 1.0_r8
+             else
+                wu_snum(i,k) = 0.0_r8
+             end if
+
+          end do
+       end do
+
+      call outfld('CLIQSNUM',cliq_snum      ,pcols, lchnk)
+      call outfld('CICESNUM',cice_snum      ,pcols, lchnk)
+      call outfld('CRAINNUM',crain_snum     ,pcols, lchnk)
+      call outfld('CSNOWNUM',csnow_snum     ,pcols, lchnk)
+      call outfld('CGRAPNUM',cgraupel_snum  ,pcols, lchnk)
+      call outfld('WUZMSNUM',wu_snum        ,pcols, lchnk)
+
+      call outfld('DIFZM'   ,dif            ,pcols, lchnk)
+      call outfld('DLFZM'   ,dlf            ,pcols, lchnk)
+      call outfld('DNIFZM'  ,dnif           ,pcols, lchnk)
+      call outfld('DNLFZM'  ,dnlf           ,pcols, lchnk)
+      call outfld('FRZZM'   ,frz            ,pcols, lchnk)
+
+      call outfld('WUZM'    ,microp_st%wu   ,pcols, lchnk)
+!      call outfld('FRZZM'   ,microp_st%frz  ,pcols, lchnk)
+
+      call outfld('CLDLIQZM',microp_st%qliq ,pcols, lchnk)
+      call outfld('CLDICEZM',microp_st%qice ,pcols, lchnk)
+      call outfld('QRAINZM' ,microp_st%qrain          ,pcols, lchnk)
+      call outfld('QSNOWZM' ,microp_st%qsnow          ,pcols, lchnk)
+      call outfld('QGRAPZM' ,microp_st%qgraupel       ,pcols, lchnk)
+      
+      call outfld('QNLZM'   ,microp_st%qnl            ,pcols, lchnk)
+      call outfld('QNIZM'   ,microp_st%qni            ,pcols, lchnk)
+      call outfld('QNRZM'   ,microp_st%qnr            ,pcols, lchnk)
+      call outfld('QNSZM'   ,microp_st%qns            ,pcols, lchnk)
+      call outfld('QNGZM'   ,microp_st%qng            ,pcols, lchnk)
+
+      call outfld('AUTOL_M' ,microp_st%autolm         ,pcols, lchnk)
+      call outfld('ACCRL_M' ,microp_st%accrlm         ,pcols, lchnk)
+      call outfld('BERGN_M' ,microp_st%bergnm         ,pcols, lchnk)
+      call outfld('FHTIM_M' ,microp_st%fhtimm         ,pcols, lchnk)
+      call outfld('FHTCT_M' ,microp_st%fhtctm         ,pcols, lchnk)
+      call outfld('FHML_M'  ,microp_st%fhmlm          ,pcols, lchnk)
+      call outfld('HMPI_M'  ,microp_st%hmpim          ,pcols, lchnk)
+      call outfld('ACCSL_M' ,microp_st%accslm         ,pcols, lchnk)
+      call outfld('DLF_M'   ,microp_st%dlfm           ,pcols, lchnk)  
+
+      call outfld('AUTOL_N' ,microp_st%autoln         ,pcols, lchnk)
+      call outfld('ACCRL_N' ,microp_st%accrln         ,pcols, lchnk)
+      call outfld('BERGN_N' ,microp_st%bergnn         ,pcols, lchnk)
+      call outfld('FHTIM_N' ,microp_st%fhtimn         ,pcols, lchnk)
+      call outfld('FHTCT_N' ,microp_st%fhtctn         ,pcols, lchnk)
+      call outfld('FHML_N'  ,microp_st%fhmln          ,pcols, lchnk)
+      call outfld('ACCSL_N' ,microp_st%accsln         ,pcols, lchnk)
+      call outfld('ACTIV_N' ,microp_st%activn         ,pcols, lchnk)
+      call outfld('DLF_N'   ,microp_st%dlfn           ,pcols, lchnk)
+      call outfld('AUTOI_M' ,microp_st%autoim         ,pcols, lchnk)
+      call outfld('ACCSI_M' ,microp_st%accsim         ,pcols, lchnk)
+      call outfld('DIF_M'   ,microp_st%difm           ,pcols, lchnk)
+      call outfld('NUCLI_N' ,microp_st%nuclin         ,pcols, lchnk)
+      call outfld('AUTOI_N' ,microp_st%autoin         ,pcols, lchnk)
+      call outfld('ACCSI_N' ,microp_st%accsin         ,pcols, lchnk)
+      call outfld('HMPI_N'  ,microp_st%hmpin          ,pcols, lchnk)
+      call outfld('DIF_N'   ,microp_st%difn           ,pcols, lchnk)
+      call outfld('COND_M'  ,microp_st%cmel           ,pcols, lchnk)
+      call outfld('DEPOS_M' ,microp_st%cmei           ,pcols, lchnk)
+
+      call outfld('TRSPC_M' ,microp_st%trspcm         ,pcols, lchnk)
+      call outfld('TRSPC_N' ,microp_st%trspcn         ,pcols, lchnk)
+      call outfld('TRSPI_M' ,microp_st%trspim         ,pcols, lchnk)
+      call outfld('TRSPI_N' ,microp_st%trspin         ,pcols, lchnk)
+
+      call outfld('ACCGR_M' ,microp_st%accgrm         ,pcols, lchnk)
+      call outfld('ACCGL_M' ,microp_st%accglm         ,pcols, lchnk)
+      call outfld('ACCGSL_M',microp_st%accgslm       ,pcols, lchnk)
+      call outfld('ACCGSR_M',microp_st%accgsrm       ,pcols, lchnk)
+      call outfld('ACCGIR_M',microp_st%accgirm       ,pcols, lchnk)
+      call outfld('ACCGRI_M',microp_st%accgrim       ,pcols, lchnk)
+      call outfld('ACCGRS_M',microp_st%accgrsm       ,pcols, lchnk)
+
+      call outfld('ACCGSL_N',microp_st%accgsln       ,pcols, lchnk)
+      call outfld('ACCGSR_N',microp_st%accgsrn       ,pcols, lchnk)
+      call outfld('ACCGIR_N',microp_st%accgirn       ,pcols, lchnk)
+
+      call outfld('ACCSRI_M',microp_st%accsrim       ,pcols, lchnk)
+      call outfld('ACCIGL_M',microp_st%acciglm       ,pcols, lchnk)
+      call outfld('ACCIGR_M',microp_st%accigrm       ,pcols, lchnk)
+      call outfld('ACCSIR_M',microp_st%accsirm       ,pcols, lchnk)
+
+      call outfld('ACCIGL_N',microp_st%accigln       ,pcols, lchnk)
+      call outfld('ACCIGR_N',microp_st%accigrn       ,pcols, lchnk)
+      call outfld('ACCSIR_N',microp_st%accsirn       ,pcols, lchnk)
+      call outfld('ACCGL_N' ,microp_st%accgln        ,pcols, lchnk)
+      call outfld('ACCGR_N' ,microp_st%accgrn        ,pcols, lchnk)
+
+      call outfld('ACCIL_M' ,microp_st%accilm        ,pcols, lchnk)
+      call outfld('ACCIL_N' ,microp_st%acciln        ,pcols, lchnk)
+
+      call outfld('FALLR_M' ,microp_st%fallrm        ,pcols, lchnk)
+      call outfld('FALLS_M' ,microp_st%fallsm        ,pcols, lchnk)
+      call outfld('FALLG_M' ,microp_st%fallgm        ,pcols, lchnk)
+      call outfld('FALLR_N' ,microp_st%fallrn        ,pcols, lchnk)
+      call outfld('FALLS_N' ,microp_st%fallsn        ,pcols, lchnk)
+      call outfld('FALLG_N' ,microp_st%fallgn        ,pcols, lchnk)
+
+      call outfld('FHMR_M'  ,microp_st%fhmrm         ,pcols, lchnk)
+
+ end subroutine zm_conv_micro_outfld
 !=========================================================================================
 
 

--- a/components/eam/src/physics/cam/zm_conv_intr.F90
+++ b/components/eam/src/physics/cam/zm_conv_intr.F90
@@ -29,10 +29,8 @@ module zm_conv_intr
    use spmd_utils,       only: masterproc
    use cam_history,  only: outfld, addfld, horiz_only, add_default
    use perf_mod
-   use cam_logfile,  only: iulog
-!++ MCSP 
+   use cam_logfile,  only: iulog 
    use zm_conv,      only: MCSP, MCSP_heat_coeff, MCSP_moisture_coeff, MCSP_uwind_coeff, MCSP_vwind_coeff
-!-- MCSP
 
    implicit none
    private
@@ -238,7 +236,6 @@ subroutine zm_conv_init(pref_edge)
     call addfld ('ZMICVU',     (/ 'lev' /), 'A', 'm/s', 'ZM in-cloud V updrafts')
     call addfld ('ZMICVD',     (/ 'lev' /), 'A', 'm/s', 'ZM in-cloud V downdrafts')
 
-!++ MCSP
     if( MCSP ) then 
     call addfld ('MCSP_DT',(/ 'lev' /), 'A','K/s','T tedency due to MCSP')
     call addfld ('MCSP_freq',horiz_only, 'A','1','frequency of MCSP activated')
@@ -248,7 +245,6 @@ subroutine zm_conv_init(pref_edge)
     call addfld ('ZM_depth',horiz_only,'A','Pa','ZM depth')
     call addfld ('MCSP_shear',horiz_only,'A','m/s','vertical zonal wind shear')
     end if
-!-- MCSP
 
 !Convective microphysics
 
@@ -749,10 +745,8 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    use constituents,  only: pcnst, cnst_get_ind, cnst_is_convtran1
    use physconst,     only: gravit
    use phys_control,  only: cam_physpkg_is
-!++ MCSP
    use time_manager,       only: get_curr_date
    use interpolate_data, only: vertinterp
-!-- MCSP
 
 
    ! Arguments
@@ -872,7 +866,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    integer  :: ii
 
    logical  :: lq(pcnst)
-!++ MCSP
+
    real(r8) :: alpha2, alpha_moisture, alphau, alphav, top, bottom
    real(r8) :: Q_dis(pcols), Qc_adjust, Qq_dis(pcols), Qcq_adjust
    real(r8) :: Qm(pcols,pver), Qmq(pcols,pver), Qmu(pcols,pver), Qmv(pcols,pver)
@@ -890,7 +884,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    logical  :: doslop_moisture
    logical  :: doslop_uwind
    logical  :: doslop_vwind
-!-- MCSP
+
 
    ! Convective microphysics
    real(r8) :: sprd(pcols,pver)
@@ -974,7 +968,6 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
     end if
 
 
-!++ MCSP
    doslop_heat = .false.
    doslop_moisture = .false.
    doslop_uwind = .false.
@@ -1001,7 +994,6 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    if (doslop_heat .or. doslop_moisture .or. doslop_uwind .or. doslop_vwind) then
      doslop = .true.
    endif
-!-- MCSP
 
 
    !----------------------------------------------------------------------
@@ -1021,13 +1013,13 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
 
    lq(:) = .FALSE.
    lq(1) = .TRUE.
-!++ MCSP 
+ 
    if(doslop) then
         call physics_ptend_init(ptend_loc, state%psetcols, 'zm_convr', ls=.true., lu = doslop_uwind, lv = doslop_vwind, lq=lq)! initialize local ptend type
    else
         call physics_ptend_init(ptend_loc, state%psetcols, 'zm_convr', ls=.true., lq=lq)! initialize local ptend type
    end if
-!-- MCSP
+
 !
 ! Associate pointers with physics buffer fields
 !
@@ -1253,7 +1245,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
 ! End the MCSP parameterization here 
 !   
    
-!++ MCSP
+
   MCSP_DT(:ncol,:pver) = MCSP_DT(:ncol,:pver)/cpair
    call outfld('MCSP_DT    ',MCSP_DT           ,pcols   ,lchnk   )
    call outfld('MCSP_freq    ',MCSP_freq           ,pcols   ,lchnk   )
@@ -1261,7 +1253,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    call outfld('MCSP_DV    ',ptend_loc%v*86400._r8           ,pcols   ,lchnk   )
    call outfld('ZM_depth   ',ZM_depth                        ,pcols   ,lchnk   )
    call outfld('MCSP_shear ',MCSP_shear                      ,pcols   ,lchnk   )
-!-- MCSP
+
    end if
 !
 ! Output fractional occurance of ZM convection

--- a/components/eam/src/physics/cam/zm_conv_intr.F90
+++ b/components/eam/src/physics/cam/zm_conv_intr.F90
@@ -23,6 +23,7 @@ module zm_conv_intr
 
    use ndrop_bam,        only: ndrop_bam_init
    use cam_abortutils,   only: endrun
+   use physconst,        only: pi
 
    use spmd_utils,       only: masterproc
 !>songxl---------------
@@ -647,7 +648,6 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
 !++ MCSP
    use time_manager,       only: get_curr_date
    use interpolate_data, only: vertinterp
-   use physconst,     only: pi
 !-- MCSP
 
 

--- a/components/eam/src/physics/cam/zm_microphysics.F90
+++ b/components/eam/src/physics/cam/zm_microphysics.F90
@@ -324,7 +324,7 @@ subroutine zm_mphyi
 
 ! autoconversion size threshold for cloud ice to snow (m)
 
-        Dcs = 150.e-6_r8
+!        Dcs = 150.e-6_r8
 ! immersion freezing parameters, bigg 1953
 
 	bimm = 100._r8
@@ -380,7 +380,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                    accgrm, accglm, accgslm,accgsrm,accgirm,accgrim,accgrsm,accgsln,accgsrn,   &
                    accgirn,accsrim,acciglm,accigrm,accsirm,accigln,accigrn,accsirn,accgln,    &
                    accgrn ,accilm, acciln ,fallrm ,fallsm ,fallgm ,fallrn ,fallsn ,fallgn,    &
-                   fhmrm  ,dsfm, dsfn)
+                   fhmrm  ,dsfm, dsfn, auto_fac, accr_fac, dcs)
    
 
 ! Purpose:
@@ -421,6 +421,9 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
   real(r8) grav                                 ! gravity
   real(r8) cp                                   ! heat capacity of dry air
   real(r8) rd                                   ! gas constant for dry air
+  real(r8) auto_fac                             ! droplet-rain autoconversion enhancement factor  
+  real(r8) accr_fac                             ! droplet-rain accretion enhancement factor
+  real(r8) dcs                                  ! autoconversion size threshold for cloud ice to snow (m)
 
 ! output variables
   real(r8), intent(out) :: qc(pcols,pver)       ! cloud water mixing ratio (kg/kg)
@@ -1487,7 +1490,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                  ! Khrouditnov and Kogan (2000) 
 !                 prc(k) = 1350._r8*qcic(i,k)**2.47_r8*    &
 !                    (ncic(i,k)/1.e6_r8*rho(i,k))**(-1.79_r8)
-                 prc(k) = 213500._r8*qcic(i,k)**3.19_r8*    &
+                 prc(k) = auto_fac*30500._r8*qcic(i,k)**3.19_r8*    &
                     (ncic(i,k)/1.e6_r8*rho(i,k))**(-1.2_r8)
                  nprc1(k) = prc(k)/(qcic(i,k)/ncic(i,k))
                  nprc(k) = prc(k) * (1._r8/droplet_mass_25um)
@@ -1982,7 +1985,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
 
               if (qric(i,k).ge.qsmall .and. qcic(i,k).ge.qsmall) then
 !                 pra(k) = 67._r8*(qcic(i,k)*qric(i,k))**1.15_r8
-                 pra(k) = 1.5_r8*67._r8*(qcic(i,k)*qric(i,k))**1.15_r8
+                 pra(k) = accr_fac*67._r8*(qcic(i,k)*qric(i,k))**1.15_r8
                  npra(k) = pra(k)/(qcic(i,k)/ncic(i,k))
               else
                  pra(k)=0._r8

--- a/components/eam/src/physics/cam/zm_microphysics.F90
+++ b/components/eam/src/physics/cam/zm_microphysics.F90
@@ -1,0 +1,3461 @@
+module  zm_microphysics
+
+!---------------------------------------------------------------------------------
+! Purpose:
+!   CAM Interface for cumulus microphysics
+! 
+! Author: Xialiang Song and Guang Jun Zhang, June 2010  
+!---------------------------------------------------------------------------------
+
+use shr_kind_mod,      only: r8=>shr_kind_r8
+use spmd_utils,        only: masterproc    
+use ppgrid,            only: pcols, pver, pverp
+use physconst,         only: gravit, rair, tmelt, cpair, rh2o, r_universal, mwh2o, rhoh2o
+use physconst,         only: latvap, latice
+use activate_drop_mam, only: actdrop_mam_calc
+use ndrop_bam,         only: ndrop_bam_run
+use nucleate_ice_conv, only: nucleati_conv
+#ifndef HAVE_ERF_INTRINSICS
+use shr_spfn_mod,      only: erf => shr_spfn_erf
+#endif
+use shr_spfn_mod, only: gamma => shr_spfn_gamma
+use wv_saturation,  only: svp_water, svp_ice
+use cam_logfile,       only: iulog
+use cam_abortutils,    only: endrun
+implicit none
+private
+save
+
+public :: &
+   zm_mphyi, &
+   zm_mphy,  &
+   zm_aero_t,  &
+   zm_microp_st
+
+! Private module data
+
+! constants remaped
+real(r8) :: g      ! gravity
+real(r8) :: mw     ! molecular weight of water
+real(r8) :: r      ! Dry air Gas constant
+real(r8) :: rv     ! water vapor gas contstant
+real(r8) :: rr     ! universal gas constant
+real(r8) :: cpp    ! specific heat of dry air
+real(r8) :: rhow   ! density of liquid water
+real(r8) :: xlf    ! latent heat of freezing
+
+!from 'microconstants'
+real(r8) :: rhosn  ! bulk density snow
+real(r8) :: rhoi   ! bulk density ice
+real(r8) :: rhog   ! bulk density graupel
+
+real(r8) :: ac,bc,as,bs,ai,bi,ar,br,ag,bg  !fall speed parameters 
+real(r8) :: ci,di    !ice mass-diameter relation parameters
+real(r8) :: cs,ds    !snow mass-diameter relation parameters
+real(r8) :: cr,dr    !drop mass-diameter relation parameters
+real(r8) :: cg,dg    !graupel mass-diameter relation parameters
+real(r8) :: Eii      !collection efficiency aggregation of ice
+real(r8) :: Ecc      !collection efficiency
+real(r8) :: Ecr      !collection efficiency cloud droplets/rain
+real(r8) :: ecg      ! collection efficiency, ice-droplet collisions
+real(r8) :: DCS      !autoconversion size threshold
+real(r8) :: bimm,aimm !immersion freezing
+real(r8) :: rhosu     !typical 850mn air density
+real(r8) :: mi0       ! new crystal mass
+real(r8) :: mg0       ! mass of embryo graupel
+real(r8) :: rin       ! radius of contact nuclei
+real(r8) :: pi       ! pi
+real(r8) :: mmult
+
+! for Bergeron process (Rotstayn et al.2000)
+real(r8) :: Ka_b       ! thermal conductivity of air(J/m/s/K)
+real(r8) :: Ls_b       ! latent heat of sublimation of water(J/kg)
+real(r8) :: Rv_b       ! specigic gas constant for water vapour(J/kg/K)
+real(r8) :: alfa_b     ! parameter for ice crystal habit
+real(r8) :: rhoi13     ! rhoi**(1/3)
+real(r8) :: c23        ! 2/3  
+
+real(r8) ::  cons14,cons16,cons17,cons18,cons19,cons24,cons25, cons31, cons32, cons41
+
+real(r8) :: droplet_mass_25um
+
+! contact freezing due to dust
+! dust number mean radius (m), Zender et al JGR 2003 assuming number mode radius of 0.6 micron, sigma=2
+real(r8), parameter :: rn_dst1 = 0.258e-6_r8
+real(r8), parameter :: rn_dst2 = 0.717e-6_r8
+real(r8), parameter :: rn_dst3 = 1.576e-6_r8
+real(r8), parameter :: rn_dst4 = 3.026e-6_r8
+
+! smallest mixing ratio considered in microphysics
+real(r8), parameter :: qsmall = 1.e-18_r8
+
+
+type, public :: ptr2d
+   real(r8), pointer :: val(:,:)
+end type ptr2d
+
+! Aerosols
+type :: zm_aero_t
+
+   ! Aerosol treatment
+   character(len=5) :: scheme  ! either 'bulk' or 'modal'
+
+   ! Bulk aerosols
+   integer :: nbulk    =  0 ! number of bulk aerosols affecting climate
+   integer :: idxsul   = -1 ! index in aerosol list for sulfate
+   integer :: idxdst1  = -1 ! index in aerosol list for dust1
+   integer :: idxdst2  = -1 ! index in aerosol list for dust2
+   integer :: idxdst3  = -1 ! index in aerosol list for dust3
+   integer :: idxdst4  = -1 ! index in aerosol list for dust4
+   integer :: idxbcphi = -1 ! index in aerosol list for Soot (BCPHI)
+
+   real(r8),    allocatable :: num_to_mass_aer(:)  ! conversion of mmr to number conc for bulk aerosols
+   type(ptr2d), allocatable :: mmr_bulk(:)         ! array of pointers to bulk aerosol mmr
+   real(r8),    allocatable :: mmrg_bulk(:,:,:)    ! gathered bulk aerosol mmr
+
+   ! Modal aerosols
+   integer                  :: nmodes = 0      ! number of modes
+   integer,     allocatable :: nspec(:)        ! number of species in each mode
+   type(ptr2d), allocatable :: num_a(:)        ! number mixing ratio of modes (interstitial phase)
+   type(ptr2d), allocatable :: mmr_a(:,:)      ! species mmr in each mode (interstitial phase)
+   real(r8),    allocatable :: numg_a(:,:,:)   ! gathered number mixing ratio of modes (interstitial phase)
+   real(r8),    allocatable :: mmrg_a(:,:,:,:) ! gathered species mmr in each mode (interstitial phase)
+   real(r8),    allocatable :: voltonumblo(:)  ! volume to number conversion (lower bound) for each mode
+   real(r8),    allocatable :: voltonumbhi(:)  ! volume to number conversion (upper bound) for each mode
+   real(r8),    allocatable :: specdens(:,:)   ! density of modal species
+   real(r8),    allocatable :: spechygro(:,:)  ! hygroscopicity of modal species
+
+   integer :: mode_accum_idx  = -1  ! index of accumulation mode
+   integer :: mode_aitken_idx = -1  ! index of aitken mode
+   integer :: mode_coarse_idx = -1  ! index of coarse mode
+   integer :: coarse_dust_idx = -1  ! index of dust in coarse mode
+   integer :: coarse_nacl_idx = -1  ! index of nacl in coarse mode
+
+   type(ptr2d), allocatable :: dgnum(:)        ! mode dry radius
+   real(r8),    allocatable :: dgnumg(:,:,:)   ! gathered mode dry radius
+
+   real(r8) :: sigmag_aitken
+
+end type zm_aero_t
+
+type :: zm_microp_st
+
+   real(r8),    allocatable :: wu(:,:)             ! vertical velocity
+
+   real(r8),    allocatable :: qliq(:,:)           ! convective cloud liquid water.
+   real(r8),    allocatable :: qice(:,:)           ! convective cloud ice.
+   real(r8),    allocatable :: qrain(:,:)          ! convective rain water.
+   real(r8),    allocatable :: qsnow(:,:)          ! convective snow.
+   real(r8),    allocatable :: qgraupel(:,:)       ! convective graupel.
+   real(r8),    allocatable :: qnl(:,:)            ! convective cloud liquid water num concen.
+   real(r8),    allocatable :: qni(:,:)            ! convective cloud ice num concen.
+   real(r8),    allocatable :: qnr(:,:)            ! convective rain water num concen.
+   real(r8),    allocatable :: qns(:,:)            ! convective snow num concen.
+   real(r8),    allocatable :: qng(:,:)            ! convective graupel num concen.
+
+   real(r8),    allocatable :: autolm(:,:)    !mass tendency due to autoconversion of droplets to rain
+   real(r8),    allocatable :: accrlm(:,:)    !mass tendency due to accretion of droplets by rain
+   real(r8),    allocatable :: bergnm(:,:)    !mass tendency due to Bergeron process
+   real(r8),    allocatable :: fhtimm(:,:)    !mass tendency due to immersion freezing
+   real(r8),    allocatable :: fhtctm(:,:)    !mass tendency due to contact freezing
+   real(r8),    allocatable :: fhmlm (:,:)    !mass tendency due to homogeneous freezing
+   real(r8),    allocatable :: hmpim (:,:)    !mass tendency due to HM process
+   real(r8),    allocatable :: accslm(:,:)    !mass tendency due to accretion of droplets by snow
+   real(r8),    allocatable :: dlfm  (:,:)    !mass tendency due to detrainment of droplet
+   real(r8),    allocatable :: autoln(:,:)    !num tendency due to autoconversion of droplets to rain
+   real(r8),    allocatable :: accrln(:,:)    !num tendency due to accretion of droplets by rain
+   real(r8),    allocatable :: bergnn(:,:)    !num tendency due to Bergeron process
+   real(r8),    allocatable :: fhtimn(:,:)    !num tendency due to immersion freezing
+   real(r8),    allocatable :: fhtctn(:,:)    !num tendency due to contact freezing
+   real(r8),    allocatable :: fhmln (:,:)    !num tendency due to homogeneous freezing
+   real(r8),    allocatable :: accsln(:,:)    !num tendency due to accretion of droplets by snow
+   real(r8),    allocatable :: activn(:,:)    !num tendency due to droplets activation
+   real(r8),    allocatable :: dlfn  (:,:)    !num tendency due to detrainment of droplet
+   real(r8),    allocatable :: autoim(:,:)    !mass tendency due to autoconversion of cloud ice to snow
+   real(r8),    allocatable :: accsim(:,:)    !mass tendency due to accretion of cloud ice by snow
+   real(r8),    allocatable :: difm  (:,:)    !mass tendency due to detrainment of cloud ice
+   real(r8),    allocatable :: nuclin(:,:)    !num tendency due to ice nucleation
+   real(r8),    allocatable :: autoin(:,:)    !num tendency due to autoconversion of cloud ice to snow
+   real(r8),    allocatable :: accsin(:,:)    !num tendency due to accretion of cloud ice by snow
+   real(r8),    allocatable :: hmpin (:,:)    !num tendency due to HM process
+   real(r8),    allocatable :: difn  (:,:)    !num tendency due to detrainment of cloud ice
+   real(r8),    allocatable :: cmel  (:,:)    !mass tendency due to condensation
+   real(r8),    allocatable :: cmei  (:,:)    !mass tendency due to deposition
+   real(r8),    allocatable :: trspcm(:,:)    !LWC tendency due to convective transport
+   real(r8),    allocatable :: trspcn(:,:)    !droplet num tendency due to convective transport
+   real(r8),    allocatable :: trspim(:,:)    !IWC tendency due to convective transport
+   real(r8),    allocatable :: trspin(:,:)    !ice crystal num tendency due to convective transport
+   real(r8),    allocatable :: accgrm(:,:)    ! mass tendency due to collection of rain by graupel
+   real(r8),    allocatable :: accglm(:,:)    ! mass tendency due to collection of droplets by graupel
+   real(r8),    allocatable :: accgslm(:,:)   ! mass tendency of graupel due to collection of droplets by snow
+   real(r8),    allocatable :: accgsrm(:,:)   ! mass tendency of graupel due to collection of rain by snow
+   real(r8),    allocatable :: accgirm(:,:)   ! mass tendency of graupel due to collection of rain by ice
+   real(r8),    allocatable :: accgrim(:,:)   ! mass tendency of graupel due to collection of ice by rain
+   real(r8),    allocatable :: accgrsm(:,:)   ! mass tendency due to collection of snow by rain
+   real(r8),    allocatable :: accgsln(:,:)   ! num tendency of graupel due to collection of droplets by snow
+   real(r8),    allocatable :: accgsrn(:,:)   ! num tendency of graupel due to collection of rain by snow
+   real(r8),    allocatable :: accgirn(:,:)   ! num tendency of graupel due to collection of rain by ice
+   real(r8),    allocatable :: accsrim(:,:)   ! mass tendency of snow due to collection of ice by rain
+   real(r8),    allocatable :: acciglm(:,:)   ! mass tendency of ice mult(splintering) due to acc droplets by graupel
+   real(r8),    allocatable :: accigrm(:,:)   ! mass tendency of ice mult(splintering) due to acc rain by graupel
+   real(r8),    allocatable :: accsirm(:,:)   ! mass tendency of snow due to collection of rain by ice
+   real(r8),    allocatable :: accigln(:,:)   ! num tendency of ice mult(splintering) due to acc droplets by graupel
+   real(r8),    allocatable :: accigrn(:,:)   ! num tendency of ice mult(splintering) due to acc rain by graupel
+   real(r8),    allocatable :: accsirn(:,:)   ! num tendency of snow due to collection of rain by ice
+   real(r8),    allocatable :: accgln(:,:)    ! num tendency due to collection of droplets by graupel
+   real(r8),    allocatable :: accgrn(:,:)    ! num tendency due to collection of rain by graupel
+   real(r8),    allocatable :: accilm(:,:)    ! mass tendency of cloud ice due to collection of droplet by cloud ice
+   real(r8),    allocatable :: acciln(:,:)    ! number conc tendency of cloud ice due to collection of droplet by cloud ice
+   real(r8),    allocatable :: fallrm(:,:)    ! mass tendency of rain fallout
+   real(r8),    allocatable :: fallsm(:,:)    ! mass tendency of snow fallout
+   real(r8),    allocatable :: fallgm(:,:)    ! mass tendency of graupel fallout
+   real(r8),    allocatable :: fallrn(:,:)    ! num tendency of rain fallout
+   real(r8),    allocatable :: fallsn(:,:)    ! num tendency of snow fallout
+   real(r8),    allocatable :: fallgn(:,:)    ! num tendency of graupel fallout
+   real(r8),    allocatable :: fhmrm (:,:)    ! mass tendency due to homogeneous freezing of rain
+
+end type zm_microp_st
+
+
+real(r8), parameter :: dcon  = 25.e-6_r8
+real(r8), parameter :: mucon = 5.3_r8
+real(r8), parameter :: lambdadpcu = (mucon + 1._r8)/dcon
+
+!===============================================================================
+contains
+!===============================================================================
+
+subroutine zm_mphyi
+
+!----------------------------------------------------------------------- 
+! 
+! Purpose:
+! initialize constants for the cumulus microphysics
+! called from zm_conv_init() in zm_conv_intr.F90
+!
+! Author: Xialiang Song, June 2010
+! 
+!-----------------------------------------------------------------------
+
+!NOTE:
+! latent heats should probably be fixed with temperature 
+! for energy conservation with the rest of the model
+! (this looks like a +/- 3 or 4% effect, but will mess up energy balance)
+
+   xlf = latice          ! latent heat freezing
+
+! from microconstants
+
+! parameters below from Reisner et al. (1998)
+! density parameters (kg/m3)
+
+      rhosn = 100._r8    ! bulk density snow
+!      rhosn = 250._r8  ! bulk density snow
+      rhoi = 500._r8     ! bulk density ice
+      rhow = 1000._r8    ! bulk density liquid
+
+      rhog = 400._r8     ! bulk density graupel(if dense precipitating ice is graupel)
+!      rhog = 900._r8     ! bulk density graupel(if dense precipitating ice is hail)
+
+! fall speed parameters, V = aD^b
+! V is in m/s
+
+! droplets
+	ac = 3.e7_r8
+	bc = 2._r8
+
+! snow
+	as = 11.72_r8
+	bs = 0.41_r8
+
+! cloud ice
+	ai = 700._r8
+	bi = 1._r8
+
+! rain
+	ar = 841.99667_r8
+	br = 0.8_r8
+
+!graupel(if dense precipitating ice is graupel)
+
+        ag = 19.3
+        bg = 0.37
+
+!if dense precipitating ice is hail (matsun and huggins 1980)
+!        ag = 114.5
+!        bg = 0.5
+
+  
+! particle mass-diameter relationship
+! currently we assume spherical particles for cloud ice/snow
+! m = cD^d
+
+        pi = 3.14159265358979323846_r8
+
+! cloud ice mass-diameter relationship
+
+	ci = rhoi*pi/6._r8
+	di = 3._r8
+
+! snow mass-diameter relationship
+
+	cs = rhosn*pi/6._r8
+	ds = 3._r8
+
+! drop mass-diameter relationship
+
+	cr = rhow*pi/6._r8
+	dr = 3._r8
+
+! graupel mass-diameter relationship
+
+        cg = rhog*pi/6._r8
+        dg = 3._r8
+
+! collection efficiency, aggregation of cloud ice and snow
+
+	Eii = 0.1_r8
+
+! collection efficiency, accretion of cloud water by rain
+
+	Ecr = 1.0_r8
+
+        ecg = 0.7_r8
+
+! autoconversion size threshold for cloud ice to snow (m)
+
+        Dcs = 150.e-6_r8
+! immersion freezing parameters, bigg 1953
+
+	bimm = 100._r8
+	aimm = 0.66_r8
+
+! typical air density at 850 mb
+
+	rhosu = 85000._r8/(rair * tmelt)
+
+! for Bergeron process (Rotstayn et al.2000)
+        Ka_b = 2.4e-2_r8     ! thermal conductivity of air(J/m/s/K)
+        Ls_b = 2.834e6_r8    ! latent heat of sublimation of water(J/kg)
+        Rv_b = 461._r8     ! specigic gas constant for water vapour(J/kg/K)
+        alfa_b = 1._r8/3._r8 
+        rhoi13 = rhoi**alfa_b
+        c23 = 2._r8/3._r8
+
+! mass of new crystal due to aerosol freezing and growth (kg)
+
+	mi0 = 4._r8/3._r8*pi*rhoi*(10.e-6_r8)*(10.e-6_r8)*(10.e-6_r8)
+
+        mg0 = 1.6E-10
+! radius of contact nuclei aerosol (m)
+
+        rin = 0.1e-6_r8
+        mmult = 4._r8/3._r8*pi*rhoi*(5.e-6_r8)**3
+
+        cons14=gamma(bg+3._r8)*pi/4._r8*ecg
+        cons16=gamma(bi+3._r8)*pi/4._r8*ecg
+        cons17=4._r8*2._r8*3._r8*rhosu*pi*ecg*ecg*gamma(2._r8*bs+2._r8)/(8._r8*(rhog-rhosn))
+        cons18=rhosn*rhosn
+        cons19=rhow*rhow
+        cons24=pi/4._r8*ecr*gamma(br+3._r8)
+        cons25=pi*pi/24._r8*rhow*ecr*gamma(br+6._r8)
+         
+        cons31=pi*pi*ecr*rhosn
+        cons32=pi/2.*ecr
+        cons41=pi*pi*ecr*rhow  
+
+        droplet_mass_25um = 4._r8/3._r8*pi*rhow*(25.e-6_r8)**3
+end subroutine zm_mphyi
+
+!===============================================================================
+
+subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,   qe,        &
+                   eps0,  jb,   jt,   jlcl, msg,   il2g,  grav,  cp,   rd,   aero, gamhat,    &
+                   qc,    qi,   nc,   ni,   qcde,  qide,  ncde,  nide, rprd, sprd, frz,       &
+                   wu,    qr,   qni,  nr,   ns,    qg,    ng,    qnide,nsde,                  &
+                   autolm, accrlm, bergnm, fhtimm, fhtctm,    &
+                   fhmlm,  hmpim,  accslm, dlfm,   autoln, accrln, bergnn, fhtimn, fhtctn,    &
+                   fhmln,  accsln, activn, dlfn,   autoim, accsim, difm,   nuclin, autoin,    &
+                   accsin, hmpin,  difn,   trspcm, trspcn, trspim, trspin, lamc,   pgam  ,    &
+                   accgrm, accglm, accgslm,accgsrm,accgirm,accgrim,accgrsm,accgsln,accgsrn,   &
+                   accgirn,accsrim,acciglm,accigrm,accsirm,accigln,accigrn,accsirn,accgln,    &
+                   accgrn ,accilm, acciln ,fallrm ,fallsm ,fallgm ,fallrn ,fallsn ,fallgn,    &
+                   fhmrm  ,dsfm, dsfn)
+   
+
+! Purpose:
+! microphysic parameterization for Zhang-McFarlane convection scheme
+! called from cldprp() in zm_conv.F90
+!
+! Author: Xialiang Song, June 2010
+
+  use time_manager,    only: get_step_size
+
+! variable declarations
+
+  implicit none
+
+! input variables
+  real(r8), intent(in) :: su(pcols,pver)        ! normalized dry stat energy of updraft
+  real(r8), intent(in) :: qu(pcols,pver)        ! spec hum of updraft
+  real(r8), intent(in) :: mu(pcols,pver)        ! updraft mass flux
+  real(r8), intent(in) :: du(pcols,pver)        ! detrainement rate of updraft
+  real(r8), intent(in) :: eu(pcols,pver)        ! entrainment rate of updraft
+  real(r8), intent(in) :: cmel(pcols,pver)      ! condensation rate of updraft
+  real(r8), intent(in) :: cmei(pcols,pver)      ! condensation rate of updraft
+  real(r8), intent(in) :: zf(pcols,pverp)       ! height of interfaces
+  real(r8), intent(in) :: pm(pcols,pver)        ! pressure of env
+  real(r8), intent(in) :: te(pcols,pver)        ! temp of env
+  real(r8), intent(in) :: qe(pcols,pver)        ! spec. humidity of env
+  real(r8), intent(in) :: eps0(pcols)
+  real(r8), intent(in) :: gamhat(pcols,pver)    ! gamma=L/cp(dq*/dT) at interface
+
+  integer, intent(in) :: jb(pcols)              ! updraft base level
+  integer, intent(in) :: jt(pcols)              ! updraft plume top
+  integer, intent(in) :: jlcl(pcols)            ! updraft lifting cond level
+  integer, intent(in) :: msg                    ! missing moisture vals
+  integer, intent(in) :: il2g                   ! number of columns in gathered arrays
+
+  type(zm_aero_t), intent(in) :: aero           ! aerosol object
+
+  real(r8) grav                                 ! gravity
+  real(r8) cp                                   ! heat capacity of dry air
+  real(r8) rd                                   ! gas constant for dry air
+
+! output variables
+  real(r8), intent(out) :: qc(pcols,pver)       ! cloud water mixing ratio (kg/kg)
+  real(r8), intent(out) :: qi(pcols,pver)       ! cloud ice mixing ratio (kg/kg)
+  real(r8), intent(out) :: nc(pcols,pver)       ! cloud water number conc (1/kg)
+  real(r8), intent(out) :: ni(pcols,pver)       ! cloud ice number conc (1/kg)
+  real(r8), intent(out) :: qcde(pcols,pver)     ! cloud water mixing ratio for detrainment(kg/kg)
+  real(r8), intent(out) :: qide(pcols,pver)     ! cloud ice mixing ratio for detrainment (kg/kg)
+  real(r8), intent(out) :: qnide(pcols,pver)    ! cloud snow mixing ratio for detrainment (kg/kg) 
+  real(r8), intent(out) :: ncde(pcols,pver)     ! cloud water number conc for detrainment (1/kg)
+  real(r8), intent(out) :: nide(pcols,pver)     ! cloud ice number conc for detrainment (1/kg)
+  real(r8), intent(out) :: nsde(pcols,pver)     ! cloud snow number conc for detrainment (1/kg)
+  real(r8), intent(out) :: qni(pcols,pver)      ! snow mixing ratio
+  real(r8), intent(out) :: qr(pcols,pver)       ! rain mixing ratio
+  real(r8), intent(out) :: ns(pcols,pver)       ! snow number conc
+  real(r8), intent(out) :: nr(pcols,pver)       ! rain number conc
+  real(r8), intent(out) :: qg(pcols,pver)       ! graupel mixing ratio
+  real(r8), intent(out) :: ng(pcols,pver)       ! graupel number conc
+  real(r8), intent(out) :: rprd(pcols,pver)     ! rate of production of precip at that layer
+  real(r8), intent(out) :: sprd(pcols,pver)     ! rate of production of snow/graupel at that layer
+  real(r8), intent(out) :: frz(pcols,pver)      ! rate of freezing 
+
+
+  real(r8), intent(inout) :: lamc(pcols,pver)     ! slope of cloud liquid size distr
+  real(r8), intent(inout) :: pgam(pcols,pver)     ! spectral width parameter of droplet size distr
+
+! tendency for output
+  real(r8) :: autolm(pcols,pver)    !mass tendency due to autoconversion of droplets to rain
+  real(r8) :: accrlm(pcols,pver)    !mass tendency due to accretion of droplets by rain
+  real(r8) :: bergnm(pcols,pver)    !mass tendency due to Bergeron process
+  real(r8) :: fhtimm(pcols,pver)    !mass tendency due to immersion freezing
+  real(r8) :: fhtctm(pcols,pver)    !mass tendency due to contact freezing
+  real(r8) :: fhmlm (pcols,pver)    !mass tendency due to homogeneous freezing
+  real(r8) :: hmpim (pcols,pver)    !mass tendency due to HM process
+  real(r8) :: accslm(pcols,pver)    !mass tendency due to accretion of droplets by snow
+  real(r8) :: dlfm  (pcols,pver)    !mass tendency due to detrainment of droplet
+  real(r8) :: trspcm(pcols,pver)    !mass tendency of droplets due to convective transport
+
+  real(r8) :: autoln(pcols,pver)    !num tendency due to autoconversion of droplets to rain
+  real(r8) :: accrln(pcols,pver)    !num tendency due to accretion of droplets by rain
+  real(r8) :: bergnn(pcols,pver)    !num tendency due to Bergeron process
+  real(r8) :: fhtimn(pcols,pver)    !num tendency due to immersion freezing
+  real(r8) :: fhtctn(pcols,pver)    !num tendency due to contact freezing
+  real(r8) :: fhmln (pcols,pver)    !num tendency due to homogeneous freezing
+  real(r8) :: accsln(pcols,pver)    !num tendency due to accretion of droplets by snow
+  real(r8) :: activn(pcols,pver)    !num tendency due to droplets activation
+  real(r8) :: dlfn  (pcols,pver)    !num tendency due to detrainment of droplet
+  real(r8) :: trspcn(pcols,pver)    !num tendency of droplets due to convective transport
+
+  real(r8) :: autoim(pcols,pver)    !mass tendency due to autoconversion of cloud ice to snow
+  real(r8) :: accsim(pcols,pver)    !mass tendency due to accretion of cloud ice by snow
+  real(r8) :: difm  (pcols,pver)    !mass tendency due to detrainment of cloud ice
+  real(r8) :: trspim(pcols,pver)    !mass tendency of ice crystal due to convective transport
+
+  real(r8) :: nuclin(pcols,pver)    !num tendency due to ice nucleation
+  real(r8) :: autoin(pcols,pver)    !num tendency due to autoconversion of cloud ice to snow
+  real(r8) :: accsin(pcols,pver)    !num tendency due to accretion of cloud ice by snow
+  real(r8) :: hmpin (pcols,pver)    !num tendency due to HM process
+  real(r8) :: difn  (pcols,pver)    !num tendency due to detrainment of cloud ice
+  real(r8) :: trspin(pcols,pver)    !num tendency of ice crystal due to convective transport
+
+  real(r8) :: dsfm  (pcols,pver)    !mass tendency due to detrainment of snow
+  real(r8) :: trspsm(pcols,pver)    !mass tendency of snow due to convective transport
+  real(r8) :: dsfn  (pcols,pver)    !num tendency due to detrainment of snow
+  real(r8) :: trspsn(pcols,pver)    !num tendency of snow due to convective transport
+!graupel
+  real(r8) :: accgrm(pcols,pver)          ! mass tendency due to collection of rain by graupel
+  real(r8) :: accglm(pcols,pver)          ! mass tendency due to collection of droplets by graupel
+  real(r8) :: accgslm(pcols,pver)         ! mass tendency of graupel due to collection of droplets by snow
+  real(r8) :: accgsrm(pcols,pver)         ! mass tendency of graupel due to collection of rain by snow
+  real(r8) :: accgirm(pcols,pver)         ! mass tendency of graupel due to collection of rain by ice
+  real(r8) :: accgrim(pcols,pver)         ! mass tendency of graupel due to collection of ice by rain
+  real(r8) :: accgrsm(pcols,pver)         ! mass tendency due to collection of snow by rain
+
+  real(r8) :: accgsln(pcols,pver)         ! num tendency of graupel due to collection of droplets by snow
+  real(r8) :: accgsrn(pcols,pver)         ! num tendency of graupel due to collection of rain by snow
+  real(r8) :: accgirn(pcols,pver)         ! num tendency of graupel due to collection of rain by ice
+
+  real(r8) :: accsrim(pcols,pver)         ! mass tendency of snow due to collection of ice by rain
+  real(r8) :: acciglm(pcols,pver)         ! mass tendency of ice mult(splintering) due to acc droplets by graupel
+  real(r8) :: accigrm(pcols,pver)         ! mass tendency of ice mult(splintering) due to acc rain by graupel
+  real(r8) :: accsirm(pcols,pver)         ! mass tendency of snow due to collection of rain by ice
+
+  real(r8) :: accigln(pcols,pver)         ! num tendency of ice mult(splintering) due to acc droplets by graupel
+  real(r8) :: accigrn(pcols,pver)         ! num tendency of ice mult(splintering) due to acc rain by graupel
+  real(r8) :: accsirn(pcols,pver)         ! num tendency of snow due to collection of rain by ice
+  real(r8) :: accgln(pcols,pver)          ! num tendency due to collection of droplets by graupel
+  real(r8) :: accgrn(pcols,pver)          ! num tendency due to collection of rain by graupel
+  real(r8) :: accilm(pcols,pver)          ! mass tendency of cloud ice due to collection of droplet by cloud ice
+  real(r8) :: acciln(pcols,pver)          ! number conc tendency of cloud ice due to collection of droplet by cloud ice
+
+  real(r8) :: fallrm(pcols, pver)         ! mass tendency of rain fallout 
+  real(r8) :: fallsm(pcols, pver)         ! mass tendency of snow fallout
+  real(r8) :: fallgm(pcols, pver)         ! mass tendency of graupel fallout
+  real(r8) :: fallrn(pcols, pver)         ! num tendency of rain fallout
+  real(r8) :: fallsn(pcols, pver)         ! num tendency of snow fallout
+  real(r8) :: fallgn(pcols, pver)         ! num tendency of graupel fallout
+
+! output for ice nucleation
+  real(r8) :: nimey(pcols,pver)     !number conc of ice nuclei due to meyers deposition (1/m3)
+  real(r8) :: nihf(pcols,pver)      !number conc of ice nuclei due to heterogenous freezing (1/m3)
+  real(r8) :: nidep(pcols,pver)     !number conc of ice nuclei due to deoposion nucleation (hetero nuc) (1/m3)
+  real(r8) :: niimm(pcols,pver)     !number conc of ice nuclei due to immersion freezing (hetero nuc) (1/m3)
+
+!................................................................................
+! local workspace
+! all units mks unless otherwise stated
+  real(r8) :: deltat                ! time step (s)
+  real(r8) :: omsm                  ! number near unity for round-off issues
+  real(r8) :: dum                   ! temporary dummy variable
+  real(r8) :: dum1                  ! temporary dummy variable 
+  real(r8) :: dum2                  ! temporary dummy variable
+
+  real(r8) :: q(pcols,pver)         ! water vapor mixing ratio (kg/kg)
+  real(r8) :: t(pcols,pver)         ! temperature (K)
+  real(r8) :: rho(pcols,pver)       ! air density (kg m-3)
+  real(r8) :: dz(pcols,pver)        ! height difference across model vertical level
+
+  real(r8) :: qcic(pcols,pver)      ! in-cloud cloud liquid mixing ratio
+  real(r8) :: qiic(pcols,pver)      ! in-cloud cloud ice mixing ratio
+  real(r8) :: qniic(pcols,pver)     ! in-cloud snow mixing ratio
+  real(r8) :: qric(pcols,pver)      ! in-cloud rain mixing ratio
+  real(r8) :: qgic(pcols,pver)      ! in-cloud graupel mixing ratio  
+  real(r8) :: ncic(pcols,pver)      ! in-cloud droplet number conc
+  real(r8) :: niic(pcols,pver)      ! in-cloud cloud ice number conc
+  real(r8) :: nsic(pcols,pver)      ! in-cloud snow number conc
+  real(r8) :: nric(pcols,pver)      ! in-cloud rain number conc
+  real(r8) :: ngic(pcols,pver)      ! in-cloud graupel number conc
+
+  real(r8) :: lami(pver)            ! slope of cloud ice size distr
+  real(r8) :: n0i(pver)             ! intercept of cloud ice size distr
+  real(r8) :: n0c(pver)             ! intercept of cloud liquid size distr
+  real(r8) :: lams(pver)            ! slope of snow size distr
+  real(r8) :: n0s(pver)             ! intercept of snow size distr
+  real(r8) :: lamg(pver)            ! slope of graupel size distr
+  real(r8) :: n0g(pver)             ! intercept of graupel size distr
+  real(r8) :: lamr(pver)            ! slope of rain size distr
+  real(r8) :: n0r(pver)             ! intercept of rain size distr
+  real(r8) :: cdist1(pver)          ! size distr parameter to calculate droplet freezing
+  real(r8) :: lammax                ! maximum allowed slope of size distr
+  real(r8) :: lammin                ! minimum allowed slope of size distr
+
+  real(r8) :: mnuccc(pver)          ! mixing ratio tendency due to freezing of cloud water
+  real(r8) :: nnuccc(pver)          ! number conc tendency due to freezing of cloud water
+  real(r8) :: mnucct(pver)          ! mixing ratio tendency due to contact freezing of cloud water
+  real(r8) :: nnucct(pver)          ! number conc tendency due to contact freezing of cloud water
+  real(r8) :: msacwi(pver)          ! mixing ratio tendency due to HM ice multiplication
+  real(r8) :: nsacwi(pver)          ! number conc tendency due to HM ice multiplication
+  real(r8) :: prf(pver)             ! mixing ratio tendency due to fallout of rain
+  real(r8) :: psf(pver)             ! mixing ratio tendency due to fallout of snow
+  real(r8) :: pnrf(pver)            ! number conc tendency due to fallout of rain
+  real(r8) :: pnsf(pver)            ! number conc tendency due to fallout of snow
+  real(r8) :: pgf(pver)             ! mixing ratio tendency due to fallout of graupel
+  real(r8) :: pngf(pver)            ! number conc tendency due to fallout of graupel
+  real(r8) :: prc(pver)             ! mixing ratio tendency due to autoconversion of cloud droplets
+  real(r8) :: nprc(pver)            ! number conc tendency due to autoconversion of cloud droplets
+  real(r8) :: nprc1(pver)           ! qr tendency due to autoconversion of cloud droplets
+  real(r8) :: nsagg(pver)           ! ns tendency due to self-aggregation of snow
+  real(r8) :: dc0                   ! mean size droplet size distr
+  real(r8) :: ds0                   ! mean size snow size distr (area weighted)
+  real(r8) :: eci                   ! collection efficiency for riming of snow by droplets
+  real(r8) :: dv(pcols,pver)        ! diffusivity of water vapor in air
+  real(r8) :: mua(pcols,pver)       ! viscocity of air
+  real(r8) :: psacws(pver)          ! mixing rat tendency due to collection of droplets by snow
+  real(r8) :: npsacws(pver)         ! number conc tendency due to collection of droplets by snow
+  real(r8) :: pracs(pver)           ! mixing rat tendency due to collection of rain	by snow
+  real(r8) :: npracs(pver)          ! number conc tendency due to collection of rain by snow
+  real(r8) :: mnuccr(pver)          ! mixing rat tendency due to freezing of rain
+  real(r8) :: nnuccr(pver)          ! number conc tendency due to freezing of rain
+  real(r8) :: pra(pver)             ! mixing rat tendnency due to accretion of droplets by rain
+  real(r8) :: npra(pver)            ! nc tendnency due to accretion of droplets by rain
+  real(r8) :: nragg(pver)           ! nr tendency due to self-collection of rain
+  real(r8) :: prci(pver)            ! mixing rat tendency due to autoconversion of cloud ice to snow
+  real(r8) :: nprci(pver)           ! number conc tendency due to autoconversion of cloud ice to snow
+  real(r8) :: prai(pver)            ! mixing rat tendency due to accretion of cloud ice by snow
+  real(r8) :: nprai(pver)           ! number conc tendency due to accretion of cloud ice by snow
+  real(r8) :: prb(pver)             ! rain mixing rat tendency due to Bergeron process
+  real(r8) :: nprb(pver)            ! number conc tendency due to Bergeron process
+  real(r8) :: fhmrm (pcols,pver)    ! mass tendency due to homogeneous freezing of rain
+!graupel
+  real(r8) :: psacwi(pver)          ! mass tendency of cloud ice due to collection of droplet by cloud ice
+  real(r8) :: npsacwi(pver)         ! number conc tendency of cloud ice due to collection of droplet by cloud ice
+  real(r8) :: pracg(pver)           ! mixing rat tendency due to collection of rain by graupel
+  real(r8) :: psacwg(pver)          ! mixing rat tendency due to collection of droplets by graupel
+  real(r8) :: pgsacw(pver)          ! mixing rat tendency of graupel due to collection of droplets by snow
+  real(r8) :: pgracs(pver)          ! mixing rat tendency of graupel due to collection of rain by snow
+  real(r8) :: piacr(pver)           ! mixing rat tendency of graupel due to collection of rain by ice
+  real(r8) :: praci(pver)           ! mixing rat tendency of graupel due to collection of ice by rain
+  real(r8) :: psacr(pver)           ! mixing rat tendency due to collection of snow by rain
+ 
+  real(r8) :: nscng(pver)           ! number conc tendency of graupel due to collection of droplets by snow
+  real(r8) :: ngracs(pver)          ! number conc tendency of graupel due to collection of rain by snow
+  real(r8) :: niacr(pver)           ! number conc tendency of graupel due to collection of rain by ice
+
+  real(r8) :: pracis(pver)          ! mixing rat tendency of snow due to collection of ice by rain
+  real(r8) :: qmultg(pver)          ! mixing rat tendency of ice mult(splintering) due to acc droplets by graupel
+  real(r8) :: qmultrg(pver)         ! mixing rat tendency of ice mult(splintering) due to acc rain by graupel
+  real(r8) :: piacrs(pver)          ! mixing rat tendency of snow due to collection of rain by ice 
+
+  real(r8) :: nmultg(pver)          ! number conc tendency of ice mult(splintering) due to acc droplets by graupel
+  real(r8) :: nmultrg(pver)         ! number conc tendency of ice mult(splintering) due to acc rain by graupel
+  real(r8) :: niacrs(pver)          ! number conc tendency of snow due to collection of rain by ice
+  real(r8) :: npsacwg(pver)         ! number conc tendency due to collection of droplets by graupel
+  real(r8) :: npracg(pver)          ! number conc tendency due to collection of rain by graupel
+
+! fall speed
+  real(r8) :: arn(pcols,pver)       ! air density corrected rain fallspeed parameter
+  real(r8) :: asn(pcols,pver)       ! air density corrected snow fallspeed parameter
+  real(r8) :: agn(pcols,pver)       ! air density corrected graupel fallspeed parameter
+  real(r8) :: acn(pcols,pver)       ! air density corrected cloud droplet fallspeed parameter
+  real(r8) :: ain(pcols,pver)       ! air density corrected cloud ice fallspeed parameter
+  real(r8) :: uns(pver)             ! number-weighted snow fallspeed
+  real(r8) :: ums(pver)             ! mass-weighted snow fallspeed
+  real(r8) :: ung(pver)             ! number-weighted graupel fallspeed
+  real(r8) :: umg(pver)             ! mass-weighted graupel fallspeed
+  real(r8) :: unr(pver)             ! number-weighted rain fallspeed
+  real(r8) :: umr(pver)             ! mass-weighted rain fallspeed
+
+! conservation check
+  real(r8) :: qce                   ! dummy qc for conservation check
+  real(r8) :: qie                   ! dummy qi for conservation check
+  real(r8) :: nce                   ! dummy nc for conservation check
+  real(r8) :: nie                   ! dummy ni for conservation check
+  real(r8) :: qre                   ! dummy qr for conservation check
+  real(r8) :: nre                   ! dummy nr for conservation check
+  real(r8) :: qnie                  ! dummy qni for conservation check
+  real(r8) :: nse                   ! dummy ns for conservation check      
+  real(r8) :: qge                   ! dummy qg for conservation check
+  real(r8) :: nge                   ! dummy ng for conservation check
+  real(r8) :: ratio                 ! parameter for conservation check
+
+! sum of source/sink terms for cloud hydrometeor
+  real(r8) :: qctend(pcols,pver)    ! microphysical tendency qc (1/s)
+  real(r8) :: qitend(pcols,pver)    ! microphysical tendency qi (1/s)
+  real(r8) :: nctend(pcols,pver)    ! microphysical tendency nc (1/(kg*s))
+  real(r8) :: nitend(pcols,pver)    ! microphysical tendency ni (1/(kg*s))
+  real(r8) :: qnitend(pcols,pver)   ! snow mixing ratio source/sink term
+  real(r8) :: nstend(pcols,pver)    ! snow number concentration source/sink term
+  real(r8) :: qrtend(pcols,pver)    ! rain mixing ratio source/sink term
+  real(r8) :: nrtend(pcols,pver)    ! rain number concentration source/sink term
+  real(r8) :: qgtend(pcols,pver)    ! graupel mixing ratio source/sink term
+  real(r8) :: ngtend(pcols,pver)    ! graupel number concentration source/sink term
+
+! terms for Bergeron process
+  real(r8) :: bergtsf               !bergeron timescale to remove all liquid
+  real(r8) :: plevap                ! cloud liquid water evaporation rate
+  real(r8) :: a_prime
+  real(r8) :: b_prime
+  real(r8) :: csvd
+  real(r8) :: cpvd
+  real(r8) :: dqi
+
+
+! variables for droplet activation by modal aerosols
+  real(r8) :: wmix, wmin, wmax, wdiab
+  real(r8) :: vol, nlsrc
+  real(r8), allocatable :: vaerosol(:), hygro(:), naermod(:)
+  real(r8), allocatable :: fn(:)      ! number fraction of aerosols activated
+  real(r8), allocatable :: fm(:)      ! mass fraction of aerosols activated
+  real(r8), allocatable :: fluxn(:)   ! flux of activated aerosol number fraction into cloud (cm/s)
+  real(r8), allocatable :: fluxm(:)   ! flux of activated aerosol mass fraction into cloud (cm/s)
+  real(r8) :: flux_fullact            ! flux of activated aerosol fraction assuming 100% activation (cm/s)
+  real(r8) :: dmc
+  real(r8) :: ssmc
+  real(r8) :: dgnum_aitken
+
+! bulk aerosol variables
+  real(r8), allocatable :: naer2(:,:,:)    ! new aerosol number concentration (/m3)
+  real(r8), allocatable :: naer2h(:,:,:)   ! new aerosol number concentration (/m3) 
+  real(r8), allocatable :: maerosol(:)     ! aerosol mass conc (kg/m3)
+  real(r8) :: so4_num
+  real(r8) :: soot_num
+  real(r8) :: dst1_num
+  real(r8) :: dst2_num
+  real(r8) :: dst3_num
+  real(r8) :: dst4_num
+  real(r8) :: dst_num
+
+! droplet activation
+  logical  :: in_cloud              ! true when above cloud base layer (k > jb)
+  real(r8) :: smax_f                ! droplet and rain size distr factor used in the
+                                    ! in-cloud smax calculation
+  real(r8) :: dum2l(pcols,pver)     ! number conc of CCN (1/kg)
+  real(r8) :: npccn(pver)           ! droplet activation rate
+  real(r8) :: ncmax
+  real(r8) :: mtimec                ! factor to account for droplet activation timescale
+
+! ice nucleation
+  real(r8) :: dum2i(pcols,pver)     ! number conc of ice nuclei available (1/kg)
+  real(r8) :: qs(pcols,pver)        ! liquid-ice weighted sat mixing rat (kg/kg)
+  real(r8) :: es(pcols,pver)        ! sat vapor press (pa) over water
+  real(r8) :: relhum(pcols,pver)    ! relative humidity
+  real(r8) :: esi(pcols,pver)       ! sat vapor press (pa) over ice
+  real(r8) :: nnuccd(pver)          ! ice nucleation rate from deposition/cond.-freezing
+  real(r8) :: mnuccd(pver)          ! mass tendency from ice nucleation
+  real(r8) :: mtime                 ! factor to account for ice nucleation timescale
+
+  real(r8) :: wpice, weff, fhom      ! unused dummies  
+
+! loop array variables
+  integer i,k, n, l
+  integer ii,kk, m
+
+! loop variables for iteration solution
+  integer iter,it,ltrue(pcols)
+
+! used in contact freezing via dust particles
+  real(r8)  tcnt, viscosity, mfp
+  real(r8)  slip1, slip2, slip3, slip4
+  real(r8)  dfaer1, dfaer2, dfaer3, dfaer4
+  real(r8)  nacon1,nacon2,nacon3,nacon4
+
+! used in immersion freezing via soot
+  real(r8) ttend(pver)
+  real(r8) naimm
+  real(r8) :: ntaer(pcols,pver)
+  real(r8) :: ntaerh(pcols,pver)
+
+! used in homogeneous freezing
+  real(r8) :: fholm (pcols,pver)    !mass tendency due to homogeneous freezing
+  real(r8) :: fholn (pcols,pver)    !number conc tendency due to homogeneous freezing
+
+! used in secondary ice production
+  real(r8) ni_secp
+
+! used in vertical velocity calculation
+  real(r8) th(pcols,pver)
+  real(r8) qh(pcols,pver)
+  real(r8) wu(pcols,pver)
+  real(r8) zkine(pcols,pver) 
+  real(r8) zbuo(pcols,pver)    
+  real(r8) zfacbuo, cwdrag, cwifrac, retv,  zbuoc
+  real(r8) zbc, zbe,  zdkbuo, zdken
+  real(r8) arcf(pcols,pver)
+  real(r8) p(pcols,pver)
+  real(r8) ph(pcols,pver)
+
+! used in vertical integreation
+  logical qcimp(pver)             ! true to solve qc with implicit formula
+  logical ncimp(pver)             ! true to solve nc with implicit formula
+  logical qiimp(pver)             ! true to solve qi with implicit formula
+  logical niimp(pver)             ! true to solve ni with implicit formula
+
+! tendency due to adjustment
+  real(r8) :: ncadj(pcols,pver)     !droplet num tendency due to adjustment
+  real(r8) :: niadj(pcols,pver)     !ice crystal num tendency due to adjustment
+  real(r8) :: nsadj(pcols,pver)     !snow num tendency due to adjustment
+  real(r8) :: ncorg, niorg, nsorg, total
+
+  real(r8) :: rhoh(pcols,pver)    ! air density (kg m-3) at interface 
+  real(r8) :: rhom(pcols,pver)    ! air density (kg m-3) at mid-level
+  real(r8) :: tu(pcols,pver)      ! temperature in updraft (K)
+
+  integer  kqi(pcols),kqc(pcols)
+  logical  lcbase(pcols), libase(pcols)
+
+  real(r8) :: nai_bcphi, nai_dst1, nai_dst2, nai_dst3, nai_dst4
+
+  real(r8) flxrm, mvtrm, flxrn, mvtrn, flxsm, mvtsm, flxsn, mvtsn
+  real(r8) flxgm, mvtgm, flxgn, mvtgn
+  integer  nlr, nls, nlg 
+
+  real(r8)  rmean, beta6, beta66, r6, r6c
+
+  real(r8)  dt, fmult
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+! initialization
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+  if (aero%scheme == 'modal') then
+
+     allocate(vaerosol(aero%nmodes), hygro(aero%nmodes), naermod(aero%nmodes), &
+        fn(aero%nmodes), fm(aero%nmodes), fluxn(aero%nmodes), fluxm(aero%nmodes))
+
+  else if (aero%scheme == 'bulk') then
+
+     allocate( &
+        naer2(pcols,pver,aero%nbulk),  &
+        naer2h(pcols,pver,aero%nbulk), &
+        maerosol(aero%nbulk))
+
+  end if
+	
+  deltat= get_step_size()      !for FV dynamical core
+        
+  ! parameters for scheme
+  omsm=0.99999_r8
+  zfacbuo = 0.5_r8/(1._r8+0.5_r8)
+  cwdrag  = 1.875_r8*0.506_r8
+  cwifrac = 0.5_r8
+  retv    = 0.608_r8
+  bergtsf = 1800._r8
+ 
+  ! initialize multi-level fields
+  do i=1,il2g
+     do k=1,pver
+        q(i,k) = qu(i,k)         
+        tu(i,k)= su(i,k) - grav/cp*zf(i,k)
+        t(i,k) = su(i,k) - grav/cp*zf(i,k)
+        p(i,k) = 100._r8*pm(i,k)
+        wu(i,k)   = 0._r8
+        zkine(i,k)= 0._r8
+        arcf(i,k) = 0._r8
+        zbuo(i,k) = 0._r8
+        nc(i,k)   = 0._r8
+        ni(i,k)   = 0._r8
+        qc(i,k)   = 0._r8
+        qi(i,k)   = 0._r8
+        ncde(i,k) = 0._r8
+        nide(i,k) = 0._r8
+        nsde(i,k) = 0._r8
+        qcde(i,k) = 0._r8
+        qide(i,k) = 0._r8
+        qnide(i,k) = 0._r8
+        rprd(i,k) = 0._r8
+        sprd(i,k) = 0._r8
+        frz(i,k)  = 0._r8
+        qcic(i,k) = 0._r8
+        qiic(i,k) = 0._r8
+        ncic(i,k) = 0._r8
+        niic(i,k) = 0._r8 
+        qr(i,k)   = 0._r8
+        qni(i,k)  = 0._r8
+        qg(i,k)  = 0._r8
+        nr(i,k)   = 0._r8
+        ns(i,k)   = 0._r8
+        ng(i,k)   = 0._r8
+        qric(i,k)  = 0._r8
+        qniic(i,k) = 0._r8
+        nric(i,k)  = 0._r8
+        nsic(i,k)  = 0._r8
+        qgic(i,k)  = 0._r8
+        ngic(i,k)  = 0._r8        
+        nimey(i,k) = 0._r8
+        nihf(i,k)  = 0._r8
+        nidep(i,k) = 0._r8
+        niimm(i,k) = 0._r8  
+        fhmrm(i,k) = 0._r8
+
+        autolm(i,k) = 0._r8
+        accrlm(i,k) = 0._r8
+        bergnm(i,k) = 0._r8
+        fhtimm(i,k) = 0._r8
+        fhtctm(i,k) = 0._r8
+        fhmlm (i,k) = 0._r8
+        fholm (i,k) = 0._r8
+        hmpim (i,k) = 0._r8
+        accslm(i,k) = 0._r8
+        dlfm  (i,k) = 0._r8
+
+        autoln(i,k) = 0._r8
+        accrln(i,k) = 0._r8
+        bergnn(i,k) = 0._r8
+        fhtimn(i,k) = 0._r8
+        fhtctn(i,k) = 0._r8
+        fhmln (i,k) = 0._r8
+        fholn (i,k) = 0._r8
+        accsln(i,k) = 0._r8
+        activn(i,k) = 0._r8
+        dlfn  (i,k) = 0._r8
+
+        autoim(i,k) = 0._r8
+        accsim(i,k) = 0._r8
+        difm  (i,k) = 0._r8
+
+        nuclin(i,k) = 0._r8
+        autoin(i,k) = 0._r8
+        accsin(i,k) = 0._r8
+        hmpin (i,k) = 0._r8
+        difn  (i,k) = 0._r8
+
+        trspcm(i,k) = 0._r8
+        trspcn(i,k) = 0._r8
+        trspim(i,k) = 0._r8
+        trspin(i,k) = 0._r8
+        trspsm(i,k) = 0._r8
+        trspsn(i,k) = 0._r8
+
+        dsfm  (i,k) = 0._r8
+        dsfn  (i,k) = 0._r8
+        ncadj (i,k) = 0._r8
+        niadj (i,k) = 0._r8
+        nsadj (i,k) = 0._r8
+
+        accgrm(i,k) = 0._r8          
+        accglm(i,k) = 0._r8        
+        accgslm(i,k)= 0._r8        
+        accgsrm(i,k)= 0._r8         
+        accgirm(i,k)= 0._r8         
+        accgrim(i,k)= 0._r8         
+        accgrsm(i,k)= 0._r8         
+
+        accgsln(i,k)= 0._r8         
+        accgsrn(i,k)= 0._r8         
+        accgirn(i,k)= 0._r8         
+
+        accsrim(i,k)= 0._r8         
+        acciglm(i,k)= 0._r8         
+        accigrm(i,k)= 0._r8         
+        accsirm(i,k)= 0._r8         
+
+        accigln(i,k)= 0._r8         
+        accigrn(i,k)= 0._r8         
+        accsirn(i,k)= 0._r8         
+        accgln(i,k) = 0._r8         
+        accgrn(i,k) = 0._r8
+
+        accilm(i,k) = 0._r8
+        acciln(i,k) = 0._r8
+
+        fallrm(i,k) = 0._r8
+        fallsm(i,k) = 0._r8
+        fallgm(i,k) = 0._r8
+        fallrn(i,k) = 0._r8
+        fallsn(i,k) = 0._r8
+        fallgn(i,k) = 0._r8
+     end do
+  end do
+
+  ! initialize time-varying parameters
+  do k=1,pver
+     do i=1,il2g
+        if (k .eq.1) then
+           rhoh(i,k) = p(i,k)/(t(i,k)*rd)
+           rhom(i,k) = p(i,k)/(t(i,k)*rd)
+           th (i,k) = te(i,k)
+           qh (i,k) = qe(i,k)
+           dz (i,k)  = zf(i,k) - zf(i,k+1)
+           ph(i,k)   = p(i,k)
+        else 
+           rhoh(i,k) = 0.5_r8*(p(i,k)+p(i,k-1))/(t(i,k)*rd)
+           if (k .eq. pver) then
+              rhom(i,k) = p(i,k)/(rd*t(i,k))   
+           else
+              rhom(i,k) = 2.0_r8*p(i,k)/(rd*(t(i,k)+t(i,k+1)))
+           end if
+           th (i,k) = 0.5_r8*(te(i,k)+te(i,k-1))
+           qh (i,k) = 0.5_r8*(qe(i,k)+qe(i,k-1))
+           dz(i,k)  = zf(i,k-1) - zf(i,k)
+           ph(i,k)  = 0.5_r8*(p(i,k) + p(i,k-1))
+        end if
+        dv(i,k) = 8.794E-5_r8*t(i,k)**1.81_r8/ph(i,k)
+        mua(i,k) = 1.496E-6_r8*t(i,k)**1.5_r8/ &
+           (t(i,k)+120._r8)
+
+        rho(i,k) = rhoh(i,k)    
+
+        ! air density adjustment for fallspeed parameters
+        ! add air density correction factor to the power of 
+        ! 0.54 following Heymsfield and Bansemer 2006
+
+        arn(i,k)=ar*(rhosu/rho(i,k))**0.54
+        asn(i,k)=as*(rhosu/rho(i,k))**0.54
+        acn(i,k)=ac*(rhosu/rho(i,k))**0.54
+        ain(i,k)=ai*(rhosu/rho(i,k))**0.54
+        agn(i,k)=ag*(rhosu/rho(i,k))**0.54
+     end do
+  end do
+
+  if (aero%scheme == 'modal') then
+
+     wmix  = 0._r8
+     wmin  = 0._r8
+     wmax  = 10._r8
+     wdiab = 0._r8
+
+     do k=1,pver
+        do i=1,il2g
+           dum2l(i,k)=0._r8
+           dum2i(i,k)=0._r8
+           ntaer(i,k) = 0.0_r8
+           ntaerh(i,k) = 0.0_r8
+           do m = 1, aero%nmodes
+              ntaer(i,k) = ntaer(i,k) + aero%numg_a(i,k,m)*rhom(i,k)
+           enddo
+        end do
+     end do
+
+  else if (aero%scheme == 'bulk') then
+
+     ! initialize aerosol number
+     do k=1,pver
+        do i=1,il2g
+           naer2(i,k,:)=0._r8
+           naer2h(i,k,:)=0._r8      
+           dum2l(i,k)=0._r8
+           dum2i(i,k)=0._r8
+        end do
+     end do
+
+     do k=1,pver
+        do i=1,il2g
+           ntaer(i,k) = 0.0_r8
+           ntaerh(i,k) = 0.0_r8
+           do m = 1, aero%nbulk
+              maerosol(m) = aero%mmrg_bulk(i,k,m)*rhom(i,k)
+
+              ! set number nucleated for sulfate based on Lohmann et al. 2000 (JGR) Eq.2
+              !    Na=340.*(massSO4)^0.58  where Na=cm-3 and massSO4=ug/m3
+              ! convert units to Na [m-3] and SO4 [kgm-3]
+              !    Na(m-3)= 1.e6 cm3 m-3 Na(cm-3)=340. *(massSO4[kg/m3]*1.e9ug/kg)^0.58
+              !    or Na(m-3)= 1.e6* 340.*(1.e9ug/kg)^0.58 * (massSO4[kg/m3])^0.58
+
+              if (m .eq. aero%idxsul) then
+                 naer2(i,k,m)= 5.64259e13_r8 * maerosol(m)**0.58
+              else
+                 naer2(i,k,m)=maerosol(m)*aero%num_to_mass_aer(m)
+              end if
+              ntaer(i,k) = ntaer(i,k) + naer2(i,k,m) 
+           end do
+        end do
+     end do
+
+  end if
+
+  do i=1,il2g
+     ltrue(i)=0
+     do k=1,pver
+        if (qc(i,k).ge.qsmall.or.qi(i,k).ge.qsmall.or.cmel(i,k).ge.qsmall.or.cmei(i,k).ge.qsmall) ltrue(i)=1
+     end do
+  end do
+
+  ! skip microphysical calculations if no cloud water
+  do i=1,il2g
+     if (ltrue(i).eq.0) then
+        do k=1,pver
+           qctend(i,k)=0._r8
+           qitend(i,k)=0._r8
+           qnitend(i,k)=0._r8
+           qrtend(i,k)=0._r8
+           qgtend(i,k)=0._r8
+           nctend(i,k)=0._r8
+           nitend(i,k)=0._r8
+           nrtend(i,k)=0._r8
+           nstend(i,k)=0._r8
+           ngtend(i,k)=0._r8         
+           qniic(i,k)=0._r8
+           qgic(i,k)=0._r8 
+           qric(i,k)=0._r8
+           nsic(i,k)=0._r8
+           ngic(i,k)=0._r8
+           nric(i,k)=0._r8
+           qni(i,k)=0._r8
+           qg(i,k)=0._r8  
+           qr(i,k)=0._r8
+           ns(i,k)=0._r8
+           ng(i,k)=0._r8 
+           nr(i,k)=0._r8
+           qc(i,k) = 0._r8
+           qi(i,k) = 0._r8
+           nc(i,k) = 0._r8
+           ni(i,k) = 0._r8
+           qcde(i,k) = 0._r8
+           qide(i,k) = 0._r8
+           qnide(i,k) = 0._r8
+           ncde(i,k) = 0._r8
+           nide(i,k) = 0._r8
+           nsde(i,k) = 0._r8
+           rprd(i,k) = 0._r8
+           sprd(i,k) = 0._r8  
+           frz(i,k)  = 0._r8
+        end do
+        goto 300
+     end if
+
+     kqc(i) = 1
+     kqi(i) = 1
+     lcbase(i) = .true.
+     libase(i) = .true. 
+
+     ! assign number of steps for iteration
+     ! use 2 steps following Song and Zhang, 2011, J. Clim.
+     iter = 2
+
+     !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+     !  iteration
+     !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+     do it=1,iter
+
+        ! initialize sub-step microphysical tendencies
+        do k=1,pver
+           qctend(i,k)=0._r8
+           qitend(i,k)=0._r8
+           qnitend(i,k)=0._r8
+           qrtend(i,k)=0._r8
+           qgtend(i,k)=0._r8
+           nctend(i,k)=0._r8
+           nitend(i,k)=0._r8
+           nrtend(i,k)=0._r8
+           nstend(i,k)=0._r8
+           ngtend(i,k)=0._r8
+           rprd(i,k) = 0._r8
+           sprd(i,k) = 0._r8
+           frz(i,k)  = 0._r8
+           qniic(i,k)=0._r8
+           qric(i,k)=0._r8
+           qgic(i,k)=0._r8
+           nsic(i,k)=0._r8
+           nric(i,k)=0._r8
+           ngic(i,k)=0._r8
+           qiic(i,k)=0._r8
+           qcic(i,k)=0._r8
+           niic(i,k)=0._r8
+           ncic(i,k)=0._r8           
+           qcimp(k) = .false.
+           ncimp(k) = .false.
+           qiimp(k) = .false.
+           niimp(k) = .false.
+           dum2l(i,k)=0._r8
+           dum2i(i,k)=0._r8
+           autolm(i,k) = 0._r8
+           accrlm(i,k) = 0._r8
+           bergnm(i,k) = 0._r8
+           fhtimm(i,k) = 0._r8
+           fhtctm(i,k) = 0._r8
+           fhmlm (i,k) = 0._r8
+           fholm (i,k) = 0._r8
+           hmpim (i,k) = 0._r8
+           accslm(i,k) = 0._r8
+           dlfm  (i,k) = 0._r8
+
+           autoln(i,k) = 0._r8
+           accrln(i,k) = 0._r8
+           bergnn(i,k) = 0._r8
+           fhtimn(i,k) = 0._r8
+           fhtctn(i,k) = 0._r8
+           fhmln (i,k) = 0._r8
+           fholn (i,k) = 0._r8
+           accsln(i,k) = 0._r8
+           activn(i,k) = 0._r8
+           dlfn  (i,k) = 0._r8
+           ncadj (i,k) = 0._r8
+
+           autoim(i,k) = 0._r8
+           accsim(i,k) = 0._r8
+           difm  (i,k) = 0._r8
+
+           nuclin(i,k) = 0._r8
+           autoin(i,k) = 0._r8
+           accsin(i,k) = 0._r8
+           hmpin (i,k) = 0._r8
+           difn  (i,k) = 0._r8
+           niadj (i,k) = 0._r8
+
+           dsfm  (i,k) = 0._r8
+           dsfn  (i,k) = 0._r8
+           nsadj (i,k) = 0._r8
+
+           trspcm(i,k) = 0._r8
+           trspcn(i,k) = 0._r8
+           trspim(i,k) = 0._r8
+           trspin(i,k) = 0._r8
+           trspsm(i,k) = 0._r8
+           trspsn(i,k) = 0._r8
+
+           fhmrm (i,k) = 0._r8
+
+           accgrm(i,k) = 0._r8
+           accglm(i,k) = 0._r8
+           accgslm(i,k)= 0._r8
+           accgsrm(i,k)= 0._r8
+           accgirm(i,k)= 0._r8
+           accgrim(i,k)= 0._r8
+           accgrsm(i,k)= 0._r8
+
+           accgsln(i,k)= 0._r8
+           accgsrn(i,k)= 0._r8
+           accgirn(i,k)= 0._r8
+
+           accsrim(i,k)= 0._r8
+           acciglm(i,k)= 0._r8
+           accigrm(i,k)= 0._r8
+           accsirm(i,k)= 0._r8
+
+           accigln(i,k)= 0._r8
+           accigrn(i,k)= 0._r8
+           accsirn(i,k)= 0._r8
+           accgln(i,k) = 0._r8
+           accgrn(i,k) = 0._r8
+
+           accilm(i,k) = 0._r8
+           acciln(i,k) = 0._r8
+
+           fallrm(i,k) = 0._r8
+           fallsm(i,k) = 0._r8
+           fallgm(i,k) = 0._r8
+           fallrn(i,k) = 0._r8
+           fallsn(i,k) = 0._r8
+           fallgn(i,k) = 0._r8
+        end do
+
+        do k = pver,msg+2,-1
+  
+           if (k > jt(i) .and. k <= jb(i) .and. eps0(i) > 0._r8      &
+              .and.mu(i,k).gt.0._r8 .and. mu(i,k-1).gt.0._r8) then
+
+              ! initialize precip fallspeeds to zero
+              if (it.eq.1) then
+                ums(k)=0._r8 
+                uns(k)=0._r8 
+                umr(k)=0._r8 
+                unr(k)=0._r8
+                prf(k)=0._r8
+                pnrf(k)=0._r8
+                psf(k) =0._r8
+                pnsf(k) = 0._r8
+                umg(k)=0._r8
+                ung(k)=0._r8
+                pgf(k) =0._r8
+                pngf(k) = 0._r8
+              end if
+              ttend(k)=0._r8
+              nnuccd(k)=0._r8
+              npccn(k)=0._r8
+
+              !************************************************************************************
+              ! obtain values of cloud water/ice mixing ratios and number concentrations in updraft
+              ! for microphysical process calculations
+              ! units are kg/kg for mixing ratio, 1/kg for number conc
+              !************************************************************************************
+
+
+              if (it.eq.1) then
+                 qcic(i,k) = qc(i,k)
+                 qiic(i,k) = qi(i,k)
+                 ncic(i,k) = nc(i,k)
+                 niic(i,k) = ni(i,k)
+                 qniic(i,k)= qni(i,k)
+                 qric(i,k) = qr(i,k)
+                 nsic(i,k) = ns(i,k)
+                 nric(i,k) = nr(i,k)
+                 qgic(i,k) = qg(i,k)
+                 ngic(i,k) = ng(i,k)
+              else 
+                 if (k.le.kqc(i)) then   
+                    qcic(i,k) = qc(i,k)
+                    ncic(i,k) = nc(i,k)
+
+                    ! consider rain falling from above
+                    flxrm = 0._r8
+                    mvtrm = 0._r8
+                    flxrn = 0._r8
+                    mvtrn = 0._r8
+                    nlr = 0
+                    
+                    do kk= k,jt(i)+3,-1
+                       if (qr(i,kk-1) .gt. 0._r8) then
+                           nlr = nlr + 1
+                           flxrm = flxrm + umr(kk-1)*qr(i,kk-1)*arcf(i,kk-1)
+                           flxrn = flxrn + unr(kk-1)*nr(i,kk-1)*arcf(i,kk-1)
+                           mvtrm = mvtrm + umr(kk-1)*arcf(i,kk-1)
+                           mvtrn = mvtrn + unr(kk-1)*arcf(i,kk-1)
+                       end if
+                    end do
+                    if (mvtrm.gt.0) then
+                       qric(i,k) = (qr(i,k)*mu(i,k)+flxrm)/(mu(i,k)+mvtrm)
+                    else
+                       qric(i,k) = qr(i,k)
+                    end if
+                    if (mvtrn.gt.0) then
+                       nric(i,k) = (nr(i,k)*mu(i,k)+flxrn)/(mu(i,k)+mvtrn)
+                    else
+                       nric(i,k) = nr(i,k)
+                    end if
+
+                 end if
+                 if (k.eq.kqc(i)) then
+                     qcic(i,k) = qc(i,k-1)
+                     ncic(i,k) = nc(i,k-1)
+                 end if
+                 if(k.le.kqi(i)) then
+                   qiic(i,k) = qi(i,k)
+                   niic(i,k) = ni(i,k)
+! consider snow falling from above
+                   flxsm = 0._r8
+                   mvtsm = 0._r8
+                   flxsn = 0._r8
+                   mvtsn = 0._r8
+                   nls = 0
+  
+                   do kk= k,jt(i)+3,-1
+                     if (qni(i,kk-1) .gt. 0._r8) then
+                       nls = nls + 1
+                       flxsm = flxsm + ums(kk-1)*qni(i,kk-1)*arcf(i,kk-1)
+                       mvtsm = mvtsm + ums(kk-1)*arcf(i,kk-1)
+                       flxsn = flxsn + uns(kk-1)*ns(i,kk-1)*arcf(i,kk-1)
+                       mvtsn = mvtsn + uns(kk-1)*arcf(i,kk-1)
+                     end if
+                   end do
+
+                   if (mvtsm.gt.0) then
+                      qniic(i,k) = (qni(i,k)*mu(i,k)+flxsm)/(mu(i,k)+mvtsm)
+                   else
+                      qniic(i,k) = qni(i,k)
+                   end if
+                   if (mvtsn.gt.0) then
+                      nsic(i,k) = (ns(i,k)*mu(i,k)+flxsn)/(mu(i,k)+mvtsn)
+                   else
+                      nsic(i,k) = ns(i,k)
+                   end if
+!                 end if
+
+! consider graupel falling from above
+                   flxgm = 0._r8
+                   mvtgm = 0._r8
+                   flxgn = 0._r8
+                   mvtgn = 0._r8
+                   nlg = 0
+
+                   do kk= k,jt(i)+3,-1
+                     if (qg(i,kk-1) .gt. 0._r8) then
+                       nlg = nlg + 1
+                       flxgm = flxgm + umg(kk-1)*qg(i,kk-1)*arcf(i,kk-1)
+                       mvtgm = mvtgm + umg(kk-1)*arcf(i,kk-1)
+                       flxgn = flxgn + ung(kk-1)*ng(i,kk-1)*arcf(i,kk-1)
+                       mvtgn = mvtgn + ung(kk-1)*arcf(i,kk-1)
+                     end if
+                   end do
+
+                   if (mvtgm.gt.0) then
+                      qgic(i,k) = (qg(i,k)*mu(i,k)+flxgm)/(mu(i,k)+mvtgm)
+                   else
+                      qgic(i,k) = qg(i,k)
+                   end if
+                   if (mvtgn.gt.0) then
+                      ngic(i,k) = (ng(i,k)*mu(i,k)+flxgn)/(mu(i,k)+mvtgn)
+                   else
+                      ngic(i,k) = ng(i,k)
+                   end if
+                 end if
+
+
+                 if(k.eq.kqi(i)) then
+                    qiic(i,k) = qi(i,k-1)
+                    niic(i,k) = ni(i,k-1)
+                 end if
+              end if
+
+              !**********************************************************************
+              ! boundary condition for cloud liquid water and cloud ice
+              !***********************************************************************
+
+              ! boundary condition for provisional cloud water
+              if (cmel(i,k-1).gt.qsmall .and. lcbase(i) .and. it.eq.1 ) then
+                 kqc(i) = k
+                 lcbase(i) = .false.
+                 qcic(i,k) = dz(i,k)*cmel(i,k-1)/(mu(i,k-1)+dz(i,k)*du(i,k-1))
+!                 ncic(i,k) = qcic(i,k)/(4._r8/3._r8*pi*10.e-6_r8**3*rhow)
+                 ncic(i,k) = qcic(i,k)/(4._r8/3._r8*pi*25.e-6_r8**3*rhow)  
+              end if
+
+              ! boundary condition for provisional cloud ice
+              if (qiic(i,k).gt.qsmall .and. libase(i) .and. it.eq.1 ) then
+                 kqi(i) = k
+                 libase(i) = .false.
+              else if ( cmei(i,k-1).gt.qsmall .and.   &
+                 cmei(i,k).lt.qsmall .and. k.le.jb(i) .and. libase(i) .and. it.eq.1 ) then
+                 kqi(i)=k
+                 libase(i) = .false.
+                 qiic(i,k) = dz(i,k)*cmei(i,k-1)/(mu(i,k-1)+dz(i,k)*du(i,k-1))
+                 niic(i,k) = qiic(i,k)/(4._r8/3._r8*pi*15.e-6_r8**3*rhoi)               
+!                 niic(i,k) = qiic(i,k)/(4._r8/3._r8*pi*32.e-6_r8**3*rhoi)
+              end if
+
+              !***************************************************************************
+              ! get size distribution parameters based on in-cloud cloud water/ice 
+              ! these calculations also ensure consistency between number and mixing ratio
+              !***************************************************************************
+              ! cloud ice
+              if (qiic(i,k).ge.qsmall) then
+
+                 ! add upper limit to in-cloud number concentration to prevent numerical error
+                 niic(i,k)=min(niic(i,k),qiic(i,k)*1.e20_r8)
+                 lami(k) = (gamma(1._r8+di)*ci* &
+                    niic(i,k)/qiic(i,k))**(1._r8/di)
+                 n0i(k) = niic(i,k)*lami(k)
+
+                 ! check for slope
+                 lammax = 1._r8/10.e-6_r8
+                 lammin = 1._r8/(2._r8*dcs)
+
+                 ! adjust vars
+                 if (lami(k).lt.lammin) then
+                    lami(k) = lammin
+                    n0i(k) = lami(k)**(di+1._r8)*qiic(i,k)/(ci*gamma(1._r8+di))
+                    niic(i,k) = n0i(k)/lami(k)
+                 else if (lami(k).gt.lammax) then
+                    lami(k) = lammax
+                    n0i(k) = lami(k)**(di+1._r8)*qiic(i,k)/(ci*gamma(1._r8+di))
+                    niic(i,k) = n0i(k)/lami(k)
+                 end if
+              else
+                 lami(k) = 0._r8
+                 n0i(k) = 0._r8
+              end if
+
+              ! cloud water
+              if (qcic(i,k).ge.qsmall) then
+
+                 ! add upper limit to in-cloud number concentration to prevent numerical error
+                 ncic(i,k)=min(ncic(i,k),qcic(i,k)*1.e20_r8)
+
+                 ! get pgam from fit to observations of martin et al. 1994
+
+                 pgam(i,k)=0.0005714_r8*(ncic(i,k)/1.e6_r8*rho(i,k))+0.2714_r8
+                 pgam(i,k)=1._r8/(pgam(i,k)**2)-1._r8
+                 pgam(i,k)=max(pgam(i,k),2._r8)
+                 pgam(i,k)=min(pgam(i,k),15._r8)
+
+                 ! calculate lamc, gamma(z+1)=z*gamma(z), gamma(z+4)=(z+3)*(z+2)*(z+1)*gamma(z+1)
+                 lamc(i,k) = (pi/6._r8*rhow*ncic(i,k)*gamma(pgam(i,k)+4._r8)/ &
+                    (qcic(i,k)*gamma(pgam(i,k)+1._r8)))**(1._r8/3._r8)
+
+                 ! lammin, 50 micron diameter max mean size
+                 lammin = (pgam(i,k)+1._r8)/40.e-6_r8
+                 lammax = (pgam(i,k)+1._r8)/1.e-6_r8 
+
+                 if (lamc(i,k).lt.lammin) then
+                    lamc(i,k) = lammin
+                    ncic(i,k) = 6._r8*lamc(i,k)**3*qcic(i,k)* &
+                       gamma(pgam(i,k)+1._r8)/ &
+                       (pi*rhow*gamma(pgam(i,k)+4._r8))
+                 else if (lamc(i,k).gt.lammax) then
+                    lamc(i,k) = lammax
+                    ncic(i,k) = 6._r8*lamc(i,k)**3*qcic(i,k)* &
+                       gamma(pgam(i,k)+1._r8)/ &
+                       (pi*rhow*gamma(pgam(i,k)+4._r8))
+                 end if
+
+                 ! parameter to calculate droplet freezing
+
+                 cdist1(k) = ncic(i,k)/gamma(pgam(i,k)+1._r8) 
+              else
+                 lamc(i,k) = 0._r8
+                 cdist1(k) = 0._r8
+              end if
+
+              ! boundary condition for cloud liquid water
+              if ( kqc(i) .eq. k  ) then
+                 qc(i,k) =  0._r8
+                 nc(i,k) = 0._r8
+              end if
+
+              ! boundary condition for cloud ice
+              if (kqi(i).eq.k  ) then
+                 qi(i,k) = 0._r8
+                 ni(i,k) = 0._r8
+              end if
+              
+              !**************************************************************************
+              ! begin micropysical process calculations 
+              !**************************************************************************
+
+              !.................................................................
+              ! autoconversion of cloud liquid water to rain
+              ! formula from Khrouditnov and Kogan (2000)
+              ! minimum qc of 1 x 10^-8 prevents floating point error
+
+              if (qcic(i,k).ge.1.e-8_r8) then
+
+                 ! nprc is increase in rain number conc due to autoconversion
+                 ! nprc1 is decrease in cloud droplet conc due to autoconversion
+                 ! Khrouditnov and Kogan (2000) 
+!                 prc(k) = 1350._r8*qcic(i,k)**2.47_r8*    &
+!                    (ncic(i,k)/1.e6_r8*rho(i,k))**(-1.79_r8)
+                 prc(k) = 213500._r8*qcic(i,k)**3.19_r8*    &
+                    (ncic(i,k)/1.e6_r8*rho(i,k))**(-1.2_r8)
+                 nprc1(k) = prc(k)/(qcic(i,k)/ncic(i,k))
+                 nprc(k) = prc(k) * (1._r8/droplet_mass_25um)
+
+              else
+                 prc(k)=0._r8
+                 nprc(k)=0._r8
+                 nprc1(k)=0._r8
+              end if
+ 
+              ! provisional rain mixing ratio and number concentration (qric and nric)
+              ! at boundary are estimated via autoconversion
+
+              if (k.eq.kqc(i) .and. it.eq.1) then
+                 qric(i,k) = prc(k)*dz(i,k)/0.55_r8
+                 nric(i,k) = nprc(k)*dz(i,k)/0.55_r8 
+                 qr(i,k) = 0.0_r8
+                 nr(i,k) = 0.0_r8
+              end if
+
+              !.......................................................................
+              ! Autoconversion of cloud ice to snow
+              ! similar to Ferrier (1994)
+
+              if (t(i,k).le.273.15_r8.and.qiic(i,k).ge.qsmall) then
+
+                 ! note: assumes autoconversion timescale of 180 sec
+                 nprci(k) = n0i(k)/(lami(k)*180._r8)*exp(-lami(k)*dcs)
+                 prci(k) = pi*rhoi*n0i(k)/(6._r8*180._r8)* &
+                    (dcs**3/lami(k)+3._r8*dcs**2/lami(k)**2+ &
+                    6._r8*dcs/lami(k)**3+6._r8/lami(k)**4)*exp(-lami(k)*dcs)          
+              else
+                 prci(k)=0._r8
+                 nprci(k)=0._r8
+              end if
+
+              ! provisional snow mixing ratio and number concentration (qniic and nsic) 
+              ! at boundary are estimated via autoconversion
+
+              if (k.eq.kqi(i) .and. it.eq.1) then
+                 qniic(i,k)= prci(k)*dz(i,k)*0.25_r8
+                 nsic(i,k)= nprci(k)*dz(i,k)*0.25_r8
+                 qni(i,k)= 0.0_r8
+                 ns(i,k)= 0.0_r8
+              end if
+
+              ! if precip mix ratio is zero so should number concentration
+              if (qniic(i,k).lt.qsmall) then
+                 qniic(i,k)=0._r8
+                 nsic(i,k)=0._r8
+              end if
+              if (qric(i,k).lt.qsmall) then
+                 qric(i,k)=0._r8
+                 nric(i,k)=0._r8
+              end if
+              if (qgic(i,k).lt.qsmall) then
+                 qgic(i,k)=0._r8
+                 ngic(i,k)=0._r8
+              end if
+             
+              ! make sure number concentration is a positive number to avoid 
+              ! taking root of negative later
+              nric(i,k)=max(nric(i,k),0._r8)
+              nsic(i,k)=max(nsic(i,k),0._r8)
+              ngic(i,k)=max(ngic(i,k),0._r8)
+              !**********************************************************************
+              ! get size distribution parameters for precip
+              !**********************************************************************
+              ! rain
+
+              if (qric(i,k).ge.qsmall) then
+                 lamr(k) = (pi*rhow*nric(i,k)/qric(i,k))**(1._r8/3._r8)
+                 n0r(k) = nric(i,k)*lamr(k)
+
+                 ! check for slope
+                 lammax = 1._r8/150.e-6_r8
+                 lammin = 1._r8/3000.e-6_r8
+
+                 ! adjust vars
+                 if (lamr(k).lt.lammin) then
+                    lamr(k) = lammin
+                    n0r(k) = lamr(k)**4*qric(i,k)/(pi*rhow)
+                    nric(i,k) = n0r(k)/lamr(k)
+                 else if (lamr(k).gt.lammax) then
+                    lamr(k) = lammax
+                    n0r(k) = lamr(k)**4*qric(i,k)/(pi*rhow)
+                    nric(i,k) = n0r(k)/lamr(k)
+                 end if
+
+                 ! provisional rain number and mass weighted mean fallspeed (m/s)
+                 ! Eq.18 of Morrison and Gettelman, 2008, J. Climate
+                 unr(k) = min(arn(i,k)*gamma(1._r8+br)/lamr(k)**br,10._r8)
+                 umr(k) = min(arn(i,k)*gamma(4._r8+br)/(6._r8*lamr(k)**br),10._r8)
+              else
+                 lamr(k) = 0._r8
+                 n0r(k) = 0._r8
+                 umr(k) = 0._r8
+                 unr(k) = 0._r8
+              end if
+
+              !......................................................................
+              ! snow
+              if (qniic(i,k).ge.qsmall) then
+                 lams(k) = (gamma(1._r8+ds)*cs*nsic(i,k)/ &
+                    qniic(i,k))**(1._r8/ds)
+                 n0s(k) = nsic(i,k)*lams(k)
+
+                 ! check for slope
+!                 lammax = 1._r8/10.e-6_r8
+!                 lammin = 1._r8/2000.e-6_r8
+                 lammax = 1._r8/dcs
+                 lammin = 1._r8/5000.e-6_r8
+
+                 ! adjust vars
+                 if (lams(k).lt.lammin) then
+                    lams(k) = lammin
+                    n0s(k) = lams(k)**4*qniic(i,k)/(cs*gamma(1._r8+ds))
+                    nsic(i,k) = n0s(k)/lams(k)
+                 else if (lams(k).gt.lammax) then
+                    lams(k) = lammax
+                    n0s(k) = lams(k)**4*qniic(i,k)/(cs*gamma(1._r8+ds))
+                    nsic(i,k) = n0s(k)/lams(k)
+                 end if
+
+                 ! provisional snow number and mass weighted mean fallspeed (m/s)
+                 dum=(rhosu/rho(i,k))**0.54
+                 ums(k) = min(asn(i,k)*gamma(4._r8+bs)/(6._r8*lams(k)**bs),1.2_r8*dum)
+                 uns(k) = min(asn(i,k)*gamma(1._r8+bs)/lams(k)**bs,1.2_r8*dum) 
+              else
+                 lams(k) = 0._r8
+                 n0s(k) = 0._r8
+                 ums(k) = 0._r8
+                 uns(k) = 0._r8
+              end if
+              !.......................................................................
+              !graupel
+
+              if (qgic(i,k).ge.qsmall) then
+                  lamg(k) = (gamma(1._r8+dg)*cg*ngic(i,k)/qgic(i,k))**(1./dg)
+                  n0g(k) = ngic(i,k)*lamg(k)
+
+                  ! check for slope
+                  ! adjust vars
+                  lammax = 1._r8/20.e-6_r8
+                  lammin = 1._r8/5000.e-6_r8
+
+                  if (lamg(k).lt.lammin) then
+                      lamg(k) = lammin
+                      n0g(k) = lamg(k)**4*qgic(i,k)/(gamma(1._r8+dg)*cg)
+                      ngic(i,k) = n0g(k)/lamg(k)
+                  else if (lamg(k).gt.lammax) then
+                      lamg(k) = lammax
+                      n0g(k) = lamg(k)**4*qgic(i,k)/(gamma(1._r8+dg)*cg)
+                      ngic(i,k) = n0g(k)/lamg(k)
+                  end if
+                  ! provisional snow number and mass weighted mean fallspeed (m/s)
+                  dum=(rhosu/rho(i,k))**0.54
+                  umg(k) = min(agn(i,k)*gamma(4._r8+bg)/(6._r8*lamg(k)**bg),20._r8*dum)
+                  ung(k) = min(agn(i,k)*gamma(1._r8+bg)/lamg(k)**bg,20._r8*dum)
+              else
+                  lamg(k) = 0._r8
+                  n0g(k) = 0._r8
+                  umg(k) = 0._r8
+                  ung(k) = 0._r8
+              end if
+
+                 
+              !.......................................................................
+              ! snow self-aggregation from passarelli, 1978, used by Reisner(1998,Eq.A.35)
+              ! this is hard-wired for bs = 0.4 for now
+              ! ignore self-collection of cloud ice
+ 
+              if (qniic(i,k).ge.qsmall .and. t(i,k).le.273.15_r8) then
+                 nsagg(k) = -1108._r8*asn(i,k)*Eii* &
+                    pi**((1._r8-bs)/3._r8)*rhosn**((-2._r8-bs)/3._r8)*rho(i,k)** &
+                    ((2._r8+bs)/3._r8)*qniic(i,k)**((2._r8+bs)/3._r8)* &
+                    (nsic(i,k)*rho(i,k))**((4._r8-bs)/3._r8)/ &
+                    (4._r8*720._r8*rho(i,k))
+              else
+                 nsagg(k)=0._r8
+              end if
+
+              !.......................................................................
+              ! accretion of cloud droplets onto snow/graupel
+              ! here use continuous collection equation with
+              ! simple gravitational collection kernel
+              ! ignore collisions between droplets/cloud ice
+
+              ! ignore collision of snow with droplets above freezing
+
+              if (qniic(i,k).ge.qsmall .and. t(i,k).le.273.15_r8 .and. &
+                 qcic(i,k).ge.qsmall) then
+
+                 ! put in size dependent collection efficiency
+                 ! mean diameter of snow is area-weighted, since
+                 ! accretion is function of crystal geometric area
+                 ! collection efficiency is from stoke's law (Thompson et al. 2004)
+
+                 dc0 = (pgam(i,k)+1._r8)/lamc(i,k)
+                 ds0 = 1._r8/lams(k)
+                 dum = dc0*dc0*uns(k)*rhow/(9._r8*mua(i,k)*ds0)
+                 eci = dum*dum/((dum+0.4_r8)*(dum+0.4_r8))
+                 eci = max(eci,0._r8)
+                 eci = min(eci,1._r8)
+
+                 psacws(k) = pi/4._r8*asn(i,k)*qcic(i,k)*rho(i,k)* &
+                    n0s(k)*Eci*gamma(bs+3._r8)/ &
+                    lams(k)**(bs+3._r8)	
+                 npsacws(k) = pi/4._r8*asn(i,k)*ncic(i,k)*rho(i,k)* &
+                    n0s(k)*Eci*gamma(bs+3._r8)/ &
+                    lams(k)**(bs+3._r8)
+              else
+                 psacws(k)=0._r8
+                 npsacws(k)=0._r8
+              end if
+
+              ! secondary ice production due to accretion of droplets by snow 
+              ! (Hallet-Mossop process) (from Cotton et al., 1986)
+              if((t(i,k).lt.270.16_r8) .and. (t(i,k).ge.268.16_r8)) then
+                 ni_secp   = 3.5e8_r8*(270.16_r8-t(i,k))/2.0_r8*psacws(k)
+                 nsacwi(k) = ni_secp
+                 msacwi(k) = min(ni_secp*mi0,psacws(k))
+              else if((t(i,k).lt.268.16_r8) .and. (t(i,k).ge.265.16_r8)) then
+                 ni_secp   = 3.5e8_r8*(t(i,k)-265.16_r8)/3.0_r8*psacws(k)
+                 nsacwi(k) = ni_secp
+                 msacwi(k) = min(ni_secp*mi0,psacws(k))
+              else
+                 ni_secp   = 0.0_r8
+                 nsacwi(k) = 0.0_r8
+                 msacwi(k) = 0.0_r8
+              endif
+              psacws(k) = max(0.0_r8,psacws(k)-ni_secp*mi0)
+
+!........................................................................
+! conversion of rimed cloud water onto snow to graupel/hail
+
+! only allow conversion if qni > 0.1 and qc > 0.5 g/kg following rutledge and
+! hobbs (1984)
+
+           if (psacws(k).gt.0._r8 .and. qniic(i,k).ge.0.1e-3_r8.and.qcic(i,k).ge.0.5e-3_r8) then
+             if (ums(k).eq.0._r8) write(*,*) "!!! ums=0., k=",k,"i=",i
+! portion of riming converted to graupel (reisner et al. 1998, originally
+! is1991)
+             dt = dz(i,k)/ums(k)
+             pgsacw(k) = min(psacws(k),cons17*dt*n0s(k)*qcic(i,k)*qcic(i,k)* &
+                             asn(i,k)*asn(i,k)*rho(i,k)/(lams(k)**(2._r8*bs+2._r8)))
+                          
+! mix rat converted into graupel as embryo (reisner et al. 1998, orig m1990)
+             dum = max(rhosn/(rhog-rhosn)*pgsacw(k),0._r8)
+
+! number concentraiton of embryo graupel from riming of snow
+             nscng(k) = dum/mg0  
+! limit max number converted to snow number
+!             nscng(k) = min(nscng(k),nsic(i,k)/dt)
+
+! portion of riming left for snow
+             psacws(k) = psacws(k) - pgsacw(k)
+            else
+              pgsacw(k) = 0._r8
+              nscng(k) = 0._r8 !
+            end if
+
+! cloud ice collecting droplets, assume that cloud ice mean diam > 100 micron
+! before riming can occur
+! assume that rime collected on cloud ice does not lead
+! to hallet-mossop splintering
+
+         if (qiic(i,k).ge.1.e-8_r8 .and. qcic(i,k).ge.qsmall.and.1._r8/lami(k).ge.100.e-6_r8 ) then
+
+! put in size dependent collection efficiency based on stokes law
+! from thompson et al. 2004, mwr
+
+           psacwi(k) = cons16*ain(i,k)*qcic(i,k)*rho(i,k)*               &
+                       n0i(k)/lami(k)**(bi+3._r8)
+           npsacwi(k) = cons16*ain(i,k)*ncic(i,k)*rho(i,k)*              &
+                       n0i(k)/lami(k)**(bi+3._r8)
+
+         else
+           psacwi(k) = 0._r8
+           npsacwi(k) = 0._r8 
+         end if
+
+
+              !............................................................................
+              ! collection of cloud water by graupel
+
+              if (qgic(i,k).ge.1.e-8_r8 .and. qcic(i,k).ge.qsmall .and. t(i,k).le.273.15_r8) then
+
+                  psacwg(k) = cons14*agn(i,k)*qcic(i,k)*rho(i,k)*               &
+                              n0g(k)/                        &
+                              lamg(k)**(bg+3._r8)
+                  npsacwg(k) = cons14*agn(i,k)*ncic(i,k)*rho(i,k)*              &
+                               n0g(k)/                        &
+                               lamg(k)**(bg+3._r8)
+              else
+                  psacwg(k) = 0._r8
+                  npsacwg(k) = 0._r8
+              end if
+!>songxl************************
+
+              !.......................................................................
+              ! accretion of rain water by snow
+              ! formula from ikawa and saito, 1991, used by reisner et al., 1998
+
+              if (qric(i,k).ge.1.e-8_r8 .and. qniic(i,k).ge.1.e-8_r8 .and. & 
+                 t(i,k).le.273.15_r8) then
+
+                 pracs(k) = pi*pi*ecr*(((1.2_r8*umr(k)-0.95_r8*ums(k))**2+ &
+                    0.08_r8*ums(k)*umr(k))**0.5_r8*rhow*rho(i,k)* &
+                    n0r(k)*n0s(k)* &
+                    (5._r8/(lamr(k)**6*lams(k))+ &
+                    2._r8/(lamr(k)**5*lams(k)**2)+ &
+                    0.5_r8/(lamr(k)**4*lams(k)**3)))
+
+                 npracs(k) = pi/2._r8*rho(i,k)*ecr*(1.7_r8*(unr(k)-uns(k))**2+ &
+                    0.3_r8*unr(k)*uns(k))**0.5_r8*n0r(k)*n0s(k)* &
+                    (1._r8/(lamr(k)**3*lams(k))+ &
+                    1._r8/(lamr(k)**2*lams(k)**2)+ &
+                    1._r8/(lamr(k)*lams(k)**3))
+
+!<songxl**********************************
+              ! collection of snow by rain - needed for graupel conversion calculations
+              ! only calculate if snow and rain mixing ratios exceed 0.1 g/kg
+
+                 if (qniic(i,k).ge.0.1e-3_r8.and.qric(i,k).ge.0.1e-3_r8) then
+                   psacr(k) = cons31*(((1.2_r8*umr(k)-0.95_r8*ums(k))**2+              &
+                             0.08_r8*ums(k)*umr(k))**0.5_r8*rho(i,k)*                   &
+                             n0r(k)*n0s(k)/lams(k)**3*                   &
+                             (5._r8/(lams(k)**3*lamr(k))+                    &
+                             2._r8/(lams(k)**2*lamr(k)**2)+                  &
+                             0.5_r8/(lams(k)*lamr(k)**3)))
+                 else
+                   psacr(k) = 0._r8
+                 end if
+
+!>songxl***********************************
+
+              else
+                 pracs(k)=0._r8
+                 npracs(k)=0._r8
+                 psacr(k) = 0._r8
+              end if
+
+!<songxl*********************
+
+              ! conversion of rimed rainwater onto snow converted to graupel
+
+              ! only allow conversion if qni > 0.1 and qr > 0.1 g/kg following rutledge and
+              ! hobbs (1984)
+              if (pracs(k).gt.0._r8 .and. qniic(i,k).ge.0.1e-3_r8.and.qric(i,k).ge.0.1e-3_r8) then
+              ! portion of collected rainwater converted to graupel (reisner et al. 1998)
+                  dum = cons18*(4._r8/lams(k))**3*(4._r8/lams(k))**3 &
+                        /(cons18*(4._r8/lams(k))**3*(4._r8/lams(k))**3+ &
+                        cons19*(4._r8/lamr(k))**3*(4._r8/lamr(k))**3)
+                  dum=min(dum,1._r8)
+                  dum=max(dum,0._r8)
+                  pgracs(k) = (1._r8-dum)*pracs(k)
+                  ngracs(k) = (1._r8-dum)*npracs(k)
+              ! limit max number converted to min of either rain or snow number concentration
+!                  ngracs(k) = min(ngracs(k),nric(i,k)/dt)
+!                  ngracs(k) = min(ngracs(k),nsic(i,k)/dt)
+
+              ! amount left for snow production
+                  pracs(k) = pracs(k) - pgracs(k)
+                  npracs(k) = npracs(k) - ngracs(k)
+              ! conversion to graupel due to collection of snow by rain
+                  psacr(k)=psacr(k)*(1._r8-dum)
+              else
+                  pgracs(k) = 0._r8
+                  ngracs(k) = 0._r8       
+              end if
+
+!.......................................................................
+
+! collection of rainwater by graupel, from ikawa and saito 1990,
+! used by reisner et al 1998
+         if (qric(i,k).ge.1.e-8.and.qgic(i,k).ge.1.e-8) then
+
+!            umg = agn(k)*cons7/(lamg(k)**bg)
+!            umr = arn(k)*cons4/(lamr(k)**br)
+!            ung = agn(k)*cons8/lamg(k)**bg
+!            unr = arn(k)*cons6/lamr(k)**br
+
+! set reaslistic limits on fallspeeds
+! bug fix, 10/08/09
+!            dum=(rhosu/rho(k))**0.54
+!            umg=min(umg,20.*dum)
+!            ung=min(ung,20.*dum)
+!            umr=min(umr,9.1*dum)
+!            unr=min(unr,9.1*dum)
+
+            pracg(k) = cons41*(((1.2_r8*umr(k)-0.95_r8*umg(k))**2+                   &
+                  0.08_r8*umg(k)*umr(k))**0.5_r8*rho(i,k)*                      &
+                  n0r(k)*n0g(k)/lamr(k)**3*                              &
+                  (5._r8/(lamr(k)**3*lamg(k))+                    &
+                  2._r8/(lamr(k)**2*lamg(k)**2)+                              &
+                                  0.5_r8/(lamr(k)*lamg(k)**3)))
+
+            npracg(k) = cons32*rho(i,k)*(1.7_r8*(unr(k)-ung(k))**2+            &
+                0.3_r8*unr(k)*ung(k))**0.5_r8*n0r(k)*n0g(k)*              &
+                (1._r8/(lamr(k)**3*lamg(k))+                      &
+                 1._r8/(lamr(k)**2*lamg(k)**2)+                   &
+                 1._r8/(lamr(k)*lamg(k)**3))
+
+! make sure pracg doesn't exceed total rain mixing ratio
+! as this may otherwise result in too much transfer of water during
+! rime-splintering
+
+!            pracg(k) = min(pracg(k),qr3d(k)/dt)
+            else
+              pracg(k) = 0._r8
+              npracg(k) = 0._r8
+            end if
+
+!.......................................................................
+! rime-splintering - graupel
+! hallet-mossop (1974)
+! number of splinters formed is based on mass of rimed water
+
+! dum1 = mass of individual splinters
+
+! hm add threshold snow mixing ratio for rime-splintering
+! to limit rime-splintering in stratiform clouds
+         
+         fmult = 0._r8
+         nmultg(k) = 0._r8
+         qmultg(k) = 0._r8
+         nmultrg(k) = 0._r8
+         qmultrg(k) = 0._r8
+         if (qgic(i,k).ge.0.1e-3_r8) then
+         if (qcic(i,k).ge.0.5e-3_r8.or.qric(i,k).ge.0.1e-3_r8) then
+         if (psacwg(k).gt.0._r8.or.pracg(k).gt.0._r8) then
+         if((t(i,k).lt.270.16_r8) .and. (t(i,k).ge.265.16_r8))  then
+            if((t(i,k).lt.270.16_r8) .and. (t(i,k).ge.268.16_r8)) &
+               fmult = (270.16_r8-t(i,k))/2._r8
+            if(t(i,k).ge.265.16_r8 .and. t(i,k).lt.268.16_r8)   &
+               fmult = (t(i,k)-265.16_r8)/3._r8
+               
+! 1000 is to convert from kg to g
+! splintering from droplets accreted onto graupel
+
+               if (psacwg(k).gt.0._r8) then
+                  nmultg(k) = 35.e4_r8*psacwg(k)*fmult  
+                  qmultg(k) = nmultg(k)*mmult
+
+! constrain so that transfer of mass from graupel to ice cannot be more mass
+! than was rimed onto graupel
+
+                  qmultg(k) = min(qmultg(k),psacwg(k))
+                  psacwg(k) = psacwg(k)-qmultg(k)
+               end if
+
+! riming and splintering from accreted raindrops
+
+               if (pracg(k).gt.0._r8) then
+                   nmultrg(k) = 35.e4_r8*pracg(k)*fmult
+                   qmultrg(k) = nmultrg(k)*mmult
+
+! constrain so that transfer of mass from graupel to ice cannot be more mass
+! than was rimed onto graupel
+
+                   qmultrg(k) = min(qmultrg(k),pracg(k))
+                   pracg(k) = pracg(k)-qmultrg(k)
+               end if
+            end if
+            end if
+            end if
+            end if
+!>songxl***********************
+
+              !.......................................................................
+              ! heterogeneous freezing of rain drops
+              ! follows from Bigg (1953)
+
+              if (t(i,k).lt.269.15_r8 .and. qric(i,k).ge.qsmall) then
+
+                 mnuccr(k) = 20._r8*pi*pi*rhow*nric(i,k)*bimm* &
+                    (exp(aimm*(273.15_r8-t(i,k)))-1._r8)/lamr(k)**3 &
+                    /lamr(k)**3
+                 
+                 nnuccr(k) = pi*nric(i,k)*bimm* &
+                    (exp(aimm*(273.15_r8-t(i,k)))-1._r8)/lamr(k)**3
+              else
+                 mnuccr(k)=0._r8
+                 nnuccr(k)=0._r8
+              end if
+
+              !.......................................................................
+              ! accretion of cloud liquid water by rain
+              ! formula from Khrouditnov and Kogan (2000)
+              ! gravitational collection kernel, droplet fall speed neglected
+
+              if (qric(i,k).ge.qsmall .and. qcic(i,k).ge.qsmall) then
+!                 pra(k) = 67._r8*(qcic(i,k)*qric(i,k))**1.15_r8
+                 pra(k) = 1.5_r8*67._r8*(qcic(i,k)*qric(i,k))**1.15_r8
+                 npra(k) = pra(k)/(qcic(i,k)/ncic(i,k))
+              else
+                 pra(k)=0._r8
+                 npra(k)=0._r8
+              end if
+
+              !.......................................................................
+              ! Self-collection of rain drops
+              ! from Beheng(1994)
+
+              if (qric(i,k).ge.qsmall) then
+                 nragg(k) = -8._r8*nric(i,k)*qric(i,k)*rho(i,k)
+              else
+                 nragg(k)=0._r8
+              end if
+
+              !.......................................................................
+              ! Accretion of cloud ice by snow
+              ! For this calculation, it is assumed that the Vs >> Vi
+              ! and Ds >> Di for continuous collection
+
+              if (qniic(i,k).ge.qsmall.and.qiic(i,k).ge.qsmall &
+                 .and.t(i,k).le.273.15_r8) then
+                 prai(k) = pi/4._r8*asn(i,k)*qiic(i,k)*rho(i,k)* &
+                    n0s(k)*Eii*gamma(bs+3._r8)/ &
+                    lams(k)**(bs+3._r8)	
+                 nprai(k) = pi/4._r8*asn(i,k)*niic(i,k)* &
+                    rho(i,k)*n0s(k)*Eii*gamma(bs+3._r8)/ &
+                    lams(k)**(bs+3._r8)
+              else
+                 prai(k)=0._r8
+                 nprai(k)=0._r8
+              end if
+
+!.......................................................................
+! hm, add 12/13/06, collision of rain and ice to produce snow or graupel
+! follows reisner et al. 1998
+! assumed fallspeed and size of ice crystal << than for rain
+
+          niacr(k)= 0._r8
+          piacr(k)= 0._r8
+          praci(k)= 0._r8
+          niacrs(k) = 0._r8
+          piacrs(k)= 0._r8
+          pracis(k)= 0._r8 
+         if (qric(i,k).ge.1.e-8_r8.and.qiic(i,k).ge.1.e-8_r8.and.t(i,k).le.273.15_r8) then
+
+! allow graupel formation from rain-ice collisions only if rain mixing ratio >
+! 0.1 g/kg,
+! otherwise add to snow
+
+            if (qric(i,k).ge.0.1e-3_r8) then
+            niacr(k)=cons24*niic(i,k)*n0r(k)*arn(i,k) &
+                /lamr(k)**(br+3._r8)*rho(i,k)
+            piacr(k)=cons25*niic(i,k)*n0r(k)*arn(i,k) &
+                /lamr(k)**(br+3._r8)/lamr(k)**3*rho(i,k)
+            praci(k)=cons24*qiic(i,k)*n0r(k)*arn(i,k)/ &
+                lamr(k)**(br+3._r8)*rho(i,k)
+!            niacr(k)=min(niacr(k),nric(i,k)/dt)
+!            niacr(k)=min(niacr(k),niic(i,k)/dt)
+            else
+            niacrs(k)=cons24*niic(i,k)*n0r(k)*arn(i,k) &
+                /lamr(k)**(br+3._r8)*rho(i,k)
+            piacrs(k)=cons25*niic(i,k)*n0r(k)*arn(i,k) &
+                /lamr(k)**(br+3._r8)/lamr(k)**3*rho(i,k)
+            pracis(k)=cons24*qiic(i,k)*n0r(k)*arn(i,k)/ &
+                lamr(k)**(br+3._r8)*rho(i,k)
+!            niacrs(k)=min(niacrs(k),nric(i,k)/dt)
+!            niacrs(k)=min(niacrs(k),niic(i,k)/dt)
+            end if
+         end if
+!>songxl*****************
+
+              !.......................................................................
+              ! fallout term
+              prf(k)  = -umr(k)*qric(i,k)/dz(i,k)
+              pnrf(k) = -unr(k)*nric(i,k)/dz(i,k)
+              psf(k)  = -ums(k)*qniic(i,k)/dz(i,k)
+              pnsf(k) = -uns(k)*nsic(i,k)/dz(i,k)
+              pgf(k)  = -umg(k)*qgic(i,k)/dz(i,k)
+              pngf(k) = -ung(k)*ngic(i,k)/dz(i,k)
+
+              !........................................................................
+              ! calculate vertical velocity in cumulus updraft
+              
+              if (k.eq.jb(i)) then
+                 zkine(i,jb(i)) = 0.5_r8
+                 wu   (i,jb(i)) = 1._r8
+                 zbuo (i,jb(i)) = (tu(i,jb(i))*(1._r8+retv*qu(i,jb(i)))-    &
+                    th(i,jb(i))*(1._r8+retv*qh(i,jb(i))))/   &
+                    (th(i,jb(i))*(1._r8+retv*qh(i,jb(i))))
+              else
+                 if (.true.) then
+                    ! ECMWF formula
+                    zbc = tu(i,k)*(1._r8+retv*qu(i,k)-qr(i,k)-qni(i,k)-qi(i,k)-qc(i,k))
+                    zbe = th(i,k)*(1._r8+retv*qh(i,k))
+                    zbuo(i,k) = (zbc-zbe)/zbe
+                    zbuoc= (zbuo(i,k)+zbuo(i,k+1))*0.5_r8
+                    zdkbuo = dz(i,k+1)*grav*zfacbuo*zbuoc
+                    zdken = min(.99_r8,(1._r8+cwdrag)*max(du(i,k),eu(i,k))*dz(i,k+1)/      &
+                       max(1.e-10_r8,mu(i,k+1)))
+                    zkine(i,k) = (zkine(i,k+1)*(1._r8-zdken)+zdkbuo)/      &
+                       (1._r8+zdken)
+                 else
+                    ! Gregory formula
+                    zbc = tu(i,k)*(1._r8+retv*qu(i,k))
+                    zbe = th(i,k)*(1._r8+retv*qh(i,k))
+                    zbuo(i,k) = (zbc-zbe)/zbe-qr(i,k)-qni(i,k)-qi(i,k)-qc(i,k)
+                    zbuoc= (zbuo(i,k)+zbuo(i,k+1))*0.5_r8
+                    zdkbuo = dz(i,k+1)*grav*zbuoc*(1.0-0.25)/6.
+                    zdken = du(i,k)*dz(i,k+1)/max(1.e-10_r8,mu(i,k+1))
+                    zkine(i,k) = (zkine(i,k+1)*(1._r8-zdken)+zdkbuo)/      &
+                       (1._r8+zdken)
+                 end if
+                 wu(i,k) = min(15._r8,sqrt(2._r8*max(0.1_r8,zkine(i,k) )))
+              end if
+
+              arcf(i,k)= mu(i,k)/wu(i,k)
+
+              !............................................................................
+              ! droplet activation
+              ! calculate potential for droplet activation if cloud water is present
+              ! formulation from Abdul-Razzak and Ghan (2000) and Abdul-Razzak et al. (1998), AR98
+
+              if (aero%scheme == 'bulk') then
+                 naer2h(i,k,:) = 0.5_r8*(naer2(i,k,:) + naer2(i,k-1,:))
+              end if
+
+              ntaerh(i,k)   = 0.5_r8*(ntaer(i,k) + ntaer(i,k-1))
+
+              if (qcic(i,k).ge.qsmall ) then
+
+                 if (aero%scheme == 'modal') then
+
+                    nlsrc = 0._r8
+
+                    do m = 1, aero%nmodes
+                       vaerosol(m) = 0._r8
+                       hygro(m)    = 0._r8
+                       do l = 1, aero%nspec(m)
+                          vol   = max(0.5_r8*(aero%mmrg_a(i,k,l,m)+aero%mmrg_a(i,k-1,l,m)) , 0._r8)/aero%specdens(l,m)
+                          vaerosol(m) = vaerosol(m) + vol
+                          hygro(m)    = hygro(m) + vol*aero%spechygro(l,m)
+                       end do
+                       if (vaerosol(m) > 1.0e-30_r8) then
+                          hygro(m)    = hygro(m)/(vaerosol(m))
+                          vaerosol(m) = vaerosol(m)*rho(i,k)
+                       else
+                          hygro(m)    = 0.0_r8
+                          vaerosol(m) = 0.0_r8
+                       endif
+                       naermod(m) = 0.5_r8*(aero%numg_a(i,k,m)+aero%numg_a(i,k-1,m))*rho(i,k)
+                       naermod(m) = max(naermod(m), vaerosol(m)*aero%voltonumbhi(m))
+                       naermod(m) = min(naermod(m), vaerosol(m)*aero%voltonumblo(m))
+                    end do
+
+                    in_cloud = (k < jb(i))
+                    smax_f = 0.0_r8
+                    if (in_cloud) then
+                       if ( qcic(i,k).ge.qsmall )           &
+                          smax_f = ncic(i,k)/lamc(i,k) * gamma(2.0_r8 + pgam(i,k))/gamma(1.0_r8 + pgam(i,k))
+                       if ( qric(i,k).ge.qsmall)  smax_f = smax_f + nric(i,k)/lamr(k)
+
+                    end if
+
+                    call actdrop_mam_calc( &
+                       wu(i,k), wmix, wdiab, wmin, wmax,                 &
+                       t(i,k), rho(i,k), naermod, aero%nmodes, vaerosol, &
+                       hygro, in_cloud, smax_f, fn, fm,                  &
+                       fluxn, fluxm, flux_fullact)
+
+                    do m = 1, aero%nmodes
+                       nlsrc = nlsrc + fn(m)*naermod(m)  !  number nucleated
+                    end do
+
+                    if (nlsrc .ne. nlsrc) then
+                      write(iulog,*) "nlsrc=",nlsrc,"wu(i,k)=",wu(i,k)
+                      write(iulog,*) "fn(m)=",fn,"naermod(m)=",naermod,"aero%specdens(l,m)=",aero%specdens
+                      write(iulog,*) "vaerosol(m)=",vaerosol,"aero%voltonumbhi(m)=",aero%voltonumbhi
+                      write(iulog,*) "aero%voltonumblo(m)=",aero%voltonumblo,"k=",k,"i=",i
+                      write(iulog,*) "aero%numg_a(i,k,m)=",aero%numg_a(i,k,:),"rho(i,k)=",rho(i,k)
+                      write(iulog,*) "aero%mmrg_a(i,k,l,m)=",aero%mmrg_a(i,k,:,:)                                    
+                    end if
+
+                    dum2l(i,k) = nlsrc
+
+                 else if (aero%scheme == 'bulk') then
+
+                    call ndrop_bam_run( &
+                       wu(i,k), t(i,k), rho(i,k), naer2h(i,k,:), aero%nbulk, &
+                       aero%nbulk, maerosol, dum2)
+
+                    dum2l(i,k) = dum2
+
+                 end if
+
+              else
+                 dum2l(i,k) = 0._r8
+              end if
+
+              ! get droplet activation rate
+              if (qcic(i,k).ge.qsmall .and. t(i,k).gt.238.15_r8 .and. k.gt.jt(i)+2  ) then
+
+                 ! assume aerosols already activated are equal number of existing droplets for simplicity
+                 if (k.eq.kqc(i))  then
+                    npccn(k) = dum2l(i,k)/deltat
+                 else  
+                    npccn(k) = (dum2l(i,k)-ncic(i,k))/deltat
+                 end if
+
+                 ! make sure number activated > 0
+                 npccn(k) = max(0._r8,npccn(k))
+                 ncmax = dum2l(i,k)
+              else
+                 npccn(k)=0._r8
+                 ncmax = 0._r8
+              end if
+
+              !..............................................................................
+              !ice nucleation
+              es(i,k)  = svp_water(t(i,k))     ! over water in mixed clouds
+              esi(i,k) = svp_ice(t(i,k))     ! over ice
+              qs(i,k) = 0.622_r8*es(i,k)/(ph(i,k) - (1.0_r8-0.622_r8)*es(i,k))
+              qs(i,k) = min(1.0_r8,qs(i,k))
+              if (qs(i,k) < 0.0_r8)  qs(i,k) = 1.0_r8
+
+              relhum(i,k)= 1.0_r8
+
+              if (t(i,k).lt.tmelt ) then
+
+                 ! compute aerosol number for so4, soot, and dust with units #/cm^3
+                 so4_num  = 0._r8
+                 soot_num = 0._r8
+                 dst1_num = 0._r8
+                 dst2_num = 0._r8
+                 dst3_num = 0._r8
+                 dst4_num = 0._r8
+
+                 if (aero%scheme == 'modal') then          
+
+                    !For modal aerosols, assume for the upper troposphere:
+                    ! soot = accumulation mode
+                    ! sulfate = aiken mode
+                    ! dust = coarse mode
+                    ! since modal has internal mixtures.
+                    soot_num = 0.5_r8*(aero%numg_a(i,k-1,aero%mode_accum_idx)             &
+                                      +aero%numg_a(i,k,aero%mode_accum_idx))*rho(i,k)*1.0e-6_r8
+                    dmc  = 0.5_r8*(aero%mmrg_a(i,k-1,aero%coarse_dust_idx,aero%mode_coarse_idx)      &
+                                  +aero%mmrg_a(i,k,aero%coarse_dust_idx,aero%mode_coarse_idx))
+                    ssmc = 0.5_r8*(aero%mmrg_a(i,k-1,aero%coarse_nacl_idx,aero%mode_coarse_idx)      &
+                                  +aero%mmrg_a(i,k,aero%coarse_nacl_idx,aero%mode_coarse_idx))  
+                    if (dmc > 0._r8) then
+                        dst_num = dmc/(ssmc + dmc) *(aero%numg_a(i,k-1,aero%mode_coarse_idx)         & 
+                                  + aero%numg_a(i,k,aero%mode_coarse_idx))*0.5_r8*rho(i,k)*1.0e-6_r8
+                    else 
+                       dst_num = 0.0_r8
+                    end if
+                    dgnum_aitken = 0.5_r8*(aero%dgnumg(i,k,aero%mode_aitken_idx)+   &
+                                           aero%dgnumg(i,k-1,aero%mode_aitken_idx))     
+                    if (dgnum_aitken > 0._r8) then
+                       ! only allow so4 with D>0.1 um in ice nucleation
+                       so4_num  = 0.5_r8*(aero%numg_a(i,k-1,aero%mode_aitken_idx)+          &
+                          aero%numg_a(i,k,aero%mode_aitken_idx))*rho(i,k)*1.0e-6_r8         &
+                          * (0.5_r8 - 0.5_r8*erf(log(0.1e-6_r8/dgnum_aitken)/  &
+                          (2._r8**0.5_r8*log(aero%sigmag_aitken))))
+                    else 
+                       so4_num = 0.0_r8 
+                    end if
+                    so4_num = max(0.0_r8, so4_num)
+
+                 else if (aero%scheme == 'bulk') then          
+
+                    if (aero%idxsul > 0) then 
+                       so4_num = naer2h(i,k,aero%idxsul)/25._r8 *1.0e-6_r8
+                    end if
+                    if (aero%idxbcphi > 0) then 
+                       soot_num = naer2h(i,k,aero%idxbcphi)/25._r8 *1.0e-6_r8
+                    end if
+                    if (aero%idxdst1 > 0) then 
+                       dst1_num = naer2h(i,k,aero%idxdst1)/25._r8 *1.0e-6_r8
+                    end if
+                    if (aero%idxdst2 > 0) then 
+                       dst2_num = naer2h(i,k,aero%idxdst2)/25._r8 *1.0e-6_r8
+                    end if
+                    if (aero%idxdst3 > 0) then 
+                       dst3_num = naer2h(i,k,aero%idxdst3)/25._r8 *1.0e-6_r8
+                    end if
+                    if (aero%idxdst4 > 0) then 
+                       dst4_num = naer2h(i,k,aero%idxdst4)/25._r8 *1.0e-6_r8
+                    end if
+                    dst_num = dst1_num + dst2_num + dst3_num + dst4_num
+
+                 end if
+
+                 ! *** Turn off soot nucleation ***
+                 soot_num = 0.0_r8
+
+                 ! Liu et al.,J. climate, 2007
+                 if ( wu(i,k) .lt. 4.0_r8) then
+                    call nucleati_conv( &
+                       wu(i,k), t(i,k), relhum(i,k), 1.0_r8, qcic(i,k), &
+                       0.0_r8, rho(i,k), so4_num, dst_num, soot_num, .true.,  &
+                       dum2i(i,k), nihf(i,k), niimm(i,k), nidep(i,k), nimey(i,k) )
+                    
+                 end if   
+                 nihf(i,k)=nihf(i,k)*rho(i,k)           !  convert from #/kg -> #/m3)
+                 niimm(i,k)=niimm(i,k)*rho(i,k)
+                 nidep(i,k)=nidep(i,k)*rho(i,k)
+                 nimey(i,k)=nimey(i,k)*rho(i,k)
+
+                 if (.false.) then
+                    ! cooper curve (factor of 1000 is to convert from L-1 to m-3)
+                    !dum2i(i,k)=0.005_r8*exp(0.304_r8*(273.15_r8-t(i,k)))*1000._r8
+
+                    ! put limit on number of nucleated crystals, set to number at T=-30 C
+                    ! cooper (limit to value at -35 C)
+                    !dum2i(i,k)=min(dum2i(i,k),208.9e3_r8)/rho(i,k) ! convert from m-3 to kg-1
+                 end if
+
+              else
+                 dum2i(i,k)=0._r8
+              end if
+
+              ! ice nucleation if activated nuclei exist at t<0C 
+
+              if (dum2i(i,k).gt.0._r8.and.t(i,k).lt.tmelt.and. &
+                 relhum(i,k)*es(i,k)/esi(i,k).gt. 1.05_r8  .and. k.gt.jt(i)+1) then
+
+                 if (k.eq.kqi(i)) then
+                    nnuccd(k)=dum2i(i,k)/deltat
+                 else
+                    nnuccd(k)=(dum2i(i,k)-niic(i,k))/deltat
+                 end if
+                 nnuccd(k)=max(nnuccd(k),0._r8)
+
+                 !Calc mass of new particles using new crystal mass...
+                 !also this will be multiplied by mtime as nnuccd is...
+
+                 mnuccd(k) = nnuccd(k) * mi0
+              else
+                 nnuccd(k)=0._r8
+                 mnuccd(k) = 0._r8
+              end if
+
+              !................................................................................
+              ! Bergeron process
+              ! If 0C< T <-40C and both ice and liquid exist
+              if (.false.) then
+              if (t(i,k).le.273.15_r8 .and. t(i,k).gt.233.15_r8 .and.  &
+                 qiic(i,k).gt.0.5e-6_r8 .and. qcic(i,k).gt. qsmall)  then
+                 plevap = qcic(i,k)/bergtsf
+                 prb(k) = max(0._r8,plevap) 
+                 nprb(k) = prb(k)/(qcic(i,k)/ncic(i,k))
+              else
+                 prb(k)=0._r8
+                 nprb(k)=0._r8
+              end if
+              else
+              !  Rotstayn et al.(2000)  
+              if (t(i,k).le.273.15_r8 .and. t(i,k).gt.233.15_r8 .and.  &
+                 qiic(i,k).gt.0.5e-6_r8 .and. qcic(i,k).gt. qsmall)  then
+              ! Eqs.(3) and (4)                  
+                 a_prime = Ls_b*(Ls_b/(Rv_b*t(i,k))-1._r8)/(Ka_b*t(i,k))
+                 b_prime = Rv_b*t(i,k)*ph(i,k)/(2.21_r8*esi(i,k)) 
+              ! In Rotstayn et al.(2000), Ni is in units of #/m3. Since here nicc is in
+              ! units of #/kg, we do not need to calculate Ni/rho.
+              ! sphere     
+!                 csvd    = 7.8_r8*niic(i,k)**c23*(es(i,k)-esi(i,k))/   &
+!                           (rhoi13*(a_prime+b_prime)*esi(i,k))              
+!                 dqi     = max(0._r8,(c23*csvd*deltat+qiic(i,k)**c23)**1.5_r8-qiic(i,k))
+              !  plate
+                 cpvd    = 65.2_r8*niic(i,k)**0.5_r8*(es(i,k)-esi(i,k))/   &
+                           ((a_prime+b_prime)*esi(i,k))
+                 dqi     = max(0._r8,(0.5_r8*cpvd*deltat+qiic(i,k)**0.5_r8)**2._r8-qiic(i,k))
+                 prb(k)  = min(qcic(i,k),dqi)/deltat
+              ! decrease in droplet number concentration
+                 nprb(k) = prb(k)/(qcic(i,k)/ncic(i,k))
+              else
+                 prb(k)=0._r8
+                 nprb(k)=0._r8
+              end if
+              end if           
+
+              !................................................................................
+              ! heterogeneous freezing of cloud water (-5C < T < -35C)
+
+              if (qcic(i,k).ge.qsmall .and.ncic(i,k).gt.0._r8 .and. ntaerh(i,k).gt.0._r8 .and.  &
+                 t(i,k).le.268.15_r8 .and. t(i,k).gt.238.15_r8 ) then
+
+                 if (aero%scheme == 'bulk')  then
+                    ! immersion freezing (Diehl and Wurzler, 2004)
+                    ttend(k) = -grav*wu(i,k)/cp/(1.0_r8+gamhat(i,k))
+
+                    nai_bcphi = 0.0_r8
+                    nai_dst1  = 0.0_r8
+                    nai_dst2  = 0.0_r8
+                    nai_dst3  = 0.0_r8
+                    nai_dst4  = 0.0_r8
+
+                    if (aero%idxbcphi > 0) nai_bcphi = naer2h(i,k,aero%idxbcphi)
+                    if (aero%idxdst1  > 0) nai_dst1  = naer2h(i,k,aero%idxdst1)
+                    if (aero%idxdst2  > 0) nai_dst2  = naer2h(i,k,aero%idxdst2)
+                    if (aero%idxdst3  > 0) nai_dst3  = naer2h(i,k,aero%idxdst3)
+                    if (aero%idxdst4  > 0) nai_dst4  = naer2h(i,k,aero%idxdst4)
+
+                    naimm = (0.00291_r8*nai_bcphi + 32.3_r8*(nai_dst1 + nai_dst2 + &
+                       nai_dst3 + nai_dst4))/ntaerh(i,k)             !m-3
+                    if (ttend(k) .lt. 0._r8) then
+                       nnuccc(k) = -naimm*exp(273.15_r8-t(i,k))*ttend(k)*qcic(i,k)/rhow   ! kg-1s-1                        
+                       mnuccc(k) = nnuccc(k)*qcic(i,k)/ncic(i,k)
+                    end if
+                 else   
+                    if (.false.) then
+                       ! immersion freezing (Diehl and Wurzler, 2004)
+                       ttend(k) = -grav*wu(i,k)/cp/(1.0_r8+gamhat(i,k))
+                       naimm = (0.00291_r8*soot_num + 32.3_r8*dst_num )*1.0e6_r8/ntaerh(i,k)             !m-3
+                       if (ttend(k) .lt. 0._r8) then
+                          nnuccc(k) = -naimm*exp(273.15_r8-t(i,k))*ttend(k)*qcic(i,k)/rhow   ! kg-1s-1
+                          mnuccc(k) = nnuccc(k)*qcic(i,k)/ncic(i,k)
+                       end if
+                    else
+                       ! immersion freezing (Bigg, 1953)
+                       mnuccc(k) = pi*pi/36._r8*rhow* &
+                       cdist1(k)*gamma(7._r8+pgam(i,k))* &
+                       bimm*(exp(aimm*(273.15_r8-t(i,k)))-1._r8)/ &
+                       lamc(i,k)**3/lamc(i,k)**3
+
+                       nnuccc(k) = pi/6._r8*cdist1(k)*gamma(pgam(i,k)+4._r8) &
+                           *bimm*(exp(aimm*(273.15_r8-t(i,k)))-1._r8)/lamc(i,k)**3
+                    end if
+                 end if
+
+                 ! contact freezing (Young, 1974) with hooks into simulated dust
+
+                 tcnt=(270.16_r8-t(i,k))**1.3_r8
+                 viscosity=1.8e-5_r8*(t(i,k)/298.0_r8)**0.85_r8    ! Viscosity (kg/m/s)          
+                 mfp=2.0_r8*viscosity/(ph(i,k)  &                  ! Mean free path (m)
+                    *sqrt(8.0_r8*28.96e-3_r8/(pi*8.314409_r8*t(i,k))))
+
+                 slip1=1.0_r8+(mfp/rn_dst1)*(1.257_r8+(0.4_r8*Exp(-(1.1_r8*rn_dst1/mfp))))! Slip correction factor
+                 slip2=1.0_r8+(mfp/rn_dst2)*(1.257_r8+(0.4_r8*Exp(-(1.1_r8*rn_dst2/mfp))))
+                 slip3=1.0_r8+(mfp/rn_dst3)*(1.257_r8+(0.4_r8*Exp(-(1.1_r8*rn_dst3/mfp))))
+                 slip4=1.0_r8+(mfp/rn_dst4)*(1.257_r8+(0.4_r8*Exp(-(1.1_r8*rn_dst4/mfp))))
+                 
+                 dfaer1=1.381e-23_r8*t(i,k)*slip1/(6._r8*pi*viscosity*rn_dst1)  ! aerosol diffusivity (m2/s)
+                 dfaer2=1.381e-23_r8*t(i,k)*slip2/(6._r8*pi*viscosity*rn_dst2)
+                 dfaer3=1.381e-23_r8*t(i,k)*slip3/(6._r8*pi*viscosity*rn_dst3)
+                 dfaer4=1.381e-23_r8*t(i,k)*slip4/(6._r8*pi*viscosity*rn_dst4)
+
+                 nacon1=0.0_r8
+                 nacon2=0.0_r8
+                 nacon3=0.0_r8
+                 nacon4=0.0_r8
+
+                 if (aero%scheme == 'modal') then
+
+                    ! For modal aerosols:
+                    !  use size '3' for dust coarse mode...
+                    !  scale by dust fraction in coarse mode
+
+                    dmc  = 0.5_r8*(aero%mmrg_a(i,k,aero%coarse_dust_idx,aero%mode_coarse_idx)     &
+                                  +aero%mmrg_a(i,k-1,aero%coarse_dust_idx,aero%mode_coarse_idx))
+                    ssmc = 0.5_r8*(aero%mmrg_a(i,k,aero%coarse_nacl_idx,aero%mode_coarse_idx)     &
+                                  +aero%mmrg_a(i,k-1,aero%coarse_nacl_idx,aero%mode_coarse_idx)) 
+                    if (dmc > 0.0_r8) then
+                        nacon3 = dmc/(ssmc + dmc) * (aero%numg_a(i,k,aero%mode_coarse_idx)     &
+                                 + aero%numg_a(i,k-1,aero%mode_coarse_idx))*0.5_r8*rho(i,k)
+                    end if
+
+                 else if (aero%scheme == 'bulk') then
+
+                    if (aero%idxdst1.gt.0) then
+                       nacon1=naer2h(i,k,aero%idxdst1)*tcnt *0.0_r8
+                    endif
+                    if (aero%idxdst2.gt.0) then
+                       nacon2=naer2h(i,k,aero%idxdst2)*tcnt ! 1/m3
+                    endif
+                    if (aero%idxdst3.gt.0) then
+                       nacon3=naer2h(i,k,aero%idxdst3)*tcnt
+                    endif
+                    if (aero%idxdst4.gt.0) then
+                       nacon4=naer2h(i,k,aero%idxdst4)*tcnt
+                    endif
+                 end if
+
+                 mnucct(k) = (dfaer1*nacon1+dfaer2*nacon2+dfaer3*nacon3+dfaer4*nacon4)*pi*pi/3._r8*rhow* &
+                    cdist1(k)*gamma(pgam(i,k)+5._r8)/lamc(i,k)**4
+
+                 nnucct(k) = (dfaer1*nacon1+dfaer2*nacon2+dfaer3*nacon3+dfaer4*nacon4)*2._r8*pi*  &
+                    cdist1(k)*gamma(pgam(i,k)+2._r8)/lamc(i,k)
+
+                 !              if (nnuccc(k).gt.nnuccd(k)) then
+                 !                 dum=nnuccd(k)/nnuccc(k)
+                 ! scale mixing ratio of droplet freezing with limit
+                 !                 mnuccc(k)=mnuccc(k)*dum
+                 !                 nnuccc(k)=nnuccd(k)
+                 !              end if
+ 
+              else
+                 mnuccc(k) = 0._r8
+                 nnuccc(k) = 0._r8
+                 mnucct(k) = 0._r8
+                 nnucct(k) = 0._r8
+              end if
+
+              ! freeze cloud liquid water homogeneously at -40 C
+              if (t(i,k) < 233.15_r8 .and. qc(i,k) > 0._r8) then
+
+                 ! make sure freezing rain doesn't increase temperature above
+                 ! threshold
+                 dum = xlf/cp*qc(i,k)
+                 if (t(i,k)+dum.gt.233.15_r8) then
+                    dum = -(t(i,k)-233.15_r8)*cp/xlf
+                    dum = dum/qc(i,k)
+                    dum = max(0._r8,dum)
+                    dum = min(1._r8,dum)
+                 else
+                    dum = 1._r8
+                 end if
+                 fholm(i,k) = mu(i,k)*dum*qc(i,k)
+                 fholn(i,k) = mu(i,k)*dum*nc(i,k)
+               end if
+
+
+              !****************************************************************************************
+              ! conservation to ensure no negative values of cloud water/precipitation
+              ! in case microphysical process rates are large
+              ! note: for check on conservation, processes are multiplied by omsm
+              ! to prevent problems due to round off error
+
+              ! since activation/nucleation processes are fast, need to take into account
+              ! factor mtime = mixing timescale in cloud / model time step
+              ! for now mixing timescale is assumed to be 15 min
+              !*****************************************************************************************
+
+              mtime=deltat/900._r8
+              mtimec=deltat/900._r8
+
+              ! conservation of qc
+              ! ice mass production from ice nucleation(deposition/cond.-freezing), mnuccd, 
+              ! is considered as a part of cmei.
+                            
+              qce = mu(i,k)*qc(i,k)-fholm(i,k) +dz(i,k)*cmel(i,k-1)
+              dum = arcf(i,k)*(pra(k)+prc(k)+prb(k)+mnuccc(k)+mnucct(k)+msacwi(k)+   &
+                               psacws(k)+psacwg(k)+pgsacw(k) +qmultg(k)+psacwi(k) )*dz(i,k)
+!                               psacws(k))*dz(i,k)
+              if( qce.lt.0._r8)  then
+                 qcimp(k) = .true.              
+                 prc(k) = 0._r8
+                 pra(k) = 0._r8
+                 prb(k) = 0._r8
+                 mnuccc(k) = 0._r8
+                 mnucct(k) = 0._r8
+                 msacwi(k) = 0._r8
+                 psacws(k) = 0._r8
+                 psacwg(k) = 0._r8
+                 pgsacw(k) = 0._r8
+                 qmultg(k) = 0._r8
+                 psacwi(k) = 0._r8
+              else  if (dum.gt.qce) then
+                 ratio = qce/dum*omsm
+                 prc(k) = prc(k)*ratio
+                 pra(k) = pra(k)*ratio
+                 prb(k) = prb(k)*ratio
+                 mnuccc(k) = mnuccc(k)*ratio
+                 mnucct(k) = mnucct(k)*ratio  
+                 msacwi(k) = msacwi(k)*ratio  
+                 psacws(k) = psacws(k)*ratio 
+                 psacwg(k) = psacwg(k)*ratio
+                 pgsacw(k) = pgsacw(k)*ratio 
+                 qmultg(k) = qmultg(k)*ratio
+                 psacwi(k) = psacwi(k)*ratio
+              end if
+
+              ! conservation of nc
+              nce = mu(i,k)*nc(i,k)-fholn(i,k) + (arcf(i,k)*npccn(k)*mtimec)*dz(i,k)
+              dum = arcf(i,k)*dz(i,k)*(nprc1(k)+npra(k)+nnuccc(k)+nnucct(k)           &
+                     + npsacws(k)+ nprb(k)+npsacwg(k)+npsacwi(k) )              
+              if (nce.lt.0._r8) then
+                 ncimp(k) = .true.
+                 nprc1(k) = 0._r8
+                 npra(k) = 0._r8
+                 nnuccc(k) = 0._r8
+                 nnucct(k) = 0._r8
+                 npsacws(k) = 0._r8
+                 nprb(k) = 0._r8   
+                 npsacwg(k)= 0._r8 
+                 npsacwi(k) = 0._r8                              
+              else if (dum.gt.nce) then
+                 ratio = nce/dum*omsm 
+                 nprc1(k) = nprc1(k)*ratio
+                 npra(k) = npra(k)*ratio
+                 nnuccc(k) = nnuccc(k)*ratio
+                 nnucct(k) = nnucct(k)*ratio  
+                 npsacws(k) = npsacws(k)*ratio
+                 nprb(k) = nprb(k)*ratio                           
+                 npsacwg(k)= npsacwg(k)*ratio
+                 npsacwi(k)=npsacwi(k)*ratio
+              end if
+ 
+              ! conservation of qi
+!              qie = mu(i,k)*qi(i,k)+fholm(i,k) +dz(i,k)*(cmei(i,k-1) +  &
+!                    ( mnuccc(k)+mnucct(k)+msacwi(k)+prb(k)+qmultg(k)+qmultrg(k)+psacwi(k))*arcf(i,k) )
+!              dum = arcf(i,k)*(prci(k)+ prai(k)+praci(k)+pracis(k))*dz(i,k) 
+!!              dum = arcf(i,k)*(prci(k)+ prai(k))*dz(i,k)
+!              if (qie.lt.0._r8) then
+!                 qiimp(k) = .true.
+!                 prci(k) = 0._r8
+!                 prai(k) = 0._r8
+!                 praci(k)= 0._r8
+!                 pracis(k)= 0._r8
+!              else if (dum.gt.qie) then
+!                 ratio = qie/dum*omsm
+!                 prci(k) = prci(k)*ratio
+!                 prai(k) = prai(k)*ratio
+!                 praci(k)= praci(k)*ratio
+!                 pracis(k) = pracis(k)*ratio
+!              end if
+
+              ! conservation of ni
+!              nie = mu(i,k)*ni(i,k)+fholn(i,k) +dz(i,k)*(nnuccd(k)*mtime*arcf(i,k)   &
+!                    +(nnuccc(k)+ nnucct(k)+nmultg(k)+ nmultrg(k))*arcf(i,k) )
+!              dum = arcf(i,k)*dz(i,k)*(-nsacwi(k)+nprci(k)+ nprai(k)+niacr(k)+niacrs(k))
+!!              dum = arcf(i,k)*dz(i,k)*(-nsacwi(k)+nprci(k)+ nprai(k))
+!              if( nie.lt.0._r8) then
+!                 niimp(k) = .true.
+!                 nsacwi(k)= 0._r8
+!                 nprci(k) = 0._r8
+!                 nprai(k) = 0._r8
+!                 niacr(k) = 0._r8
+!                 niacrs(k)= 0._r8
+!              else  if (dum.gt.nie) then
+!                 ratio = nie/dum*omsm
+!                 nsacwi(k)= nsacwi(k)*ratio
+!                 nprci(k) = nprci(k)*ratio
+!                 nprai(k) = nprai(k)*ratio
+!                 niacr(k) = niacr(k)*ratio
+!                 niacrs(k)=niacrs(k)*ratio
+!              end if
+
+              ! conservation of qr
+
+              qre = mu(i,k)*qr(i,k)+dz(i,k)*(pra(k)+prc(k))*arcf(i,k)
+              dum = arcf(i,k)*dz(i,k)*(pracs(k)+ mnuccr(k)-prf(k)+pracg(k)+pgracs(k)    &
+                            +piacr(k)+piacrs(k)+qmultrg(k) ) 
+!              dum = arcf(i,k)*dz(i,k)*(pracs(k)+ mnuccr(k)-prf(k)) 
+
+              if (qre.lt.0._r8) then
+                 prf(k) = 0._r8
+                 pracs(k) = 0._r8
+                 mnuccr(k) = 0._r8
+                 pracg(k) = 0._r8
+                 pgracs(k)= 0._r8
+                 piacr(k) = 0._r8
+                 piacrs(k)= 0._r8
+                 qmultrg(k)=0._r8  
+              else if (dum.gt.qre) then
+                 ratio = qre/dum*omsm
+                 prf(k) = prf(k)*ratio
+                 pracs(k) = pracs(k)*ratio
+                 mnuccr(k) = mnuccr(k)*ratio
+                 pracg(k) = pracg(k)*ratio 
+                 pgracs(k)= pgracs(k)*ratio
+                 piacr(k) = piacr(k)*ratio 
+                 piacrs(k)= piacrs(k)*ratio
+                 qmultrg(k)=qmultrg(k)*ratio
+              end if
+
+              ! conservation of nr
+              nre = mu(i,k)*nr(i,k) + nprc(k)*arcf(i,k)*dz(i,k)
+              dum = arcf(i,k)*dz(i,k)*(npracs(k)+nnuccr(k) &
+                       -nragg(k)-pnrf(k)+niacr(k)+niacrs(k)+ npracg(k)-ngracs(k) )
+              if(nre.lt.0._r8) then
+                 npracs(k)= 0._r8
+                 nnuccr(k)= 0._r8
+                 nragg(k) = 0._r8
+                 pnrf(k) = 0._r8
+                 niacr(k) = 0._r8
+                 niacrs(k)= 0._r8
+                 npracg(k)= 0._r8
+                 ngracs(k)= 0._r8  
+              else if (dum.gt.nre) then
+                 ratio = nre/dum*omsm
+                 npracs(k)= npracs(k)*ratio
+                 nnuccr(k)= nnuccr(k)*ratio
+                 nragg(k) = nragg(k)*ratio
+                 pnrf(k) = pnrf(k)*ratio
+                 niacr(k) = niacr(k)*ratio
+                 niacrs(k)=niacrs(k)*ratio
+                 npracg(k)=npracg(k)*ratio
+                 ngracs(k)=ngracs(k)*ratio
+              end if
+
+              ! conservation of qi
+              qie = mu(i,k)*qi(i,k)+fholm(i,k) +dz(i,k)*(cmei(i,k-1) +  &
+                    (mnuccc(k)+mnucct(k)+msacwi(k)+prb(k)+qmultg(k)+qmultrg(k)+psacwi(k))*arcf(i,k) )
+              dum = arcf(i,k)*(prci(k)+ prai(k)+praci(k)+pracis(k))*dz(i,k)
+              if (qie.lt.0._r8) then
+                 qiimp(k) = .true.
+                 prci(k) = 0._r8
+                 prai(k) = 0._r8
+                 praci(k)= 0._r8
+                 pracis(k)= 0._r8
+              else if (dum.gt.qie) then
+                 ratio = qie/dum*omsm
+                 prci(k) = prci(k)*ratio
+                 prai(k) = prai(k)*ratio
+                 praci(k)= praci(k)*ratio
+                 pracis(k) = pracis(k)*ratio
+              end if
+
+              ! conservation of ni
+              nie = mu(i,k)*ni(i,k)+fholn(i,k) +dz(i,k)*(nnuccd(k)*mtime*arcf(i,k)   &
+                    +(nnuccc(k)+ nnucct(k)+nmultg(k)+ nmultrg(k))*arcf(i,k) )
+              dum = arcf(i,k)*dz(i,k)*(-nsacwi(k)+nprci(k)+ nprai(k)+niacr(k)+niacrs(k))
+              if( nie.lt.0._r8) then
+                 niimp(k) = .true.
+                 nsacwi(k)= 0._r8
+                 nprci(k) = 0._r8
+                 nprai(k) = 0._r8
+                 niacr(k) = 0._r8
+                 niacrs(k)= 0._r8
+              else  if (dum.gt.nie) then
+                 ratio = nie/dum*omsm
+                 nsacwi(k)= nsacwi(k)*ratio     
+                 nprci(k) = nprci(k)*ratio
+                 nprai(k) = nprai(k)*ratio
+                 niacr(k) = niacr(k)*ratio
+                 niacrs(k)=niacrs(k)*ratio
+              end if
+                                                                              
+              ! conservation of qni
+
+!              qnie = mu(i,k)*qni(i,k)+dz(i,k)*( (prai(k)+psacws(k)+prci(k)+     &
+!                 pracs(k)+mnuccr(k))*arcf(i,k) )
+!              dum = arcf(i,k)*dz(i,k)*(-psf(k))
+              qnie = mu(i,k)*qni(i,k)+dz(i,k)*( (prai(k)+psacws(k)+prci(k)+     &
+                     pracs(k)+piacrs(k)+pracis(k) )*arcf(i,k) )
+              dum = arcf(i,k)*dz(i,k)*(-psf(k)+ psacr(k) )
+
+              if(qnie.lt.0._r8) then
+                 psf(k) = 0._r8
+                 psacr(k) = 0._r8
+              else if (dum.gt.qnie) then
+                 ratio = qnie/dum*omsm
+                 psf(k) = psf(k)*ratio
+                 psacr(k)= psacr(k)*ratio 
+              end if
+
+              ! conservation of ns
+!              nse = mu(i,k)*ns(i,k)+dz(i,k)*(nprci(k)+nnuccr(k))*arcf(i,k)
+!              dum = arcf(i,k)*dz(i,k)*(-nsagg(k)-pnsf(k))
+              nse = mu(i,k)*ns(i,k)+dz(i,k)*(nprci(k)+niacrs(k))*arcf(i,k)
+              dum = arcf(i,k)*dz(i,k)*(-nsagg(k)-pnsf(k)+nscng(k)+ngracs(k))
+              if (nse.lt.0._r8) then
+                 nsagg(k) = 0._r8
+                 pnsf(k) = 0._r8
+                 nscng(k) = 0._r8
+                 ngracs(k) = 0._r8
+              else if (dum.gt.nse) then
+                 ratio = nse/dum*omsm
+                 nsagg(k) = nsagg(k)*ratio
+                 pnsf(k) = pnsf(k)*ratio
+                 nscng(k) = nscng(k)*ratio
+                 ngracs(k) = ngracs(k)*ratio 
+              end if
+
+              ! conservation of qg
+
+              qge = mu(i,k)*qg(i,k)+dz(i,k)*(pracg(k)+psacwg(k)+pgsacw(k)     &
+                     +pgracs(k)+mnuccr(k)+piacr(k)+praci(k)+psacr(k))*arcf(i,k) 
+
+              dum = arcf(i,k)*dz(i,k)*(-pgf(k))
+
+              if(qge.lt.0._r8) then
+                 pgf(k) = 0._r8
+              else if (dum.gt.qge) then
+                 ratio = qge/dum*omsm
+                 pgf(k) = pgf(k)*ratio
+              end if
+
+              ! conservation of ng
+              nge = mu(i,k)*ng(i,k)+dz(i,k)*(nscng(k)+ngracs(k)+nnuccr(k)+niacr(k))*arcf(i,k)
+              dum = arcf(i,k)*dz(i,k)*(-pngf(k))
+              if (nge.lt.0._r8) then
+                 pngf(k) = 0._r8
+              else if (dum.gt.nge) then
+                 ratio = nge/dum*omsm
+                 pngf(k) = pngf(k)*ratio
+              end if
+ 
+
+              !*****************************************************************************
+              ! get tendencies due to microphysical conversion processes
+              !*****************************************************************************
+
+              if (k.le.kqc(i))   then
+!                 qctend(i,k) = (-pra(k)-prc(k)-prb(k)-mnuccc(k)-mnucct(k)-msacwi(k)- &   
+!                                psacws(k))
+                 qctend(i,k) = (-pra(k)-prc(k)-prb(k)-mnuccc(k)-mnucct(k)-msacwi(k)- &
+                                psacws(k))-psacwg(k) -pgsacw(k) -qmultg(k)-psacwi(k)
+
+!                 qitend(i,k) = (prb(k)+mnuccc(k)+mnucct(k)+msacwi(k)-prci(k)- prai(k))
+                 qitend(i,k) = (prb(k)+mnuccc(k)+mnucct(k)+msacwi(k)-prci(k)- prai(k))  &
+                                -praci(k)-pracis(k)+qmultg(k)+ qmultrg(k)+psacwi(k) 
+
+!                qrtend(i,k) = (pra(k)+prc(k))+(-pracs(k)- mnuccr(k))
+                 qrtend(i,k) = pra(k)+prc(k)-pracs(k)-mnuccr(k)-pracg(k)-pgracs(k)  &
+                               -piacr(k)-piacrs(k) -qmultrg(k) 
+
+!                qnitend(i,k) = (prai(k)+psacws(k)+prci(k))+(pracs(k)+mnuccr(k))
+                 qnitend(i,k) = (prai(k)+psacws(k)+prci(k))+pracs(k)-psacr(k)+piacrs(k)   &
+                                 +pracis(k)
+                 
+                 qgtend(i,k) = (pracg(k)+psacwg(k)+pgsacw(k)+pgracs(k)+ &
+                                +mnuccr(k)+piacr(k)+praci(k)+psacr(k))
+
+                 if ((qnitend(i,k)+qrtend(i,k)+qgtend(i,k))<0._r8) then
+                    dum = (qnitend(i,k)+qrtend(i,k)+qgtend(i,k))/omsm
+                    qrtend(i,k) = qrtend(i,k) - dum
+                    qmultrg(k) = qmultrg(k) + dum
+                    qitend(i,k) = qitend(i,k) + dum
+                 end if
+
+                 ! multiply activation/nucleation by mtime to account for fast timescale
+
+                 nctend(i,k) = npccn(k)*mtimec+(-nnuccc(k)-nnucct(k)-npsacws(k) &    
+                               -npra(k)-nprc1(k)-nprb(k)- npsacwg(k)-npsacwi(k))                           
+!                              -npra(k)-nprc1(k)-nprb(k))
+
+                 nitend(i,k) = nnuccd(k)*mtime+(nnuccc(k)+ nnucct(k)+nsacwi(k)-nprci(k)- &
+                               nprai(k)) - niacr(k)-niacrs(k)+nmultg(k)+ nmultrg(k) 
+!                               nprai(k))
+
+!                 nstend(i,k) = nsagg(k)+nnuccr(k) + nprci(k)
+                 nstend(i,k) = nsagg(k) + nprci(k)- nscng(k)-ngracs(k)+niacrs(k) 
+
+                 nrtend(i,k) = nprc(k)+(-npracs(k)-nnuccr(k) +nragg(k))-niacr(k)-niacrs(k)  &
+                               -npracg(k)-ngracs(k)
+
+                 ngtend(i,k) = (nscng(k)+ngracs(k)+nnuccr(k)+niacr(k))
+
+                 ! for output
+                 ! cloud liquid water-------------
+
+                 autolm(i,k-1) = -prc(k)*arcf(i,k)
+                 accrlm(i,k-1) = -pra(k)*arcf(i,k)
+                 bergnm(i,k-1) = -prb(k)*arcf(i,k)
+                 fhtimm(i,k-1) = -mnuccc(k)*arcf(i,k)
+                 fhtctm(i,k-1) = -mnucct(k)*arcf(i,k)
+                 hmpim (i,k-1) = -msacwi(k)*arcf(i,k)
+                 accslm(i,k-1) = -psacws(k)*arcf(i,k)
+                 fhmlm(i,k-1)  = -fholm(i,k)/dz(i,k)
+
+                 autoln(i,k-1) = -nprc1(k)*arcf(i,k)
+                 accrln(i,k-1) = -npra(k)*arcf(i,k)
+                 bergnn(i,k-1) = -nprb(k)*arcf(i,k)
+                 fhtimn(i,k-1) = -nnuccc(k)*arcf(i,k)
+                 fhtctn(i,k-1) = -nnucct(k)*arcf(i,k)
+                 accsln(i,k-1) = -npsacws(k)*arcf(i,k)
+                 activn(i,k-1) = npccn(k)*mtimec*arcf(i,k)
+                 fhmln(i,k-1)  = -fholn(i,k)/dz(i,k)
+                 
+                 !cloud ice------------------------
+
+                 autoim(i,k-1) = -prci(k)*arcf(i,k)
+                 accsim(i,k-1) = -prai(k)*arcf(i,k)
+
+                 nuclin(i,k-1) = nnuccd(k)*mtime*arcf(i,k)
+                 autoin(i,k-1) = -nprci(k)*arcf(i,k)
+                 accsin(i,k-1) = -nprai(k)*arcf(i,k)
+                 hmpin (i,k-1) = nsacwi(k)*arcf(i,k)
+
+                 accgrm(i,k-1) = -pracg(k)*arcf(i,k)    !rain
+                 accglm(i,k-1) = -psacwg(k)*arcf(i,k)   !droplet
+                 accgslm(i,k-1)= -pgsacw(k)*arcf(i,k)   !droplet 
+                 accgsrm(i,k-1)= -pgracs(k)*arcf(i,k)   !rain
+                 accgirm(i,k-1)= -piacr(k)*arcf(i,k)    !rain 
+                 accgrim(i,k-1)= -praci(k)*arcf(i,k)    !ice 
+                 accgrsm(i,k-1)= -psacr(k)*arcf(i,k)    !snow 
+
+                 accgsln(i,k-1)= -nscng(k)*arcf(i,k)    !snow
+                 accgsrn(i,k-1)= -ngracs(k)*arcf(i,k)   !snow, rain
+                 accgirn(i,k-1)= -niacr(k)*arcf(i,k)    !ice ,rain
+
+                 accsrim(i,k-1)= -pracis(k)*arcf(i,k)   !ice
+                 acciglm(i,k-1)= -qmultg(k)*arcf(i,k)   !droplet
+                 accigrm(i,k-1)= qmultrg(k)*arcf(i,k)   !ice
+                 accsirm(i,k-1)= -piacrs(k)*arcf(i,k)   !rain
+
+                 accigln(i,k-1)= nmultg(k)*arcf(i,k)    !ice
+                 accigrn(i,k-1)= nmultrg(k)*arcf(i,k)   !ice
+                 accsirn(i,k-1)= -niacrs(k)*arcf(i,k)   !ice,rain
+                 accgln(i,k-1) = -npsacwg(k)*arcf(i,k)  !droplet 
+                 accgrn(i,k-1) = -npracg(k)*arcf(i,k)   !rain
+
+                 accilm(i,k-1) = -psacwi(k)*arcf(i,k)   !droplet  
+                 acciln(i,k-1) = -npsacwi(k)*arcf(i,k)  !droplet
+
+                 fallrm(i,k-1) = prf(k)*arcf(i,k)       !rain
+                 fallsm(i,k-1) = psf(k)*arcf(i,k)       !snow
+                 fallgm(i,k-1) = pgf(k)*arcf(i,k)       !graupel                 
+                 fallrn(i,k-1) = pnrf(k)*arcf(i,k)       !rain
+                 fallsn(i,k-1) = pnsf(k)*arcf(i,k)       !snow
+                 fallgn(i,k-1) = pngf(k)*arcf(i,k)       !graupel
+              else
+                 qctend(i,k) = 0._r8
+                 qitend(i,k) = 0._r8
+                 qrtend(i,k) = 0._r8
+                 qnitend(i,k) = 0._r8
+                 qgtend(i,k) = 0._r8
+                 nctend(i,k) = 0._r8
+                 nitend(i,k) = 0._r8
+                 nstend(i,k) = 0._r8
+                 nrtend(i,k) = 0._r8
+                 ngtend(i,k) = 0._r8
+              end if
+
+              !********************************************************************************
+              !  vertical integration
+              !********************************************************************************
+              ! graupel
+              if ( k.le.kqi(i) ) then
+                 qg(i,k-1) = 1._r8/mu(i,k-1)*                                       &
+                    (mu(i,k)*qg(i,k)+dz(i,k)*(qgtend(i,k)+pgf(k))*arcf(i,k) )
+
+                 ng(i,k-1) = 1._r8/mu(i,k-1)*                                        &
+                    (mu(i,k)*ng(i,k)+dz(i,k)*(ngtend(i,k)+pngf(k))*arcf(i,k) )
+                 ng(i,k-1) = max(ng(i,k-1),0._r8)    
+!                 if (ng(i,k-1) .lt. 0._r8) write(*,*) "ng(i,k-1)<0,k=",k,"i=",i
+              else
+                 qg(i,k-1)=0._r8
+                 ng(i,k-1)=0._r8
+              end if
+
+              if (qg(i,k-1).le.0._r8) then
+                 qg(i,k-1)=0._r8
+                 ng(i,k-1)=0._r8
+              end if
+  
+              
+
+              ! snow
+              if ( k.le.kqi(i) ) then
+!                 qni(i,k-1) = 1._r8/mu(i,k-1)*                                    &
+                 qni(i,k-1) = 1._r8/(mu(i,k-1)+dz(i,k)*du(i,k-1) )*                &
+                    (mu(i,k)*qni(i,k)+dz(i,k)*(qnitend(i,k)+psf(k))*arcf(i,k) )
+                 
+!                 ns(i,k-1) = 1._r8/mu(i,k-1)*                                    &
+                 ns(i,k-1) = 1._r8/(mu(i,k-1)+dz(i,k)*du(i,k-1)  )*                                    &
+                    (mu(i,k)*ns(i,k)+dz(i,k)*(nstend(i,k)+pnsf(k))*arcf(i,k) )
+                 ns(i,k-1) = max(ns(i,k-1),0._r8)
+                 qnide(i,k) = qni(i,k-1)
+                 nsde(i,k) = ns(i,k-1)
+              else
+                 qni(i,k-1)=0._r8
+                 ns(i,k-1)=0._r8
+              end if
+              dsfm(i,k-1) = -du(i,k-1)*qnide(i,k)
+              dsfn(i,k-1) = -du(i,k-1)*nsde(i,k)
+
+              if (qni(i,k-1).le.0._r8) then
+                 qni(i,k-1)=0._r8
+                 ns(i,k-1)=0._r8
+              end if
+
+              ! rain
+              if (k.le.kqc(i) ) then
+                 qr(i,k-1) = 1._r8/mu(i,k-1)*                                    &
+                    (mu(i,k)*qr(i,k)+dz(i,k)*(qrtend(i,k)+prf(k))*arcf(i,k) )
+
+                 nr(i,k-1) = 1._r8/mu(i,k-1)*                                    &
+                    (mu(i,k)*nr(i,k)+dz(i,k)*(nrtend(i,k)+pnrf(k))*arcf(i,k) )
+                 nr(i,k-1) = max(nr(i,k-1),0._r8)
+              else
+                 qr(i,k-1)=0._r8
+                 nr(i,k-1)=0._r8
+              end if
+
+              if( qr(i,k-1) .le. 0._r8) then
+                 qr(i,k-1)=0._r8
+                 nr(i,k-1)=0._r8
+              end if
+
+              ! freeze rain homogeneously at -40 C
+
+              if (t(i,k-1) < 233.15_r8 .and. qr(i,k-1) > 0._r8) then
+
+                 ! make sure freezing rain doesn't increase temperature above threshold
+                 dum = xlf/cp*qr(i,k-1) 
+                 if (t(i,k-1)+dum.gt.233.15_r8) then
+                    dum = -(t(i,k-1)-233.15_r8)*cp/xlf
+                    dum = dum/qr(i,k-1)
+                    dum = max(0._r8,dum)
+                    dum = min(1._r8,dum)
+                 else
+                    dum = 1._r8
+                 end if
+                 if (.true.) then 
+                    qg(i,k-1)=qg(i,k-1)+dum*qr(i,k-1)
+                    ng(i,k-1)=ng(i,k-1)+dum*nr(i,k-1)
+                    ng(i,k-1) = max(ng(i,k-1),0._r8)
+                 else      
+                    qni(i,k-1)=qni(i,k-1)+dum*qr(i,k-1)
+                    ns(i,k-1)=ns(i,k-1)+dum*nr(i,k-1)
+                    ns(i,k-1) = max(ns(i,k-1),0._r8)
+                 end if
+                 fhmrm(i,k-1) = -mu(i,k-1)*dum*qr(i,k-1)/dz(i,k)
+                 qr(i,k-1)=(1._r8-dum)*qr(i,k-1)
+                 nr(i,k-1)=(1._r8-dum)*nr(i,k-1)
+                 nr(i,k-1) = max(nr(i,k-1),0._r8)
+!                 fhmrm(i,k-1) = -mu(i,k-1)*dum*qr(i,k-1)/dz(i,k)
+              end if
+
+              rprd(i,k-1)= (qnitend(i,k) + qrtend(i,k)+ qgtend(i,k) )*arcf(i,k) + dsfm(i,k-1)
+              sprd(i,k-1)= (qnitend(i,k)+qgtend(i,k)) *arcf(i,k) -fhmrm(i,k-1) + dsfm(i,k-1)
+              if (rprd(i,k-1).lt.0._r8) then
+                 if (dsfm(i,k-1).ne.0._r8) then
+                    dsfn(i,k-1) = dsfn(i,k-1)*(dsfm(i,k-1)-rprd(i,k-1))/dsfm(i,k-1)
+                    dsfm(i,k-1) = -(qnitend(i,k) + qrtend(i,k)+ qgtend(i,k) )*arcf(i,k)
+                    qnide(i,k)  = -dsfm(i,k-1)/du(i,k-1)
+                    nsde(i,k)   = -dsfn(i,k-1)/du(i,k-1)
+                    qni(i,k-1) = qni(i,k-1) + dz(i,k)*du(i,k-1)*(qni(i,k-1)-qnide(i,k))/mu(i,k-1)
+                    ns(i,k-1)  =  ns(i,k-1) + dz(i,k)*du(i,k-1)*(ns(i,k-1)-nsde(i,k))/mu(i,k-1)
+                    ns(i,k-1) = max(ns(i,k-1),0._r8)
+                 end if
+                 rprd(i,k-1) = 0._r8
+                 sprd(i,k-1) = 0._r8
+              end if
+
+
+              ! cloud water
+              if ( k.le.kqc(i) ) then
+                  qc(i,k-1) = (mu(i,k)*qc(i,k)-fholm(i,k)+dz(i,k)*qctend(i,k)*arcf(i,k)      &
+                               +dz(i,k)*cmel(i,k-1) )/(mu(i,k-1)+dz(i,k)*du(i,k-1))
+
+                  qcde(i,k) = qc(i,k-1)
+
+                  nc(i,k-1) = (mu(i,k)*nc(i,k) -fholn(i,k) +dz(i,k)*nctend(i,k)*arcf(i,k) )   & 
+                              /(mu(i,k-1)+dz(i,k)*du(i,k-1)) 
+                  nc(i,k-1) = max(nc(i,k-1),0._r8)  
+                  ncde(i,k) = nc(i,k-1)
+              else
+                 qc(i,k-1)=0._r8
+                 nc(i,k-1)=0._r8
+              end if
+
+              if (qc(i,k-1).lt.0._r8) write(iulog,*) "negative qc(i,k-1)=",qc(i,k-1)
+              dlfm(i,k-1) = -du(i,k-1)*qcde(i,k)
+              dlfn(i,k-1) = -du(i,k-1)*ncde(i,k)
+
+              if (qc(i,k-1).le. 0._r8) then
+                 qc(i,k-1)=0._r8
+                 nc(i,k-1)=0._r8
+              end if
+
+              if (nc(i,k-1).lt. 0._r8) then
+                 write(iulog,*) "nc(i,k-1)=",nc(i,k-1),"k-1=",k-1,"arcf(i,k)=",arcf(i,k)
+                 write(iulog,*) "mu(i,k-1)=",mu(i,k-1),"mu(i,k)=",mu(i,k),"nc(i,k)=",ni(i,k)
+                 write(iulog,*) "dz(i,k)=",dz(i,k),"du(i,k-1)=",du(i,k-1),"nctend(i,k)=",nctend(i,k)
+                 write(iulog,*) "eu(i,k-1)=",eu(i,k-1)
+              end if              
+  
+              ! cloud ice
+              if( k.le.kqi(i)) then  
+                  qi(i,k-1) = (mu(i,k)*qi(i,k)+fholm(i,k) +dz(i,k)*qitend(i,k)*arcf(i,k)      &
+                               +dz(i,k)*cmei(i,k-1) )/(mu(i,k-1)+dz(i,k)*du(i,k-1))
+
+                  qide(i,k) = qi(i,k-1)
+                
+                  ni(i,k-1) = (mu(i,k)*ni(i,k)+fholn(i,k)+dz(i,k)*nitend(i,k)*arcf(i,k) )   &
+                              /(mu(i,k-1)+dz(i,k)*du(i,k-1))
+                  ni(i,k-1) = max(ni(i,k-1),0._r8)
+                  nide(i,k) = ni(i,k-1)
+              else
+                 qi(i,k-1)=0._r8
+                 ni(i,k-1)=0._r8
+              end if
+
+              if (qi(i,k-1).lt.0._r8) then 
+                 write(iulog,*) "negative qi(i,k-1)=",qi(i,k-1),"k-1=",k-1,"qitend=",qitend(i,k)
+                 write(*,*) "prb=",prb(k),"mnuccc=",mnuccc(k),"mnucct=",mnucct(k),"msacwi=",msacwi(k), & 
+                             "prci=",prci(k),"prai=", prai(k),"praci=",praci(k),"pracis=", pracis(k),   & 
+                             "qmultg=", qmultg(k),"qmultrg=", qmultrg(k)
+
+              end if
+              difm(i,k-1) = -du(i,k-1)*qide(i,k)
+              difn(i,k-1) = -du(i,k-1)*nide(i,k)         
+
+              if (qi(i,k-1).le. 0._r8) then
+                 qi(i,k-1)=0._r8
+                 ni(i,k-1)=0._r8
+              end if
+
+
+              if (ni(i,k-1).lt. 0._r8) then  
+                 write(iulog,*) "ni(i,k-1)=",ni(i,k-1),"k-1=",k-1,"arcf(i,k)=",arcf(i,k)
+                 write(iulog,*) "mu(i,k-1)=",mu(i,k-1),"mu(i,k)=",mu(i,k),"ni(i,k)=",ni(i,k)
+                 write(iulog,*) "dz(i,k)=",dz(i,k),"du(i,k-1)=",du(i,k-1),"nitend(i,k)=",nitend(i,k)
+                 write(iulog,*) "eu(i,k-1)=",eu(i,k-1)
+              end if            
+
+
+!              frz(i,k-1) = cmei(i,k-1) + arcf(i,k)*(prb(k)+mnuccc(k)+mnucct(k)+msacwi(k)+   &
+!                     pracs(k)+mnuccr(k)+psacws(k) )-fhmlm(i,k-1)-fhmrm(i,k-1)
+              frz(i,k-1) = cmei(i,k-1) + arcf(i,k)*(prb(k)+mnuccc(k)+mnucct(k)+msacwi(k)+   &
+                     pracs(k)+mnuccr(k)+psacws(k)+pracg(k)+psacwg(k)+pgsacw(k)+pgracs(k)+   &
+                     piacr(k)+piacrs(k)+qmultg(k)+ qmultrg(k)+psacwi(k) )-fhmlm(i,k-1)-fhmrm(i,k-1)
+
+
+
+              !******************************************************************************
+              ! get size distribution parameters based on in-cloud cloud water/ice
+              ! these calculations also ensure consistency between number and mixing ratio
+
+              ! following equation(2,3,4) of Morrison and Gettelman, 2008, J. Climate.
+              ! Gamma(n)= (n-1)! 
+              ! lamc <-> lambda for cloud liquid water
+              ! pgam <-> meu    for cloud liquid water
+              ! meu=0 for ice,rain and snow         
+              !*******************************************************************************
+
+              ! cloud ice
+              niorg = ni(i,k-1)
+              if (qi(i,k-1).ge.qsmall) then
+
+                 ! add upper limit to in-cloud number concentration to prevent numerical error
+                 ni(i,k-1)=min(ni(i,k-1),qi(i,k-1)*1.e20_r8)
+                 ! ni should be non-negative
+                 ! ni(i,k-1) = max(ni(i,k-1), 0._r8)
+                 if (ni(i,k-1).lt. 0._r8) write(iulog,*) "ni(i,k-1)=",ni(i,k-1)
+
+                 lami(k-1) = (gamma(1._r8+di)*ci* &
+                    ni(i,k-1)/qi(i,k-1))**(1._r8/di)
+                 n0i(k-1) = ni(i,k-1)*lami(k-1)
+
+                 ! check for slope
+                 lammax = 1._r8/10.e-6_r8
+                 lammin = 1._r8/(2._r8*dcs)
+
+                 ! adjust vars
+                 if (lami(k-1).lt.lammin) then
+                    lami(k-1) = lammin
+                    n0i(k-1) = lami(k-1)**(di+1._r8)*qi(i,k-1)/(ci*gamma(1._r8+di))
+                    ni(i,k-1) = n0i(k-1)/lami(k-1)
+                 else if (lami(k-1).gt.lammax) then
+                    lami(k-1) = lammax
+                    n0i(k-1) = lami(k-1)**(di+1._r8)*qi(i,k-1)/(ci*gamma(1._r8+di))
+                    ni(i,k-1) = n0i(k-1)/lami(k-1)
+                 end if
+              else
+                 lami(k-1) = 0._r8
+                 n0i(k-1) = 0._r8
+              end if
+
+              nide(i,k)   = ni(i,k-1)
+              difn(i,k-1) = -du(i,k-1)*nide(i,k)
+
+              niadj(i,k-1)= (ni(i,k-1)- niorg)*mu(i,k-1)/dz(i,k)
+
+              if (niadj(i,k-1) .lt. 0._r8) then
+                 total = nuclin(i,k-1)-fhtimn(i,k-1)-fhtctn(i,k-1)-fhmln(i,k-1)+ hmpin (i,k-1)
+                 if (total .ne. 0._r8) then
+                    nuclin(i,k-1) = nuclin(i,k-1) + nuclin(i,k-1)*niadj(i,k-1)/total
+                    fhtimn(i,k-1) = fhtimn(i,k-1) + fhtimn(i,k-1)*niadj(i,k-1)/total
+                    fhtctn(i,k-1) = fhtctn(i,k-1) + fhtctn(i,k-1)*niadj(i,k-1)/total 
+                    fhmln (i,k-1) = fhmln (i,k-1) + fhmln (i,k-1)*niadj(i,k-1)/total
+                    hmpin (i,k-1) = hmpin (i,k-1) + hmpin (i,k-1)*niadj(i,k-1)/total
+                 else
+                    total = 5._r8
+                    nuclin(i,k-1) = nuclin(i,k-1) + niadj(i,k-1)/total
+                    fhtimn(i,k-1) = fhtimn(i,k-1) + niadj(i,k-1)/total
+                    fhtctn(i,k-1) = fhtctn(i,k-1) + niadj(i,k-1)/total
+                    fhmln (i,k-1) = fhmln (i,k-1) + niadj(i,k-1)/total
+                    hmpin (i,k-1) = hmpin (i,k-1) + niadj(i,k-1)/total
+                 end if
+              else if (niadj(i,k-1) .gt. 0._r8)   then
+                 total = autoin(i,k-1)+accsin(i,k-1)
+                 if (total .ne. 0._r8) then
+                    autoin(i,k-1) = autoin(i,k-1) + autoin(i,k-1)*niadj(i,k-1)/total
+                    accsin(i,k-1) = accsin(i,k-1) + accsin(i,k-1)*niadj(i,k-1)/total 
+                 else
+                    total = 2._r8
+                    autoin(i,k-1) = autoin(i,k-1) + niadj(i,k-1)/total
+                    accsin(i,k-1) = accsin(i,k-1) + niadj(i,k-1)/total  
+                 end if  
+              end if
+
+              !................................................................................
+              !cloud water
+              ncorg = nc(i,k-1)
+              if (qc(i,k-1).ge.qsmall) then
+
+                 ! add upper limit to in-cloud number concentration to prevent numerical error
+                 nc(i,k-1)=min(nc(i,k-1),qc(i,k-1)*1.e20_r8)
+                 ! and make sure it's non-negative
+                 ! nc(i,k-1) = max(nc(i,k-1), 0._r8)
+                 if (nc(i,k-1).lt. 0._r8) write(iulog,*) "nc(i,k-1)=",nc(i,k-1) 
+
+                 ! get pgam from fit to observations of martin et al. 1994
+
+                 pgam(i,k-1)=0.0005714_r8*(nc(i,k-1)/1.e6_r8/rho(i,k-1))+0.2714_r8
+                 pgam(i,k-1)=1._r8/(pgam(i,k-1)**2)-1._r8
+                 pgam(i,k-1)=max(pgam(i,k-1),2._r8)
+                 pgam(i,k-1)=min(pgam(i,k-1),15._r8)
+                 ! calculate lamc
+
+                 lamc(i,k-1) = (pi/6._r8*rhow*nc(i,k-1)*gamma(pgam(i,k-1)+4._r8)/ &
+                    (qc(i,k-1)*gamma(pgam(i,k-1)+1._r8)))**(1._r8/3._r8)
+
+                 ! lammin, 50 micron diameter max mean size
+                 lammin = (pgam(i,k-1)+1._r8)/40.e-6_r8
+                 lammax = (pgam(i,k-1)+1._r8)/1.e-6_r8
+
+                 if (lamc(i,k-1).lt.lammin) then
+                    lamc(i,k-1) = lammin
+                    nc(i,k-1) = 6._r8*lamc(i,k-1)**3*qc(i,k-1)* &
+                       gamma(pgam(i,k-1)+1._r8)/ &
+                       (pi*rhow*gamma(pgam(i,k-1)+4._r8))
+                 else if (lamc(i,k-1).gt.lammax) then
+                    lamc(i,k-1) = lammax
+                    nc(i,k-1) = 6._r8*lamc(i,k-1)**3*qc(i,k-1)* &
+                       gamma(pgam(i,k-1)+1._r8)/ &
+                       (pi*rhow*gamma(pgam(i,k-1)+4._r8))
+                 end if
+
+                 ! parameter to calculate droplet freezing
+
+                 cdist1(k-1) = nc(i,k-1)/gamma(pgam(i,k-1)+1._r8)
+              else
+                 lamc(i,k-1) = 0._r8
+                 cdist1(k-1) = 0._r8
+              end if
+
+              ncde(i,k)   = nc(i,k-1)
+              dlfn(i,k-1) = -du(i,k-1)*ncde(i,k)
+              
+              ncadj(i,k-1) = (nc(i,k-1)- ncorg)*mu(i,k-1)/dz(i,k)
+              if (ncadj(i,k-1) .lt. 0._r8) then 
+                 activn(i,k-1) = activn(i,k-1) + ncadj(i,k-1)
+              else if (ncadj(i,k-1) .gt. 0._r8) then
+                total = autoln(i,k-1)+accrln(i,k-1)+bergnn(i,k-1)+accsln(i,k-1)
+                if (total .ne. 0._r8) then
+                    autoln(i,k-1) = autoln(i,k-1) + autoln(i,k-1)*ncadj(i,k-1)/total
+                    accrln(i,k-1) = accrln(i,k-1) + accrln(i,k-1)*ncadj(i,k-1)/total
+                    bergnn(i,k-1) = bergnn(i,k-1) + bergnn(i,k-1)*ncadj(i,k-1)/total
+                    accsln(i,k-1) = accsln(i,k-1) + accsln(i,k-1)*ncadj(i,k-1)/total
+                else
+                    total = 4._r8
+                    autoln(i,k-1) = autoln(i,k-1) + ncadj(i,k-1)/total
+                    accrln(i,k-1) = accrln(i,k-1) + ncadj(i,k-1)/total
+                    bergnn(i,k-1) = bergnn(i,k-1) + ncadj(i,k-1)/total
+                    accsln(i,k-1) = accsln(i,k-1) + ncadj(i,k-1)/total
+                end if
+              end if
+
+              trspcm(i,k-1) = (mu(i,k)*qc(i,k) - mu(i,k-1)*qc(i,k-1))/dz(i,k)
+              trspcn(i,k-1) = (mu(i,k)*nc(i,k) - mu(i,k-1)*nc(i,k-1))/dz(i,k)
+              trspim(i,k-1) = (mu(i,k)*qi(i,k) - mu(i,k-1)*qi(i,k-1))/dz(i,k)
+              trspin(i,k-1) = (mu(i,k)*ni(i,k) - mu(i,k-1)*ni(i,k-1))/dz(i,k)
+
+              if (k-1 .eq. jt(i)+1)  then
+                 trspcm(i,k-2) =  mu(i,k-1)*qc(i,k-1)/dz(i,k-1)
+                 trspcn(i,k-2) =  mu(i,k-1)*nc(i,k-1)/dz(i,k-1)
+                 trspim(i,k-2) =  mu(i,k-1)*qi(i,k-1)/dz(i,k-1)
+                 trspin(i,k-2) =  mu(i,k-1)*ni(i,k-1)/dz(i,k-1)
+                 qcde(i,k-1)   = qc(i,k-1)
+                 ncde(i,k-1)   = nc(i,k-1)
+                 qide(i,k-1)   = qi(i,k-1)
+                 nide(i,k-1)   = ni(i,k-1)
+                 dlfm  (i,k-2) = -du(i,k-2)*qcde(i,k-1)
+                 dlfn  (i,k-2) = -du(i,k-2)*ncde(i,k-1)
+                 difm  (i,k-2) = -du(i,k-2)*qide(i,k-1)
+                 difn  (i,k-2) = -du(i,k-2)*nide(i,k-1)
+              end if
+
+
+              !.......................................................................
+              ! get size distribution parameters for precip
+              !......................................................................
+              ! rain
+              if (qr(i,k-1).ge.qsmall) then
+                 if (nr(i,k-1).lt. 0._r8) write(iulog,*) "nr(i,k-1)=",nr(i,k-1)
+                 lamr(k-1) = (pi*rhow*nr(i,k-1)/qr(i,k-1))**(1._r8/3._r8)
+                 n0r(k-1) = nr(i,k-1)*lamr(k-1)
+
+                 ! check for slope
+                 lammax = 1._r8/150.e-6_r8
+                 lammin = 1._r8/3000.e-6_r8
+                 ! adjust vars
+                 if (lamr(k-1).lt.lammin) then
+                    lamr(k-1) = lammin
+                    n0r(k-1) = lamr(k-1)**4*qr(i,k-1)/(pi*rhow)
+                    nr(i,k-1) = n0r(k-1)/lamr(k-1)
+                 else if (lamr(k-1).gt.lammax) then
+                    lamr(k-1) = lammax
+                    n0r(k-1) = lamr(k-1)**4*qr(i,k-1)/(pi*rhow)
+                    nr(i,k-1) = n0r(k-1)/lamr(k-1)
+                 end if
+
+                 unr(k-1) = min(arn(i,k-1)*gamma(1._r8+br)/lamr(k-1)**br,10._r8)
+                 umr(k-1) = min(arn(i,k-1)*gamma(4._r8+br)/(6._r8*lamr(k-1)**br),10._r8)                   
+              else
+                 lamr(k-1) = 0._r8
+                 n0r(k-1) = 0._r8
+                 umr(k-1) = 0._r8
+                 unr(k-1) = 0._r8
+              end if
+
+              !......................................................................
+              ! snow
+              nsorg = ns(i,k-1)
+              if (qni(i,k-1).ge.qsmall) then
+                 if (ns(i,k-1).lt. 0._r8) write(iulog,*) "ns(i,k-1)=",ns(i,k-1)     
+                 lams(k-1) = (gamma(1._r8+ds)*cs*ns(i,k-1)/ &
+                    qni(i,k-1))**(1._r8/ds)
+                 n0s(k-1) = ns(i,k-1)*lams(k-1)
+
+                 ! check for slope
+!                 lammax = 1._r8/10.e-6_r8
+!                 lammin = 1._r8/2000.e-6_r8
+                 lammax = 1._r8/dcs
+                 lammin = 1._r8/5000.e-6_r8
+
+                 ! adjust vars
+                 if (lams(k-1).lt.lammin) then
+                    lams(k-1) = lammin
+                    n0s(k-1) = lams(k-1)**(ds+1._r8)*qni(i,k-1)/(cs*gamma(1._r8+ds))
+                    ns(i,k-1) = n0s(k-1)/lams(k-1)
+                 else if (lams(k-1).gt.lammax) then
+                    lams(k-1) = lammax
+                    n0s(k-1) = lams(k-1)**(ds+1._r8)*qni(i,k-1)/(cs*gamma(1._r8+ds))
+                    ns(i,k-1) = n0s(k-1)/lams(k-1)
+                 end if
+                 dum=(rhosu/rho(i,k))**0.54
+                 ums(k-1) = min(asn(i,k-1)*gamma(4._r8+bs)/(6._r8*lams(k-1)**bs),1.2_r8*dum)
+                 uns(k-1) = min(asn(i,k-1)*gamma(1._r8+bs)/lams(k-1)**bs,1.2_r8*dum)
+              else
+                 lams(k-1) = 0._r8
+                 n0s(k-1) = 0._r8
+                 ums(k-1) = 0._r8
+                 uns(k-1) = 0._r8
+              end if
+
+              nsde(i,k)   = ns(i,k-1)
+              dsfn(i,k-1) = -du(i,k-1)*nsde(i,k)
+
+              nsadj(i,k-1) = (ns(i,k-1)- nsorg)*mu(i,k-1)/dz(i,k)
+              trspsm(i,k-1) = (mu(i,k)*qni(i,k) - mu(i,k-1)*qni(i,k-1))/dz(i,k)
+              trspsn(i,k-1) = (mu(i,k)*ns(i,k) - mu(i,k-1)*ns(i,k-1))/dz(i,k)
+              if (k-1 .eq. jt(i)+1)  then
+                 trspsm(i,k-2) =  mu(i,k-1)*qni(i,k-1)/dz(i,k-1)
+                 trspsn(i,k-2) =  mu(i,k-1)*ns(i,k-1)/dz(i,k-1)
+
+! no snow detrainment between jt and jt+1
+                 qnide(i,k-1)  = 0._r8
+                 nsde(i,k-1)   = 0._r8
+                 dsfm  (i,k-2) = 0._r8
+                 dsfn  (i,k-2) = 0._r8
+!                 qnide(i,k-1)   = qni(i,k-1)
+!                 nsde(i,k-1)   = ns(i,k-1)
+!                 dsfm  (i,k-2) = -du(i,k-2)*qnide(i,k-1)
+!                 dsfn  (i,k-2) = -du(i,k-2)*nsde(i,k-1)                 
+              
+              end if
+
+              !graupel
+              if (qg(i,k-1).ge.qsmall) then
+  
+                  if (ng(i,k-1).lt. 0._r8) write(iulog,*) "ng(i,k-1)=",ng(i,k-1)
+                  lamg(k-1) = (gamma(1._r8+dg)*cg*ng(i,k-1)/qg(i,k-1))**(1./dg)
+                  n0g(k-1) = ng(i,k-1)*lamg(k-1)
+
+                  ! check for slope
+                  ! adjust vars
+                  lammax = 1._r8/20.e-6_r8
+                  lammin = 1._r8/5000.e-6_r8
+
+                  if (lamg(k-1).lt.lammin) then
+                      lamg(k-1) = lammin
+                      n0g(k-1) = lamg(k-1)**4*qg(i,k-1)/(gamma(1._r8+dg)*cg)
+                      ng(i,k-1) = n0g(k-1)/lamg(k-1)
+                  else if (lamg(k-1).gt.lammax) then
+                      lamg(k-1) = lammax
+                      n0g(k-1) = lamg(k-1)**4*qg(i,k-1)/(gamma(1._r8+dg)*cg)
+                      ng(i,k-1) = n0g(k-1)/lamg(k-1)
+                  end if
+                  ! provisional graupel number and mass weighted mean fallspeed
+                  ! (m/s)
+                  dum=(rhosu/rho(i,k))**0.54
+                  umg(k-1) = min(agn(i,k-1)*gamma(4._r8+bg)/(6._r8*lamg(k-1)**bg),20._r8*dum)
+                  ung(k-1) = min(agn(i,k-1)*gamma(1._r8+bg)/lamg(k-1)**bg,20._r8*dum)
+              else
+                  lamg(k-1) = 0._r8
+                  n0g(k-1) = 0._r8
+                  umg(k-1) = 0._r8
+                  ung(k-1) = 0._r8
+              end if
+
+!              rprd(i,k-1)= (qnitend(i,k) + qrtend(i,k))*arcf(i,k)
+!              sprd(i,k-1)=  qnitend(i,k) *arcf(i,k) -fhmrm(i,k-1)       
+!              rprd(i,k-1)= (qnitend(i,k) + qrtend(i,k)+ qgtend(i,k) )*arcf(i,k)
+!              sprd(i,k-1)= (qnitend(i,k)+qgtend(i,k)) *arcf(i,k) -fhmrm(i,k-1)
+!              rprd(i,k-1)= (qnitend(i,k) + qrtend(i,k)+ qgtend(i,k) )*arcf(i,k) + dsfm(i,k-1)
+!              sprd(i,k-1)= (qnitend(i,k)+qgtend(i,k)) *arcf(i,k) -fhmrm(i,k-1) + dsfm(i,k-1)
+
+           end if  ! k<jlcl
+
+           ! if rain/snow mix ratio is zero so should number concentration
+
+           if (qni(i,k-1).lt.qsmall) then
+              qni(i,k-1)=0._r8
+              ns(i,k-1)=0._r8
+           end if
+
+           if (qr(i,k-1).lt.qsmall) then
+              qr(i,k-1)=0._r8
+              nr(i,k-1)=0._r8
+           end if
+
+           if (qg(i,k-1).lt.qsmall) then
+              qg(i,k-1)=0._r8
+              ng(i,k-1)=0._r8
+           end if 
+
+           if (qi(i,k-1).lt.qsmall) then
+              qi(i,k-1)=0._r8
+              ni(i,k-1)=0._r8
+           end if
+
+           if (qc(i,k-1).lt.qsmall) then
+              qc(i,k-1)=0._r8
+              nc(i,k-1)=0._r8
+           end if
+
+           ! make sure number concentration is a positive number to avoid 
+           ! taking root of negative
+
+           nr(i,k-1)=max(nr(i,k-1),0._r8)
+           ns(i,k-1)=max(ns(i,k-1),0._r8)
+           ng(i,k-1)=max(ng(i,k-1),0._r8) 
+           ni(i,k-1)=max(ni(i,k-1),0._r8)
+           nc(i,k-1)=max(nc(i,k-1),0._r8)
+           
+           !!......................................................................
+        end do ! k loop
+
+     end do ! it loop, iteration
+
+300  continue  ! continue if no cloud water
+
+  end do ! i loop
+
+  !........................................................................
+
+  if (aero%scheme == 'modal') then
+     deallocate( &
+        vaerosol, &
+        hygro,    &
+        naermod,  &
+        fn,       &
+        fm,       &
+        fluxn,    &
+        fluxm     )
+  else if (aero%scheme == 'bulk') then
+     deallocate( &
+        naer2,    &
+        naer2h,   &
+        maerosol  )
+  end if
+
+end subroutine zm_mphy
+
+!##############################################################################
+
+end module zm_microphysics

--- a/components/eam/src/physics/cam/zm_microphysics.F90
+++ b/components/eam/src/physics/cam/zm_microphysics.F90
@@ -2297,8 +2297,8 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
 #endif  
                         endif
                        
-                        dst3_num = wght *(aero%numg_a(i,k-1,aero%mode_coarse_idx)         & 
-                                  + aero%numg_a(i,k,aero%mode_coarse_idx))*0.5_r8*rho(i,k)*1.0e-6_r8
+                        dst3_num = wght *(aero%numg_a(i,k-1,aero%mode_coarse_dst_idx)         & 
+                                  + aero%numg_a(i,k,aero%mode_coarse_dst_idx))*0.5_r8*rho(i,k)*1.0e-6_r8
                         dst_num  = dst3_num
                     else
                         dst3_num = 0.0_r8 
@@ -2500,13 +2500,8 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                     !  use size '3' for dust coarse mode...
                     !  scale by dust fraction in coarse mode
 
-                    dmc  = 0.5_r8*(aero%mmrg_a(i,k,aero%coarse_dust_idx,aero%mode_coarse_idx)     &
-                                  +aero%mmrg_a(i,k-1,aero%coarse_dust_idx,aero%mode_coarse_idx))
-                    ssmc = 0.5_r8*(aero%mmrg_a(i,k,aero%coarse_nacl_idx,aero%mode_coarse_idx)     &
-                                  +aero%mmrg_a(i,k-1,aero%coarse_nacl_idx,aero%mode_coarse_idx)) 
                     if (dmc > 0.0_r8) then
-                        nacon3 = dmc/(ssmc + dmc) * (aero%numg_a(i,k,aero%mode_coarse_idx)     &
-                                 + aero%numg_a(i,k-1,aero%mode_coarse_idx))*0.5_r8*rho(i,k)
+                         nacon3 = dst3_num*tcnt*1.0e6_r8 
                     end if
 
                  else if (aero%scheme == 'bulk') then

--- a/components/eam/src/physics/cam/zm_microphysics.F90
+++ b/components/eam/src/physics/cam/zm_microphysics.F90
@@ -4,7 +4,7 @@ module  zm_microphysics
 ! Purpose:
 !   CAM Interface for cumulus microphysics
 ! 
-! Author: Xialiang Song and Guang Jun Zhang, June 2010  
+! Author: Xialiang Song and Guang Zhang, June 2010  
 !---------------------------------------------------------------------------------
 
 use shr_kind_mod,      only: r8=>shr_kind_r8
@@ -64,7 +64,7 @@ real(r8) :: rhosu     !typical 850mn air density
 real(r8) :: mi0       ! new crystal mass
 real(r8) :: mg0       ! mass of embryo graupel
 real(r8) :: rin       ! radius of contact nuclei
-real(r8) :: pi       ! pi
+real(r8) :: pi        ! pi
 real(r8) :: mmult
 
 ! for Bergeron process (Rotstayn et al.2000)
@@ -140,18 +140,18 @@ end type zm_aero_t
 
 type :: zm_microp_st
 
-   real(r8),    allocatable :: wu(:,:)             ! vertical velocity
+   real(r8),    allocatable :: wu(:,:)        ! vertical velocity
 
-   real(r8),    allocatable :: qliq(:,:)           ! convective cloud liquid water.
-   real(r8),    allocatable :: qice(:,:)           ! convective cloud ice.
-   real(r8),    allocatable :: qrain(:,:)          ! convective rain water.
-   real(r8),    allocatable :: qsnow(:,:)          ! convective snow.
-   real(r8),    allocatable :: qgraupel(:,:)       ! convective graupel.
-   real(r8),    allocatable :: qnl(:,:)            ! convective cloud liquid water num concen.
-   real(r8),    allocatable :: qni(:,:)            ! convective cloud ice num concen.
-   real(r8),    allocatable :: qnr(:,:)            ! convective rain water num concen.
-   real(r8),    allocatable :: qns(:,:)            ! convective snow num concen.
-   real(r8),    allocatable :: qng(:,:)            ! convective graupel num concen.
+   real(r8),    allocatable :: qliq(:,:)      ! convective cloud liquid water.
+   real(r8),    allocatable :: qice(:,:)      ! convective cloud ice.
+   real(r8),    allocatable :: qrain(:,:)     ! convective rain water.
+   real(r8),    allocatable :: qsnow(:,:)     ! convective snow.
+   real(r8),    allocatable :: qgraupel(:,:)  ! convective graupel.
+   real(r8),    allocatable :: qnl(:,:)       ! convective cloud liquid water num concen.
+   real(r8),    allocatable :: qni(:,:)       ! convective cloud ice num concen.
+   real(r8),    allocatable :: qnr(:,:)       ! convective rain water num concen.
+   real(r8),    allocatable :: qns(:,:)       ! convective snow num concen.
+   real(r8),    allocatable :: qng(:,:)       ! convective graupel num concen.
 
    real(r8),    allocatable :: autolm(:,:)    !mass tendency due to autoconversion of droplets to rain
    real(r8),    allocatable :: accrlm(:,:)    !mass tendency due to accretion of droplets by rain
@@ -250,7 +250,6 @@ subroutine zm_mphyi
 ! density parameters (kg/m3)
 
       rhosn = 100._r8    ! bulk density snow
-!      rhosn = 250._r8  ! bulk density snow
       rhoi = 500._r8     ! bulk density ice
       rhow = 1000._r8    ! bulk density liquid
 
@@ -322,9 +321,6 @@ subroutine zm_mphyi
 
         ecg = 0.7_r8
 
-! autoconversion size threshold for cloud ice to snow (m)
-
-!        Dcs = 150.e-6_r8
 ! immersion freezing parameters, bigg 1953
 
 	bimm = 100._r8
@@ -447,8 +443,8 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
   real(r8), intent(out) :: frz(pcols,pver)      ! rate of freezing 
 
 
-  real(r8), intent(inout) :: lamc(pcols,pver)     ! slope of cloud liquid size distr
-  real(r8), intent(inout) :: pgam(pcols,pver)     ! spectral width parameter of droplet size distr
+  real(r8), intent(inout) :: lamc(pcols,pver)   ! slope of cloud liquid size distr
+  real(r8), intent(inout) :: pgam(pcols,pver)   ! spectral width parameter of droplet size distr
 
 ! tendency for output
   real(r8) :: autolm(pcols,pver)    !mass tendency due to autoconversion of droplets to rain
@@ -490,37 +486,37 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
   real(r8) :: dsfn  (pcols,pver)    !num tendency due to detrainment of snow
   real(r8) :: trspsn(pcols,pver)    !num tendency of snow due to convective transport
 !graupel
-  real(r8) :: accgrm(pcols,pver)          ! mass tendency due to collection of rain by graupel
-  real(r8) :: accglm(pcols,pver)          ! mass tendency due to collection of droplets by graupel
-  real(r8) :: accgslm(pcols,pver)         ! mass tendency of graupel due to collection of droplets by snow
-  real(r8) :: accgsrm(pcols,pver)         ! mass tendency of graupel due to collection of rain by snow
-  real(r8) :: accgirm(pcols,pver)         ! mass tendency of graupel due to collection of rain by ice
-  real(r8) :: accgrim(pcols,pver)         ! mass tendency of graupel due to collection of ice by rain
-  real(r8) :: accgrsm(pcols,pver)         ! mass tendency due to collection of snow by rain
+  real(r8) :: accgrm(pcols,pver)    ! mass tendency due to collection of rain by graupel
+  real(r8) :: accglm(pcols,pver)    ! mass tendency due to collection of droplets by graupel
+  real(r8) :: accgslm(pcols,pver)   ! mass tendency of graupel due to collection of droplets by snow
+  real(r8) :: accgsrm(pcols,pver)   ! mass tendency of graupel due to collection of rain by snow
+  real(r8) :: accgirm(pcols,pver)   ! mass tendency of graupel due to collection of rain by ice
+  real(r8) :: accgrim(pcols,pver)   ! mass tendency of graupel due to collection of ice by rain
+  real(r8) :: accgrsm(pcols,pver)   ! mass tendency due to collection of snow by rain
 
-  real(r8) :: accgsln(pcols,pver)         ! num tendency of graupel due to collection of droplets by snow
-  real(r8) :: accgsrn(pcols,pver)         ! num tendency of graupel due to collection of rain by snow
-  real(r8) :: accgirn(pcols,pver)         ! num tendency of graupel due to collection of rain by ice
+  real(r8) :: accgsln(pcols,pver)   ! num tendency of graupel due to collection of droplets by snow
+  real(r8) :: accgsrn(pcols,pver)   ! num tendency of graupel due to collection of rain by snow
+  real(r8) :: accgirn(pcols,pver)   ! num tendency of graupel due to collection of rain by ice
 
-  real(r8) :: accsrim(pcols,pver)         ! mass tendency of snow due to collection of ice by rain
-  real(r8) :: acciglm(pcols,pver)         ! mass tendency of ice mult(splintering) due to acc droplets by graupel
-  real(r8) :: accigrm(pcols,pver)         ! mass tendency of ice mult(splintering) due to acc rain by graupel
-  real(r8) :: accsirm(pcols,pver)         ! mass tendency of snow due to collection of rain by ice
+  real(r8) :: accsrim(pcols,pver)   ! mass tendency of snow due to collection of ice by rain
+  real(r8) :: acciglm(pcols,pver)   ! mass tendency of ice mult(splintering) due to acc droplets by graupel
+  real(r8) :: accigrm(pcols,pver)   ! mass tendency of ice mult(splintering) due to acc rain by graupel
+  real(r8) :: accsirm(pcols,pver)   ! mass tendency of snow due to collection of rain by ice
 
-  real(r8) :: accigln(pcols,pver)         ! num tendency of ice mult(splintering) due to acc droplets by graupel
-  real(r8) :: accigrn(pcols,pver)         ! num tendency of ice mult(splintering) due to acc rain by graupel
-  real(r8) :: accsirn(pcols,pver)         ! num tendency of snow due to collection of rain by ice
-  real(r8) :: accgln(pcols,pver)          ! num tendency due to collection of droplets by graupel
-  real(r8) :: accgrn(pcols,pver)          ! num tendency due to collection of rain by graupel
-  real(r8) :: accilm(pcols,pver)          ! mass tendency of cloud ice due to collection of droplet by cloud ice
-  real(r8) :: acciln(pcols,pver)          ! number conc tendency of cloud ice due to collection of droplet by cloud ice
+  real(r8) :: accigln(pcols,pver)   ! num tendency of ice mult(splintering) due to acc droplets by graupel
+  real(r8) :: accigrn(pcols,pver)   ! num tendency of ice mult(splintering) due to acc rain by graupel
+  real(r8) :: accsirn(pcols,pver)   ! num tendency of snow due to collection of rain by ice
+  real(r8) :: accgln(pcols,pver)    ! num tendency due to collection of droplets by graupel
+  real(r8) :: accgrn(pcols,pver)    ! num tendency due to collection of rain by graupel
+  real(r8) :: accilm(pcols,pver)    ! mass tendency of cloud ice due to collection of droplet by cloud ice
+  real(r8) :: acciln(pcols,pver)    ! number conc tendency of cloud ice due to collection of droplet by cloud ice
 
-  real(r8) :: fallrm(pcols, pver)         ! mass tendency of rain fallout 
-  real(r8) :: fallsm(pcols, pver)         ! mass tendency of snow fallout
-  real(r8) :: fallgm(pcols, pver)         ! mass tendency of graupel fallout
-  real(r8) :: fallrn(pcols, pver)         ! num tendency of rain fallout
-  real(r8) :: fallsn(pcols, pver)         ! num tendency of snow fallout
-  real(r8) :: fallgn(pcols, pver)         ! num tendency of graupel fallout
+  real(r8) :: fallrm(pcols, pver)   ! mass tendency of rain fallout 
+  real(r8) :: fallsm(pcols, pver)   ! mass tendency of snow fallout
+  real(r8) :: fallgm(pcols, pver)   ! mass tendency of graupel fallout
+  real(r8) :: fallrn(pcols, pver)   ! num tendency of rain fallout
+  real(r8) :: fallsn(pcols, pver)   ! num tendency of snow fallout
+  real(r8) :: fallgn(pcols, pver)   ! num tendency of graupel fallout
 
 ! output for ice nucleation
   real(r8) :: nimey(pcols,pver)     !number conc of ice nuclei due to meyers deposition (1/m3)
@@ -668,7 +664,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
   real(r8) :: ngtend(pcols,pver)    ! graupel number concentration source/sink term
 
 ! terms for Bergeron process
-  real(r8) :: bergtsf               !bergeron timescale to remove all liquid
+  real(r8) :: bergtsf               ! bergeron timescale to remove all liquid
   real(r8) :: plevap                ! cloud liquid water evaporation rate
   real(r8) :: a_prime
   real(r8) :: b_prime
@@ -768,9 +764,9 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
   logical niimp(pver)             ! true to solve ni with implicit formula
 
 ! tendency due to adjustment
-  real(r8) :: ncadj(pcols,pver)     !droplet num tendency due to adjustment
-  real(r8) :: niadj(pcols,pver)     !ice crystal num tendency due to adjustment
-  real(r8) :: nsadj(pcols,pver)     !snow num tendency due to adjustment
+  real(r8) :: ncadj(pcols,pver)   ! droplet num tendency due to adjustment
+  real(r8) :: niadj(pcols,pver)   ! ice crystal num tendency due to adjustment
+  real(r8) :: nsadj(pcols,pver)   ! snow num tendency due to adjustment
   real(r8) :: ncorg, niorg, nsorg, total
 
   real(r8) :: rhoh(pcols,pver)    ! air density (kg m-3) at interface 
@@ -838,19 +834,19 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
         qcde(i,k) = 0._r8
         qide(i,k) = 0._r8
         qnide(i,k) = 0._r8
-        rprd(i,k) = 0._r8
-        sprd(i,k) = 0._r8
-        frz(i,k)  = 0._r8
-        qcic(i,k) = 0._r8
-        qiic(i,k) = 0._r8
-        ncic(i,k) = 0._r8
-        niic(i,k) = 0._r8 
-        qr(i,k)   = 0._r8
-        qni(i,k)  = 0._r8
-        qg(i,k)  = 0._r8
-        nr(i,k)   = 0._r8
-        ns(i,k)   = 0._r8
-        ng(i,k)   = 0._r8
+        rprd(i,k)  = 0._r8
+        sprd(i,k)  = 0._r8
+        frz(i,k)   = 0._r8
+        qcic(i,k)  = 0._r8
+        qiic(i,k)  = 0._r8
+        ncic(i,k)  = 0._r8
+        niic(i,k)  = 0._r8 
+        qr(i,k)    = 0._r8
+        qni(i,k)   = 0._r8
+        qg(i,k)    = 0._r8
+        nr(i,k)    = 0._r8
+        ns(i,k)    = 0._r8
+        ng(i,k)    = 0._r8
         qric(i,k)  = 0._r8
         qniic(i,k) = 0._r8
         nric(i,k)  = 0._r8
@@ -1133,8 +1129,8 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
            ncimp(k) = .false.
            qiimp(k) = .false.
            niimp(k) = .false.
-           dum2l(i,k)=0._r8
-           dum2i(i,k)=0._r8
+           dum2l(i,k)  = 0._r8
+           dum2i(i,k)  = 0._r8
            autolm(i,k) = 0._r8
            accrlm(i,k) = 0._r8
            bergnm(i,k) = 0._r8
@@ -1298,7 +1294,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                  if(k.le.kqi(i)) then
                    qiic(i,k) = qi(i,k)
                    niic(i,k) = ni(i,k)
-! consider snow falling from above
+                   ! consider snow falling from above
                    flxsm = 0._r8
                    mvtsm = 0._r8
                    flxsn = 0._r8
@@ -1325,9 +1321,8 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                    else
                       nsic(i,k) = ns(i,k)
                    end if
-!                 end if
 
-! consider graupel falling from above
+                   ! consider graupel falling from above
                    flxgm = 0._r8
                    mvtgm = 0._r8
                    flxgn = 0._r8
@@ -1372,6 +1367,9 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                  kqc(i) = k
                  lcbase(i) = .false.
                  qcic(i,k) = dz(i,k)*cmel(i,k-1)/(mu(i,k-1)+dz(i,k)*du(i,k-1))
+                 ! Cloud water number concentration is mainly determined by the source (e.g., activation) 
+                 ! and sink terms in the budget equation. Sensitivity test shows that the cloud water number 
+                 ! concentration is not very sensitive to the boundary conditions.  
 !                 ncic(i,k) = qcic(i,k)/(4._r8/3._r8*pi*10.e-6_r8**3*rhow)
                  ncic(i,k) = qcic(i,k)/(4._r8/3._r8*pi*25.e-6_r8**3*rhow)  
               end if
@@ -1386,7 +1384,6 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                  libase(i) = .false.
                  qiic(i,k) = dz(i,k)*cmei(i,k-1)/(mu(i,k-1)+dz(i,k)*du(i,k-1))
                  niic(i,k) = qiic(i,k)/(4._r8/3._r8*pi*15.e-6_r8**3*rhoi)               
-!                 niic(i,k) = qiic(i,k)/(4._r8/3._r8*pi*32.e-6_r8**3*rhoi)
               end if
 
               !***************************************************************************
@@ -1490,6 +1487,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                  ! Khrouditnov and Kogan (2000) 
 !                 prc(k) = 1350._r8*qcic(i,k)**2.47_r8*    &
 !                    (ncic(i,k)/1.e6_r8*rho(i,k))**(-1.79_r8)
+                 ! parameters with updated values for 72 layer model 
                  prc(k) = auto_fac*30500._r8*qcic(i,k)**3.19_r8*    &
                     (ncic(i,k)/1.e6_r8*rho(i,k))**(-1.2_r8)
                  nprc1(k) = prc(k)/(qcic(i,k)/ncic(i,k))
@@ -1599,8 +1597,6 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                  n0s(k) = nsic(i,k)*lams(k)
 
                  ! check for slope
-!                 lammax = 1._r8/10.e-6_r8
-!                 lammin = 1._r8/2000.e-6_r8
                  lammax = 1._r8/dcs
                  lammin = 1._r8/5000.e-6_r8
 
@@ -1731,7 +1727,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
 ! hobbs (1984)
 
            if (psacws(k).gt.0._r8 .and. qniic(i,k).ge.0.1e-3_r8.and.qcic(i,k).ge.0.5e-3_r8) then
-             if (ums(k).eq.0._r8) write(*,*) "!!! ums=0., k=",k,"i=",i
+!             if (ums(k).eq.0._r8) write(iulog,*) "ums=0., k=",k,"i=",i
 ! portion of riming converted to graupel (reisner et al. 1998, originally
 ! is1991)
              dt = dz(i,k)/ums(k)
@@ -1789,7 +1785,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                   psacwg(k) = 0._r8
                   npsacwg(k) = 0._r8
               end if
-!>songxl************************
+
 
               !.......................................................................
               ! accretion of rain water by snow
@@ -1811,7 +1807,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                     1._r8/(lamr(k)**2*lams(k)**2)+ &
                     1._r8/(lamr(k)*lams(k)**3))
 
-!<songxl**********************************
+
               ! collection of snow by rain - needed for graupel conversion calculations
               ! only calculate if snow and rain mixing ratios exceed 0.1 g/kg
 
@@ -1826,15 +1822,12 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                    psacr(k) = 0._r8
                  end if
 
-!>songxl***********************************
-
               else
                  pracs(k)=0._r8
                  npracs(k)=0._r8
                  psacr(k) = 0._r8
               end if
 
-!<songxl*********************
 
               ! conversion of rimed rainwater onto snow converted to graupel
 
@@ -1849,9 +1842,6 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                   dum=max(dum,0._r8)
                   pgracs(k) = (1._r8-dum)*pracs(k)
                   ngracs(k) = (1._r8-dum)*npracs(k)
-              ! limit max number converted to min of either rain or snow number concentration
-!                  ngracs(k) = min(ngracs(k),nric(i,k)/dt)
-!                  ngracs(k) = min(ngracs(k),nsic(i,k)/dt)
 
               ! amount left for snow production
                   pracs(k) = pracs(k) - pgracs(k)
@@ -1869,19 +1859,6 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
 ! used by reisner et al 1998
          if (qric(i,k).ge.1.e-8.and.qgic(i,k).ge.1.e-8) then
 
-!            umg = agn(k)*cons7/(lamg(k)**bg)
-!            umr = arn(k)*cons4/(lamr(k)**br)
-!            ung = agn(k)*cons8/lamg(k)**bg
-!            unr = arn(k)*cons6/lamr(k)**br
-
-! set reaslistic limits on fallspeeds
-! bug fix, 10/08/09
-!            dum=(rhosu/rho(k))**0.54
-!            umg=min(umg,20.*dum)
-!            ung=min(ung,20.*dum)
-!            umr=min(umr,9.1*dum)
-!            unr=min(unr,9.1*dum)
-
             pracg(k) = cons41*(((1.2_r8*umr(k)-0.95_r8*umg(k))**2+                   &
                   0.08_r8*umg(k)*umr(k))**0.5_r8*rho(i,k)*                      &
                   n0r(k)*n0g(k)/lamr(k)**3*                              &
@@ -1895,11 +1872,6 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                  1._r8/(lamr(k)**2*lamg(k)**2)+                   &
                  1._r8/(lamr(k)*lamg(k)**3))
 
-! make sure pracg doesn't exceed total rain mixing ratio
-! as this may otherwise result in too much transfer of water during
-! rime-splintering
-
-!            pracg(k) = min(pracg(k),qr3d(k)/dt)
             else
               pracg(k) = 0._r8
               npracg(k) = 0._r8
@@ -1959,7 +1931,6 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
             end if
             end if
             end if
-!>songxl***********************
 
               !.......................................................................
               ! heterogeneous freezing of rain drops
@@ -1984,7 +1955,6 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
               ! gravitational collection kernel, droplet fall speed neglected
 
               if (qric(i,k).ge.qsmall .and. qcic(i,k).ge.qsmall) then
-!                 pra(k) = 67._r8*(qcic(i,k)*qric(i,k))**1.15_r8
                  pra(k) = accr_fac*67._r8*(qcic(i,k)*qric(i,k))**1.15_r8
                  npra(k) = pra(k)/(qcic(i,k)/ncic(i,k))
               else
@@ -2044,8 +2014,6 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                 /lamr(k)**(br+3._r8)/lamr(k)**3*rho(i,k)
             praci(k)=cons24*qiic(i,k)*n0r(k)*arn(i,k)/ &
                 lamr(k)**(br+3._r8)*rho(i,k)
-!            niacr(k)=min(niacr(k),nric(i,k)/dt)
-!            niacr(k)=min(niacr(k),niic(i,k)/dt)
             else
             niacrs(k)=cons24*niic(i,k)*n0r(k)*arn(i,k) &
                 /lamr(k)**(br+3._r8)*rho(i,k)
@@ -2053,11 +2021,8 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                 /lamr(k)**(br+3._r8)/lamr(k)**3*rho(i,k)
             pracis(k)=cons24*qiic(i,k)*n0r(k)*arn(i,k)/ &
                 lamr(k)**(br+3._r8)*rho(i,k)
-!            niacrs(k)=min(niacrs(k),nric(i,k)/dt)
-!            niacrs(k)=min(niacrs(k),niic(i,k)/dt)
             end if
          end if
-!>songxl*****************
 
               !.......................................................................
               ! fallout term
@@ -2296,15 +2261,6 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                  nidep(i,k)=nidep(i,k)*rho(i,k)
                  nimey(i,k)=nimey(i,k)*rho(i,k)
 
-                 if (.false.) then
-                    ! cooper curve (factor of 1000 is to convert from L-1 to m-3)
-                    !dum2i(i,k)=0.005_r8*exp(0.304_r8*(273.15_r8-t(i,k)))*1000._r8
-
-                    ! put limit on number of nucleated crystals, set to number at T=-30 C
-                    ! cooper (limit to value at -35 C)
-                    !dum2i(i,k)=min(dum2i(i,k),208.9e3_r8)/rho(i,k) ! convert from m-3 to kg-1
-                 end if
-
               else
                  dum2i(i,k)=0._r8
               end if
@@ -2334,15 +2290,15 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
               ! Bergeron process
               ! If 0C< T <-40C and both ice and liquid exist
               if (.false.) then
-              if (t(i,k).le.273.15_r8 .and. t(i,k).gt.233.15_r8 .and.  &
-                 qiic(i,k).gt.0.5e-6_r8 .and. qcic(i,k).gt. qsmall)  then
-                 plevap = qcic(i,k)/bergtsf
-                 prb(k) = max(0._r8,plevap) 
-                 nprb(k) = prb(k)/(qcic(i,k)/ncic(i,k))
-              else
-                 prb(k)=0._r8
-                 nprb(k)=0._r8
-              end if
+                if (t(i,k).le.273.15_r8 .and. t(i,k).gt.233.15_r8 .and.  &
+                   qiic(i,k).gt.0.5e-6_r8 .and. qcic(i,k).gt. qsmall)  then
+                   plevap = qcic(i,k)/bergtsf
+                   prb(k) = max(0._r8,plevap) 
+                   nprb(k) = prb(k)/(qcic(i,k)/ncic(i,k))
+                else
+                   prb(k)=0._r8
+                   nprb(k)=0._r8
+                end if
               else
               !  Rotstayn et al.(2000)  
               if (t(i,k).le.273.15_r8 .and. t(i,k).gt.233.15_r8 .and.  &
@@ -2476,13 +2432,6 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
 
                  nnucct(k) = (dfaer1*nacon1+dfaer2*nacon2+dfaer3*nacon3+dfaer4*nacon4)*2._r8*pi*  &
                     cdist1(k)*gamma(pgam(i,k)+2._r8)/lamc(i,k)
-
-                 !              if (nnuccc(k).gt.nnuccd(k)) then
-                 !                 dum=nnuccd(k)/nnuccc(k)
-                 ! scale mixing ratio of droplet freezing with limit
-                 !                 mnuccc(k)=mnuccc(k)*dum
-                 !                 nnuccc(k)=nnuccd(k)
-                 !              end if
  
               else
                  mnuccc(k) = 0._r8
@@ -2531,7 +2480,6 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
               qce = mu(i,k)*qc(i,k)-fholm(i,k) +dz(i,k)*cmel(i,k-1)
               dum = arcf(i,k)*(pra(k)+prc(k)+prb(k)+mnuccc(k)+mnucct(k)+msacwi(k)+   &
                                psacws(k)+psacwg(k)+pgsacw(k) +qmultg(k)+psacwi(k) )*dz(i,k)
-!                               psacws(k))*dz(i,k)
               if( qce.lt.0._r8)  then
                  qcimp(k) = .true.              
                  prc(k) = 0._r8
@@ -2585,53 +2533,12 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                  npsacwg(k)= npsacwg(k)*ratio
                  npsacwi(k)=npsacwi(k)*ratio
               end if
- 
-              ! conservation of qi
-!              qie = mu(i,k)*qi(i,k)+fholm(i,k) +dz(i,k)*(cmei(i,k-1) +  &
-!                    ( mnuccc(k)+mnucct(k)+msacwi(k)+prb(k)+qmultg(k)+qmultrg(k)+psacwi(k))*arcf(i,k) )
-!              dum = arcf(i,k)*(prci(k)+ prai(k)+praci(k)+pracis(k))*dz(i,k) 
-!!              dum = arcf(i,k)*(prci(k)+ prai(k))*dz(i,k)
-!              if (qie.lt.0._r8) then
-!                 qiimp(k) = .true.
-!                 prci(k) = 0._r8
-!                 prai(k) = 0._r8
-!                 praci(k)= 0._r8
-!                 pracis(k)= 0._r8
-!              else if (dum.gt.qie) then
-!                 ratio = qie/dum*omsm
-!                 prci(k) = prci(k)*ratio
-!                 prai(k) = prai(k)*ratio
-!                 praci(k)= praci(k)*ratio
-!                 pracis(k) = pracis(k)*ratio
-!              end if
-
-              ! conservation of ni
-!              nie = mu(i,k)*ni(i,k)+fholn(i,k) +dz(i,k)*(nnuccd(k)*mtime*arcf(i,k)   &
-!                    +(nnuccc(k)+ nnucct(k)+nmultg(k)+ nmultrg(k))*arcf(i,k) )
-!              dum = arcf(i,k)*dz(i,k)*(-nsacwi(k)+nprci(k)+ nprai(k)+niacr(k)+niacrs(k))
-!!              dum = arcf(i,k)*dz(i,k)*(-nsacwi(k)+nprci(k)+ nprai(k))
-!              if( nie.lt.0._r8) then
-!                 niimp(k) = .true.
-!                 nsacwi(k)= 0._r8
-!                 nprci(k) = 0._r8
-!                 nprai(k) = 0._r8
-!                 niacr(k) = 0._r8
-!                 niacrs(k)= 0._r8
-!              else  if (dum.gt.nie) then
-!                 ratio = nie/dum*omsm
-!                 nsacwi(k)= nsacwi(k)*ratio
-!                 nprci(k) = nprci(k)*ratio
-!                 nprai(k) = nprai(k)*ratio
-!                 niacr(k) = niacr(k)*ratio
-!                 niacrs(k)=niacrs(k)*ratio
-!              end if
 
               ! conservation of qr
 
               qre = mu(i,k)*qr(i,k)+dz(i,k)*(pra(k)+prc(k))*arcf(i,k)
               dum = arcf(i,k)*dz(i,k)*(pracs(k)+ mnuccr(k)-prf(k)+pracg(k)+pgracs(k)    &
                             +piacr(k)+piacrs(k)+qmultrg(k) ) 
-!              dum = arcf(i,k)*dz(i,k)*(pracs(k)+ mnuccr(k)-prf(k)) 
 
               if (qre.lt.0._r8) then
                  prf(k) = 0._r8
@@ -2719,9 +2626,6 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                                                                               
               ! conservation of qni
 
-!              qnie = mu(i,k)*qni(i,k)+dz(i,k)*( (prai(k)+psacws(k)+prci(k)+     &
-!                 pracs(k)+mnuccr(k))*arcf(i,k) )
-!              dum = arcf(i,k)*dz(i,k)*(-psf(k))
               qnie = mu(i,k)*qni(i,k)+dz(i,k)*( (prai(k)+psacws(k)+prci(k)+     &
                      pracs(k)+piacrs(k)+pracis(k) )*arcf(i,k) )
               dum = arcf(i,k)*dz(i,k)*(-psf(k)+ psacr(k) )
@@ -2736,8 +2640,6 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
               end if
 
               ! conservation of ns
-!              nse = mu(i,k)*ns(i,k)+dz(i,k)*(nprci(k)+nnuccr(k))*arcf(i,k)
-!              dum = arcf(i,k)*dz(i,k)*(-nsagg(k)-pnsf(k))
               nse = mu(i,k)*ns(i,k)+dz(i,k)*(nprci(k)+niacrs(k))*arcf(i,k)
               dum = arcf(i,k)*dz(i,k)*(-nsagg(k)-pnsf(k)+nscng(k)+ngracs(k))
               if (nse.lt.0._r8) then
@@ -2783,20 +2685,15 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
               !*****************************************************************************
 
               if (k.le.kqc(i))   then
-!                 qctend(i,k) = (-pra(k)-prc(k)-prb(k)-mnuccc(k)-mnucct(k)-msacwi(k)- &   
-!                                psacws(k))
                  qctend(i,k) = (-pra(k)-prc(k)-prb(k)-mnuccc(k)-mnucct(k)-msacwi(k)- &
                                 psacws(k))-psacwg(k) -pgsacw(k) -qmultg(k)-psacwi(k)
 
-!                 qitend(i,k) = (prb(k)+mnuccc(k)+mnucct(k)+msacwi(k)-prci(k)- prai(k))
                  qitend(i,k) = (prb(k)+mnuccc(k)+mnucct(k)+msacwi(k)-prci(k)- prai(k))  &
                                 -praci(k)-pracis(k)+qmultg(k)+ qmultrg(k)+psacwi(k) 
 
-!                qrtend(i,k) = (pra(k)+prc(k))+(-pracs(k)- mnuccr(k))
                  qrtend(i,k) = pra(k)+prc(k)-pracs(k)-mnuccr(k)-pracg(k)-pgracs(k)  &
                                -piacr(k)-piacrs(k) -qmultrg(k) 
 
-!                qnitend(i,k) = (prai(k)+psacws(k)+prci(k))+(pracs(k)+mnuccr(k))
                  qnitend(i,k) = (prai(k)+psacws(k)+prci(k))+pracs(k)-psacr(k)+piacrs(k)   &
                                  +pracis(k)
                  
@@ -2814,13 +2711,10 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
 
                  nctend(i,k) = npccn(k)*mtimec+(-nnuccc(k)-nnucct(k)-npsacws(k) &    
                                -npra(k)-nprc1(k)-nprb(k)- npsacwg(k)-npsacwi(k))                           
-!                              -npra(k)-nprc1(k)-nprb(k))
 
                  nitend(i,k) = nnuccd(k)*mtime+(nnuccc(k)+ nnucct(k)+nsacwi(k)-nprci(k)- &
                                nprai(k)) - niacr(k)-niacrs(k)+nmultg(k)+ nmultrg(k) 
-!                               nprai(k))
 
-!                 nstend(i,k) = nsagg(k)+nnuccr(k) + nprci(k)
                  nstend(i,k) = nsagg(k) + nprci(k)- nscng(k)-ngracs(k)+niacrs(k) 
 
                  nrtend(i,k) = nprc(k)+(-npracs(k)-nnuccr(k) +nragg(k))-niacr(k)-niacrs(k)  &
@@ -2915,7 +2809,6 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                  ng(i,k-1) = 1._r8/mu(i,k-1)*                                        &
                     (mu(i,k)*ng(i,k)+dz(i,k)*(ngtend(i,k)+pngf(k))*arcf(i,k) )
                  ng(i,k-1) = max(ng(i,k-1),0._r8)    
-!                 if (ng(i,k-1) .lt. 0._r8) write(*,*) "ng(i,k-1)<0,k=",k,"i=",i
               else
                  qg(i,k-1)=0._r8
                  ng(i,k-1)=0._r8
@@ -2930,11 +2823,9 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
 
               ! snow
               if ( k.le.kqi(i) ) then
-!                 qni(i,k-1) = 1._r8/mu(i,k-1)*                                    &
                  qni(i,k-1) = 1._r8/(mu(i,k-1)+dz(i,k)*du(i,k-1) )*                &
                     (mu(i,k)*qni(i,k)+dz(i,k)*(qnitend(i,k)+psf(k))*arcf(i,k) )
                  
-!                 ns(i,k-1) = 1._r8/mu(i,k-1)*                                    &
                  ns(i,k-1) = 1._r8/(mu(i,k-1)+dz(i,k)*du(i,k-1)  )*                                    &
                     (mu(i,k)*ns(i,k)+dz(i,k)*(nstend(i,k)+pnsf(k))*arcf(i,k) )
                  ns(i,k-1) = max(ns(i,k-1),0._r8)
@@ -2997,7 +2888,6 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                  qr(i,k-1)=(1._r8-dum)*qr(i,k-1)
                  nr(i,k-1)=(1._r8-dum)*nr(i,k-1)
                  nr(i,k-1) = max(nr(i,k-1),0._r8)
-!                 fhmrm(i,k-1) = -mu(i,k-1)*dum*qr(i,k-1)/dz(i,k)
               end if
 
               rprd(i,k-1)= (qnitend(i,k) + qrtend(i,k)+ qgtend(i,k) )*arcf(i,k) + dsfm(i,k-1)
@@ -3089,8 +2979,6 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
               end if            
 
 
-!              frz(i,k-1) = cmei(i,k-1) + arcf(i,k)*(prb(k)+mnuccc(k)+mnucct(k)+msacwi(k)+   &
-!                     pracs(k)+mnuccr(k)+psacws(k) )-fhmlm(i,k-1)-fhmrm(i,k-1)
               frz(i,k-1) = cmei(i,k-1) + arcf(i,k)*(prb(k)+mnuccc(k)+mnucct(k)+msacwi(k)+   &
                      pracs(k)+mnuccr(k)+psacws(k)+pracg(k)+psacwg(k)+pgsacw(k)+pgracs(k)+   &
                      piacr(k)+piacrs(k)+qmultg(k)+ qmultrg(k)+psacwi(k) )-fhmlm(i,k-1)-fhmrm(i,k-1)
@@ -3115,7 +3003,6 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                  ! add upper limit to in-cloud number concentration to prevent numerical error
                  ni(i,k-1)=min(ni(i,k-1),qi(i,k-1)*1.e20_r8)
                  ! ni should be non-negative
-                 ! ni(i,k-1) = max(ni(i,k-1), 0._r8)
                  if (ni(i,k-1).lt. 0._r8) write(iulog,*) "ni(i,k-1)=",ni(i,k-1)
 
                  lami(k-1) = (gamma(1._r8+di)*ci* &
@@ -3182,7 +3069,6 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                  ! add upper limit to in-cloud number concentration to prevent numerical error
                  nc(i,k-1)=min(nc(i,k-1),qc(i,k-1)*1.e20_r8)
                  ! and make sure it's non-negative
-                 ! nc(i,k-1) = max(nc(i,k-1), 0._r8)
                  if (nc(i,k-1).lt. 0._r8) write(iulog,*) "nc(i,k-1)=",nc(i,k-1) 
 
                  ! get pgam from fit to observations of martin et al. 1994
@@ -3305,8 +3191,6 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                  n0s(k-1) = ns(i,k-1)*lams(k-1)
 
                  ! check for slope
-!                 lammax = 1._r8/10.e-6_r8
-!                 lammin = 1._r8/2000.e-6_r8
                  lammax = 1._r8/dcs
                  lammin = 1._r8/5000.e-6_r8
 
@@ -3345,10 +3229,6 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                  nsde(i,k-1)   = 0._r8
                  dsfm  (i,k-2) = 0._r8
                  dsfn  (i,k-2) = 0._r8
-!                 qnide(i,k-1)   = qni(i,k-1)
-!                 nsde(i,k-1)   = ns(i,k-1)
-!                 dsfm  (i,k-2) = -du(i,k-2)*qnide(i,k-1)
-!                 dsfn  (i,k-2) = -du(i,k-2)*nsde(i,k-1)                 
               
               end if
 
@@ -3384,13 +3264,6 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                   umg(k-1) = 0._r8
                   ung(k-1) = 0._r8
               end if
-
-!              rprd(i,k-1)= (qnitend(i,k) + qrtend(i,k))*arcf(i,k)
-!              sprd(i,k-1)=  qnitend(i,k) *arcf(i,k) -fhmrm(i,k-1)       
-!              rprd(i,k-1)= (qnitend(i,k) + qrtend(i,k)+ qgtend(i,k) )*arcf(i,k)
-!              sprd(i,k-1)= (qnitend(i,k)+qgtend(i,k)) *arcf(i,k) -fhmrm(i,k-1)
-!              rprd(i,k-1)= (qnitend(i,k) + qrtend(i,k)+ qgtend(i,k) )*arcf(i,k) + dsfm(i,k-1)
-!              sprd(i,k-1)= (qnitend(i,k)+qgtend(i,k)) *arcf(i,k) -fhmrm(i,k-1) + dsfm(i,k-1)
 
            end if  ! k<jlcl
 


### PR DESCRIPTION
This branch adds the following enhancements to the ZM scheme to the NGD_v3atm branch:
* Multiscale Coherent Structure Parameterization - implemented to represent the effects of organized mesoscale convective systems. 
* ZM convective cloud microphysics - developed from a two-moment four-class (cloud water, cloud ice, rain, and snow) convective microphysics scheme (Song and Zhang 2011, Song et al. 2012) by further representing the microphysical processes related to the fifth hydrometeor species, graupel, and the interaction between microphysics and cloud thermodynamics. The scheme is linked to aerosols through cloud ice nucleation and droplet activation parameterizations. Currently, the wet aerosol scavenging by convective clouds is not considered in the microphysics scheme since it is already considered in the aerosol module. This one-way coupling between microphysics and aerosol module enables the microphysics scheme to represent the impact of aerosols on convective clouds and avoid the double counting of the impact of convective clouds on aerosols.
* ZM mass flux adjustment - developed to better couple convection and circulation. 

Confluence page with info tracking tests, etc: https://acme-climate.atlassian.net/wiki/spaces/NGDAP/pages/3530719233/Add+ZM+enhancements+to+v3atm+fork

[Stealth]
