### PR TITLE
Link MOSAIC nitrate and MAM5 strat sulfate treatment

### DIFF
--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -1268,7 +1268,6 @@ if ($aer_model eq 'mam' ) {
             [qw(A A)],
             );
     }
-# kzm ++
     } elsif($aero_modes eq '5mode') {
       # For 7 sulfate modes
 
@@ -1314,8 +1313,40 @@ if ($aer_model eq 'mam' ) {
             );
     }
     else{
-     @mode_spec     = (
-     [qw(so4_a1 pom_a1 soa_a1 bc_a1 dst_a1 ncl_a1 mom_a1)],
+     if ($mosaic_spec == 1) {
+        @mode_spec     = (
+            [qw(so4_a1 pom_a1 soa_a1 bc_a1 dst_a1 ncl_a1 mom_a1 nh4_a1 no3_a1 ca_a1 co3_a1 cl_a1)],
+            [qw(so4_a2 soa_a2 ncl_a2 mom_a2 nh4_a2 no3_a2 cl_a2)],
+            [qw(dst_a3 ncl_a3 so4_a3 bc_a3 pom_a3 soa_a3 mom_a3 nh4_a3 no3_a3 ca_a3 co3_a3 cl_a3)],
+            [qw(pom_a4 bc_a4 mom_a4)],
+            [qw(so4_a5)],
+            );
+        @mode_spec_type = (
+            [qw(sulfate p-organic s-organic black-c dust seasalt m-organic ammonium nitrate calcium carbonate chloride)],
+            [qw(sulfate s-organic seasalt m-organic ammonium nitrate chloride)],
+            [qw(dust seasalt sulfate black-c p-organic s-organic m-organic ammonium nitrate calcium carbonate chloride)],
+            [qw(p-organic black-c m-organic)],
+            [qw(sulfate)],
+            );
+        @mode_spec_cw  = (
+            [qw(so4_c1 pom_c1 soa_c1 bc_c1 dst_c1 ncl_c1 mom_c1 nh4_c1 no3_c1 ca_c1 co3_c1 cl_c1)],
+            [qw(so4_c2 soa_c2 ncl_c2 mom_c2 nh4_c2 no3_c2 cl_c2)],
+            [qw(dst_c3 ncl_c3 so4_c3 bc_c3 pom_c3 soa_c3 mom_c3 nh4_c3 no3_c3 ca_c3 co3_c3 cl_c3)],
+            [qw(pom_c4 bc_c4 mom_c4)],
+            [qw(so4_c5)],
+            );
+        @mode_num_src  = qw(A A A A A);
+        @mode_spec_src = (
+            [qw(A A A A A A A A A A A A)],
+            [qw(A A A A A A A)],
+            [qw(A A A A A A A A A A A A)],
+            [qw(A A A)],
+            [qw(A)],
+            );
+     }
+     else {
+        @mode_spec     = (
+            [qw(so4_a1 pom_a1 soa_a1 bc_a1 dst_a1 ncl_a1 mom_a1)],
             [qw(so4_a2 soa_a2 ncl_a2 mom_a2)],
             [qw(dst_a3 ncl_a3 so4_a3 bc_a3 pom_a3 soa_a3 mom_a3)],
             [qw(pom_a4 bc_a4 mom_a4)],
@@ -1343,10 +1374,9 @@ if ($aer_model eq 'mam' ) {
             [qw(A A A)],
             [qw(A)],
             );
+         }
     }
 
-
-# kzm -- 
   } elsif($aero_modes eq '4mode_mom') {
       # For 4 modes
 
@@ -1945,7 +1975,6 @@ if ($chem =~ /trop_mozart/ or $chem =~ /trop_strat/ ) {
                    'num_a2   -> ' => 'num_a2_emis_file',
 		   );
         %verhash = ('ver'=>'mam');
-  # wmx ++
    } elsif ($chem =~ /mam4_resus_mom/ ||  $chem =~ /mam5/) {
         %species = (%species,
                    'bc_a4     -> ' => 'bc_a4_emis_file',
@@ -1957,7 +1986,6 @@ if ($chem =~ /trop_mozart/ or $chem =~ /trop_strat/ ) {
                    'num_a4    -> ' => 'mam7_num_a3_emis_file',
                    );
         %verhash = ('ver'=>'mam');
-   # wmx --
     } elsif ($chem =~ /mam4/ ) {
         %species = (%species,
                    'bc_a4     -> ' => 'bc_a4_emis_file',
@@ -3162,6 +3190,17 @@ if ($chem eq 'superfast_mam4_resus_mom_soag') {
     # tentatively add chemUCI-Linozv2|3 additional species here with superfast_mam4_resus_soag
     # May later add a block to use a new chem package name in parallel with superfast_mam4_resus_soag 
     if ($opts{'use_case'} =~ /chemUCI-Linoz/) {
+        if ($mosaic_spec == 1) {
+        %species = ( %species,
+                'NH3       -> ' => 'nh3_emis_file',
+                'C2H4      -> ' => 'c2h4_emis_file',
+                'C2H6      -> ' => 'c2h6_emis_file',
+                'C3H8      -> ' => 'c3h8_emis_file',
+                'CH3CHO    -> ' => 'ch3cho_emis_file',
+                'CH3COCH3  -> ' => 'ch3coch3_emis_file',
+                'E90       -> ' => 'e90_emis_file', );
+        }
+        else {
         %species = ( %species,
                 'C2H4      -> ' => 'c2h4_emis_file',
                 'C2H6      -> ' => 'c2h6_emis_file',
@@ -3169,6 +3208,7 @@ if ($chem eq 'superfast_mam4_resus_mom_soag') {
                 'CH3CHO    -> ' => 'ch3cho_emis_file',
                 'CH3COCH3  -> ' => 'ch3coch3_emis_file',
                 'E90       -> ' => 'e90_emis_file', );
+        }
     }
     my %verhash = ('ver'=>'mam');
     my $first = 1;

--- a/components/eam/bld/configure
+++ b/components/eam/bld/configure
@@ -841,9 +841,6 @@ $cfg_ref->set('chem', $chem_pkg);
 
 # mosaic option in mam
 if (defined $opts{'mosaic'}) {
-   if ($chem_pkg !~ /_mam4/) {
-	    die "ERROR: The mosaic option is only valid with MAM4 aerosols.\n";
-   }
    $cfg_ref->set('mosaic', $opts{'mosaic'});
 }
 my $mosaic = $cfg_ref->get('mosaic');

--- a/components/eam/chem_proc/inputs/pp_chemUCI_linozv3_mam4_resus_mom_soag_mosaic_tag.in
+++ b/components/eam/chem_proc/inputs/pp_chemUCI_linozv3_mam4_resus_mom_soag_mosaic_tag.in
@@ -1,0 +1,300 @@
+Comments
+     "last touch 20200326 - QT"
+     "Modified by Juno Hsu and Qi Tang - 4/9/2020"
+     "chemUCI + MAM4 for E3SM"
+     "last touch 20200331 - MJP"
+End Comments
+
+SPECIES
+
+ Solution
+* UCI Chem species
+  O3
+  OH
+  HO2
+  H2O2
+  CH2O
+  CH3O2
+  CH3OOH -> CH4O2
+  HCL -> HCl
+  NH3
+  NO
+  NO2
+  NO3
+  N2O5
+  HNO3
+  HO2NO2
+  PAN -> CH3CO3NO2
+  CO
+  C2H6
+  C3H8
+  C2H4
+  ROHO2 -> C2H5O3
+  CH3COCH3
+  C2H5O2
+  C2H5OOH
+  CH3CHO
+  CH3CO3
+  ISOP -> C5H8
+  ISOPO2 -> HOCH2COOCH3CHCH2
+  MVKMACR -> C4H6O
+* MVKMACR = sum of MVK -> CH2CHCOCH3 + MACR -> CH2CCH3CHO
+  MVKO2 -> C4H7O4
+  E90 -> O3
+  N2OLNZ -> N2
+  NOYLNZ -> N
+  CH4LNZ -> CH4
+  H2OLNZ -> H2O
+* MAM4 species
+  DMS -> C2H6S
+  SO2 -> O2S
+  H2SO4
+  SOAG -> C
+  so4_a1 -> SO4
+  so4_a2 -> SO4
+  so4_a3 -> SO4
+  nh4_a1 -> NH4
+  nh4_a2 -> NH4
+  nh4_a3 -> NH4
+  no3_a1 -> NO3
+  no3_a2 -> NO3
+  no3_a3 -> NO3
+  pom_a1 -> C
+* pom_a2 does not exist
+  pom_a3 -> C
+  pom_a4 -> C
+  soa_a1 -> C
+  soa_a2 -> C
+  soa_a3 -> C
+  bc_a1 -> C
+* bc_a2 does not exist
+  bc_a3 -> C
+  bc_a4 -> C
+  dst_a1 -> AlSiO5
+* dst_a2 does not exist
+  dst_a3 -> AlSiO5
+* dst_a4 does not exist
+  ca_a1 -> Ca
+  ca_a3 -> Ca
+  co3_a1 -> CO3
+  co3_a3 -> CO3
+  ncl_a1 -> Na
+  ncl_a2 -> Na
+  ncl_a3 -> Na
+  cl_a1 -> Cl
+  cl_a2 -> Cl
+  cl_a3 -> Cl
+  mom_a1 -> C8520H11360O8520
+  mom_a2 -> C8520H11360O8520
+  mom_a3 -> C8520H11360O8520
+  mom_a4 -> C8520H11360O8520
+  num_a1 -> H
+  num_a2 -> H
+  num_a3 -> H
+  num_a4 -> H
+ End Solution
+
+ Fixed
+   M, N2, O2, H2O, H2, CH4
+ End Fixed
+
+ Col-int
+   O3 = 0.
+   O2 = 0.
+ End Col-int
+
+End SPECIES
+
+
+Solution Classes
+
+ Explicit
+   CO, C2H6, C3H8, CH3COCH3
+   E90, N2OLNZ, NOYLNZ, CH4LNZ, H2OLNZ
+   DMS, SO2, H2SO4, SOAG
+   so4_a1,  so4_a2,  so4_a3
+   nh4_a1,  nh4_a2,  nh4_a3
+   no3_a1,  no3_a2,  no3_a3
+   pom_a1,           pom_a3,  pom_a4
+   soa_a1,  soa_a2,  soa_a3
+   bc_a1,            bc_a3,   bc_a4
+   dst_a1,           dst_a3
+   ca_a1,            ca_a3
+   co3_a1,           co3_a3
+   ncl_a1,  ncl_a2,  ncl_a3
+   cl_a1,   cl_a2,   cl_a3
+   mom_a1,  mom_a2,  mom_a3,  mom_a4
+   num_a1,  num_a2,  num_a3,  num_a4
+ End Explicit
+
+ Implicit
+   O3, OH, HO2, H2O2, CH2O, CH3O2, CH3OOH
+   NO, NO2, NO3, N2O5, HNO3, HO2NO2, PAN
+   C2H5O2, C2H5OOH, CH3CHO, CH3CO3, C2H4, ROHO2
+   ISOP, ISOPO2, MVKMACR, MVKO2, NH3, HCL
+ End Implicit
+
+End Solution Classes
+
+
+CHEMISTRY
+
+ Photolysis
+  [jo1dU->,jo3_a]   O3 + hv -> O3
+* Production rate of O(1D), this rate is null so as to not lose O3.
+  [jo2_b=userdefined,]    O2 + hv -> 2*O3
+*  [jo2]       O2 + hv -> 2*O3
+  [jh2o2]     H2O2 + hv -> 2*OH
+  [jch2o_a]   CH2O + hv -> CO + 2*HO2
+  [jch2o_b]   CH2O + hv -> CO + H2
+  [jch3ooh]   CH3OOH + hv -> CH2O + HO2 + OH
+  [jc2h5ooh->,jch3ooh]   C2H5OOH + hv -> CH3CHO + HO2 + OH
+*  [jc2h5ooh]  C2H5OOH + hv -> CH3CHO + HO2 + OH
+  [jno2]      NO2 + hv -> NO + O3
+  [jno3_a]    NO3 + hv -> NO2 + O3
+  [jno3_b]    NO3 + hv -> NO
+*  [jno3]      NO3 + hv -> 0.114*NO + 0.886*NO2 + 0.886*O3
+  [jn2o5_a]   N2O5 + hv -> NO2 + NO3
+  [jn2o5_b]   N2O5 + hv -> NO + O3 + NO3
+*  [jn2o5]     N2O5 + hv -> NO2 + NO3
+  [jhno3]     HNO3 + hv -> NO2 + OH
+  [jho2no2_a] HO2NO2 + hv -> OH + NO3
+  [jho2no2_b] HO2NO2 + hv -> NO2 + HO2
+*  [jho2no2]   HO2NO2 + hv -> 0.67*NO2 + 0.67*HO2 + 0.33*OH + 0.33*NO3
+  [jch3cho]   CH3CHO + hv -> CH3O2 + HO2 + CO
+  [jpan]      PAN + hv -> CH3CO3 + NO2
+  [jacet]     CH3COCH3 + hv -> 0.67*CH3CO3 + 1.33*CH3O2 + 0.33*CO
+*        with Fast-J update to include [jacet_b]= 1/2[jacet_a]  CH3COCH3 + hv -> 2*CH3O2 + CO
+*            = 2/3[CH3CO3 + CH3O2] + 1/3[2*CH3O2 + CO]
+  [jmvk]      MVKMACR + hv -> 2.0*CH2O + 1.5*CO + 0.5*CH3O2 + 0.5*HO2
+*        with Fast-J update to merge values w/[jmacr] = 1/3[jmvk] ?
+*             MACR +hv -> CH2O + 2.0*CO + CH3O2 + HO2
+*             MVK + hv -> 3*CH2O + CO    **final products estimated
+ End Photolysis
+
+ Reactions
+[uci1] O3 + H2O -> 2*OH                           ; 1.630E-10, 60
+*   fix typo, exp(-B/T), B=60 (JPL15)
+[uci2] O3 + H2 -> OH + HO2                        ; 1.200E-10,  0
+[uci3] O3 + CH4LNZ -> OH + CH3OO                     ; 1.750E-10,  0
+*  These 3 rates for O(1D) rxt w/ H2O, H2, CH4 are scaled with jo1d and divided
+*     by the key quenching rates are: N2 = 3.30e-11 exp(55/T), O2 = 2.15e-11 exp(110/T)
+*     and H2O = 1.63e-10 exp(60/T), and then multiplied by the rates above.
+*  effectively k[uci1] = J(jo1d)*1.63e-10*exp(60/T) /
+*     (1.63e-10*exp(60/T)*[H2O] + 3.30e-11*exp(55/T)*[N2] + 2.15e-11*exp(110/T)*[O2])
+*  and rxt[uci1] = k[uci1]*[O3]*[H2O]
+[lco_h]      CO + OH -> H                                   ; 1.500E-13,  0
+[lco_ho2]    CO + OH + M -> HO2 + M                         ; 5.90e-33, 1.0, 1.10E-12, -1.3, 0.6
+[lh2_ho2]    H2 + OH -> HO2 + H2O                           ; 2.800E-12, -1800
+[lch4]       CH4LNZ + OH -> CH3O2 + H2O                     ; 2.450E-12, -1775
+[lc2h6]      C2H6 + OH -> C2H5O2                            ; 7.660E-12, -1020
+[lc3h8]      C3H8 + OH -> HO2 + 0.80*CH3COCH3 + 0.20*CH3CHO ; 8.700E-12, -615
+[lc2h4_oh]   C2H4 + OH + M -> ROHO2                         ; 1.10E-28, 3.5, 8.40E-12, 1.75, 0.6
+[lc2h4_o3]   C2H4 + O3 -> CH2O + CO + 0.5*CH3CHO            ; 1.200E-14, -2630
+[lisop_o3]   ISOP + O3 -> MVKMACR + CH2O + OH               ; 1.100e-14, -2000
+[lisop_oh]   ISOP + OH -> ISOPO2                            ; 3.000E-11, 360
+[lch2o]      CH2O + OH -> CO + H2O + HO2                    ; 5.500E-12, 125
+[lo3_oh]     OH + O3 -> HO2 + O2                            ; 1.700E-12, -940
+[po3_oh]     OH + OH -> O3 + H2O                            ; 1.800E-12, 0
+[lo3_ho2]    HO2 + O3 -> 2*O2 + OH                          ; 1.000E-14, -490
+[lho2_oh]    HO2 + OH -> H2O + O2                           ; 4.800E-11, 250
+[uci4]  HO2 + HO2 + M -> H2O2 + M                 ; 2.100E-33, 920
+*     k[uci4] -> k[uci4] * (1 + 1.4e-21*exp(2200/T)*[H2O])
+[uci5]  HO2 + HO2 -> H2O2                         ; 3.000E-13, 460
+*     k[uci5] -> k[uci5] * (1 + 1.4e-21*exp(2200/T)*[H2O])
+[ph2o2]     OH + OH + M -> H2O2 + M                        ; 6.90e-31, 1.0,  2.60e-11, 0.0, 0.6
+[lh2o2]     H2O2 + OH -> H2O + HO2                         ; 1.800E-12, 0
+[lo3_no]    NO + O3 -> NO2 + O2                            ; 3.000E-12, -1500
+[lno_ho2]   NO + HO2 -> NO2 + OH                           ; 3.300E-12, 270
+[lo3_no2]   NO2 + O3 -> NO3 + O2                           ; 1.200E-13, -2450
+[lno3_oh]   OH + NO3 -> HO2 + NO2                          ; 2.200e-11, 0
+[lno3_no]   NO + NO3 -> 2.*NO2                             ; 1.500e-11, 170
+[lhno4]     HO2NO2 + OH -> NO2 + H2O + O2                  ; 1.300E-12, 380
+[lhno3]     HNO3 + OH -> NO3 + H2O                         ; 2.400E-14, 460
+*   fix needed to add this bimolec rate, missing from the one below
+[uci6] HNO3 + OH -> NO3 + H2O
+*    k[uci6] = (k2*k3*[M])/(k2 + k3*[M])  k2=2.7e-17*exp(2199/T)  k3=6.5e-34*exp(1335/T)*[M]
+[lno2_oh]   NO2 + OH + M -> HNO3 + M              ; 1.80e-30, 3.0,  2.80e-11, 0.0, 0.6
+[HO2NO2f]  NO2 + HO2 + M -> HO2NO2 + M            ; 1.90e-31, 3.4,  4.00e-12, 0.3, 0.6
+[N2O5f]  NO2 + NO3 + M -> N2O5 + M                ; 2.40E-30, 3.0,  1.60E-12,-0.1, 0.6
+[PANf]   CH3CO3 + NO2 + M -> PAN + M              ; 9.70E-29, 5.6,  9.30E-12, 1.5, 0.6
+[uci7]   HO2NO2 + M -> HO2 + NO2 + M              ; 2.10E-27, 10900
+*     k[uci7] -> k[HO2NO2] / k[uci7]
+[uci8]   N2O5 + M -> NO2 + NO3 + M                ; 5.80E-27, 10840
+*     k[uci8] -> k[N2O5] / k[uci8]
+[uci9]   PAN + M -> CH3CO3 + NO2 + M              ; 9.00E-29, 14000
+*     k[uci9] -> k[PAN] / k[uci9]
+[lch3o2_ho2]   CH3O2 + HO2 -> CH3OOH + O2                     ; 4.100E-13, 750
+[lch3o2_no]    CH3O2 + NO -> CH2O + HO2 + NO2                 ; 2.800E-12, 300
+[lch3o2]       CH3O2 + CH3O2 -> 2*CH2O +  2*HO2               ; 9.500E-14, 390
+[lch3ooh]      CH3OOH + OH -> 0.7*CH3O2 + 0.3*CH2O + 0.3*OH   ; 3.800E-12, 200
+[lc2h5o2_no]   C2H5O2 + NO -> CH3CHO + HO2 + NO2              ; 2.600E-12, 365
+[lc2h5o2]      C2H5O2 + C2H5O2 -> 2*CH3CHO + 2*HO2            ; 6.800E-14, 0
+[lc2h5o2_ch3]  C2H5O2 + CH3O2 -> CH3CHO + CH2O + 2*HO2        ; 2.500E-14, 0
+[lc2h5o2_ho2]  C2H5O2 + HO2 -> C2H5OOH                        ; 7.500E-13, 700
+[lc2h5ooh_a]   C2H5OOH + OH -> C2H5O2                         ; 1.900E-12, 190
+[lc2h5ooh_b]   C2H5OOH + OH -> CH3CHO + OH                    ; 8.010E-12, 0
+[lch3cho_oh]   CH3CHO + OH -> 0.5*CH3CO3 + 0.5*CH3O2 + 0.5*CO ; 4.630E-12, 350
+[lch3cho_no3]  CH3CHO + NO3 -> CH3CO3 + HNO3                  ; 1.400E-12, -1900
+[lch3co3_no]   CH3CO3 + NO -> CH3O2 + NO2                     ; 8.100E-12, 270
+[lch3co3_ch3]  CH3CO3 + CH3O2 -> CH2O + CH3O2 + HO2           ; 2.000E-12, 500
+[lch3co3]      CH3CO3 + CH3CO3 -> 2*CH3O2                     ; 2.900E-12, 500
+[lch3coch3_a]  CH3COCH3 + OH ->  CH3CO3 + CH2O                ; 1.330e-13, 0
+[lch3coch3_b]  CH3COCH3 + OH ->  CH3CO3 + CH2O                ; 3.820e-11, -2000
+[lroho2_no]    ROHO2 + NO -> CH3CHO + CH2O + NO2              ; 2.700E-12, 360
+[lroho2_ho2]   ROHO2 + HO2 -> CH3CHO + CH2O + OH              ; 1.500E-13, 1300
+[lroho2_ch3o2] ROHO2 + CH3O2 -> CH3CO + 2*CH2O + HO2          ; 1.000E-13, 0
+[lisopo2_no]   ISOPO2 + NO -> MVKMACR + CH2O + NO2            ; 2.700E-12, 360
+[lisopo2_ho2]  ISOPO2 + HO2 -> C2H5OOH + 2*CO                 ; 2.050E-13, 1300
+[lisopo2_ch3]  ISOPO2 + CH3O2 -> MVKMACR + 2*CH2O + 2*HO2     ; 1.000E-13, 0
+[lmvkmacr_o3]  MVKMACR + O3 -> 0.5*CH3CO3 + CH2O + CH3O2      ; 8.500E-16, -1520
+[lmvkmacr_oh]  MVKMACR + OH -> MVKO2                          ; 2.600E-12, 610
+[lmvko2_no]    MVKO2 + NO -> 0.5*CH3CO3 + CH2O + NO2          ; 2.700E-12, 360
+[lmvko2_ho2]   MVKO2 + HO2 -> C2H5OOH + CO                    ; 1.820E-13, 1300
+
+* UCI heterogeneous reactions has problems with E3SM MAM4 aerosols
+* comment out for now. To be fixed with the aerosol team.
+*[ucih1]  N2O5  -> 2*HNO3                          ; 0.05E+00
+*[ucih2]  NO3   -> HNO3                            ; 0.03E+00
+*[ucih3]  HO2   ->                                 ; 0.10E+00
+
+[usr_e90]  E90 ->                                 ; 1.286E-7, 0.
+
+* MAM4 chemistry below
+[ldms_oh]     DMS + OH -> SO2                    ; 9.600E-12, -234
+[usr_DMS_OH]  DMS + OH ->  .5 * SO2 + .5 * HO2
+[usr_SO2_OH]  SO2 + OH -> H2SO4
+[ldms_no3]    DMS + NO3 -> SO2 + HNO3            ; 1.9e-13,  520.
+[NH3_OH]      NH3 + OH -> H2O                    ; 1.70e-12,    -710.
+ End Reactions
+
+ Ext Forcing
+      NO2 <- dataset
+      SO2 <- dataset
+      so4_a1 <- dataset
+      so4_a2 <- dataset
+      pom_a4 <- dataset
+      bc_a4 <- dataset
+      num_a1 <- dataset
+      num_a2 <- dataset
+      num_a4 <- dataset
+      SOAG <- dataset
+ End Ext Forcing
+
+END CHEMISTRY
+
+SIMULATION PARAMETERS
+
+     Version Options
+        model   = cam
+        machine = intel
+        architecture = hybrid
+        vec_ftns  = on
+        multitask = on
+        namemod = on
+        modules = on
+     End Version Options
+
+   END SIMULATION PARAMETERS
+
+ENDSIM

--- a/components/eam/chem_proc/inputs/pp_chemUCI_linozv3_mam5_resus_mom_soag_tag_cnst_no3_oh_mosaic.in
+++ b/components/eam/chem_proc/inputs/pp_chemUCI_linozv3_mam5_resus_mom_soag_tag_cnst_no3_oh_mosaic.in
@@ -1,0 +1,303 @@
+Comments
+     "Changed to Chem-UCI-MAM5 by Ziming Ke"
+     "last touch 20200326 - QT"
+     "Modified by Juno Hsu and Qi Tang - 4/9/2020"
+     "chemUCI + MAM4 for E3SM"
+     "last touch 20200331 - MJP"
+End Comments
+
+SPECIES
+
+ Solution
+* UCI Chem species
+  O3
+  OH
+  HO2
+  H2O2
+  CH2O
+  CH3O2
+  CH3OOH -> CH4O2
+  HCL -> HCl
+  NH3
+  NO
+  NO2
+  NO3
+  N2O5
+  HNO3
+  HO2NO2
+  PAN -> CH3CO3NO2
+  CO
+  C2H6
+  C3H8
+  C2H4
+  ROHO2 -> C2H5O3
+  CH3COCH3
+  C2H5O2
+  C2H5OOH
+  CH3CHO
+  CH3CO3
+  ISOP -> C5H8
+  ISOPO2 -> HOCH2COOCH3CHCH2
+  MVKMACR -> C4H6O
+* MVKMACR = sum of MVK -> CH2CHCOCH3 + MACR -> CH2CCH3CHO
+  MVKO2 -> C4H7O4
+  E90 -> O3
+  N2OLNZ -> N2
+  NOYLNZ -> N
+  CH4LNZ -> CH4
+  H2OLNZ -> H2O
+* MAM4 species
+  DMS -> C2H6S
+  SO2 -> O2S
+  H2SO4
+  SOAG -> C
+  so4_a1 -> SO4
+  so4_a2 -> SO4
+  so4_a3 -> SO4
+  so4_a5 -> SO4
+  nh4_a1 -> NH4
+  nh4_a2 -> NH4
+  nh4_a3 -> NH4
+  no3_a1 -> NO3
+  no3_a2 -> NO3
+  no3_a3 -> NO3
+  pom_a1 -> C
+* pom_a2 does not exist
+  pom_a3 -> C
+  pom_a4 -> C
+  soa_a1 -> C
+  soa_a2 -> C
+  soa_a3 -> C
+  bc_a1 -> C
+* bc_a2 does not exist
+  bc_a3 -> C
+  bc_a4 -> C
+  dst_a1 -> AlSiO5
+* dst_a2 does not exist
+  dst_a3 -> AlSiO5
+* dst_a4 does not exist
+  ca_a1 -> Ca
+  ca_a3 -> Ca
+  co3_a1 -> CO3
+  co3_a3 -> CO3
+  ncl_a1 -> Na
+  ncl_a2 -> Na
+  ncl_a3 -> Na
+  cl_a1 -> Cl
+  cl_a2 -> Cl
+  cl_a3 -> Cl
+  mom_a1 -> C8520H11360O8520
+  mom_a2 -> C8520H11360O8520
+  mom_a3 -> C8520H11360O8520
+  mom_a4 -> C8520H11360O8520
+  num_a1 -> H
+  num_a2 -> H
+  num_a3 -> H
+  num_a4 -> H
+  num_a5 -> H
+ End Solution
+
+ Fixed
+   M, N2, O2, H2O, H2, CH4, cnst_NO3, cnst_OH
+ End Fixed
+
+ Col-int
+   O3 = 0.
+   O2 = 0.
+ End Col-int
+
+End SPECIES
+
+
+Solution Classes
+
+ Explicit
+   CO, C2H6, C3H8, CH3COCH3
+   E90, N2OLNZ, NOYLNZ, CH4LNZ, H2OLNZ
+   DMS, SO2, H2SO4, SOAG
+   so4_a1,  so4_a2,  so4_a3,  so4_a5
+   nh4_a1,  nh4_a2,  nh4_a3
+   no3_a1,  no3_a2,  no3_a3
+   pom_a1,           pom_a3,  pom_a4
+   soa_a1,  soa_a2,  soa_a3
+   bc_a1,            bc_a3,   bc_a4
+   dst_a1,           dst_a3
+   ca_a1,            ca_a3
+   co3_a1,           co3_a3
+   ncl_a1,  ncl_a2,  ncl_a3
+   cl_a1,   cl_a2,   cl_a3
+   mom_a1,  mom_a2,  mom_a3,  mom_a4
+   num_a1,  num_a2,  num_a3,  num_a4, num_a5
+ End Explicit
+
+ Implicit
+   O3, OH, HO2, H2O2, CH2O, CH3O2, CH3OOH
+   NO, NO2, NO3, N2O5, HNO3, HO2NO2, PAN
+   C2H5O2, C2H5OOH, CH3CHO, CH3CO3, C2H4, ROHO2
+   ISOP, ISOPO2, MVKMACR, MVKO2, NH3, HCL
+ End Implicit
+
+End Solution Classes
+
+
+CHEMISTRY
+
+ Photolysis
+  [jo1dU->,jo3_a]   O3 + hv -> O3
+* Production rate of O(1D), this rate is null so as to not lose O3.
+  [jo2_b=userdefined,]    O2 + hv -> 2*O3
+*  [jo2]       O2 + hv -> 2*O3
+  [jh2o2]     H2O2 + hv -> 2*OH
+  [jch2o_a]   CH2O + hv -> CO + 2*HO2
+  [jch2o_b]   CH2O + hv -> CO + H2
+  [jch3ooh]   CH3OOH + hv -> CH2O + HO2 + OH
+  [jc2h5ooh->,jch3ooh]   C2H5OOH + hv -> CH3CHO + HO2 + OH
+*  [jc2h5ooh]  C2H5OOH + hv -> CH3CHO + HO2 + OH
+  [jno2]      NO2 + hv -> NO + O3
+  [jno3_a]    NO3 + hv -> NO2 + O3
+  [jno3_b]    NO3 + hv -> NO
+*  [jno3]      NO3 + hv -> 0.114*NO + 0.886*NO2 + 0.886*O3
+  [jn2o5_a]   N2O5 + hv -> NO2 + NO3
+  [jn2o5_b]   N2O5 + hv -> NO + O3 + NO3
+*  [jn2o5]     N2O5 + hv -> NO2 + NO3
+  [jhno3]     HNO3 + hv -> NO2 + OH
+  [jho2no2_a] HO2NO2 + hv -> OH + NO3
+  [jho2no2_b] HO2NO2 + hv -> NO2 + HO2
+*  [jho2no2]   HO2NO2 + hv -> 0.67*NO2 + 0.67*HO2 + 0.33*OH + 0.33*NO3
+  [jch3cho]   CH3CHO + hv -> CH3O2 + HO2 + CO
+  [jpan]      PAN + hv -> CH3CO3 + NO2
+  [jacet]     CH3COCH3 + hv -> 0.67*CH3CO3 + 1.33*CH3O2 + 0.33*CO
+*        with Fast-J update to include [jacet_b]= 1/2[jacet_a]  CH3COCH3 + hv -> 2*CH3O2 + CO
+*            = 2/3[CH3CO3 + CH3O2] + 1/3[2*CH3O2 + CO]
+  [jmvk]      MVKMACR + hv -> 2.0*CH2O + 1.5*CO + 0.5*CH3O2 + 0.5*HO2
+*        with Fast-J update to merge values w/[jmacr] = 1/3[jmvk] ?
+*             MACR +hv -> CH2O + 2.0*CO + CH3O2 + HO2
+*             MVK + hv -> 3*CH2O + CO    **final products estimated
+ End Photolysis
+
+ Reactions
+[uci1] O3 + H2O -> 2*OH                           ; 1.630E-10, 60
+*   fix typo, exp(-B/T), B=60 (JPL15)
+[uci2] O3 + H2 -> OH + HO2                        ; 1.200E-10,  0
+[uci3] O3 + CH4LNZ -> OH + CH3OO                     ; 1.750E-10,  0
+*  These 3 rates for O(1D) rxt w/ H2O, H2, CH4 are scaled with jo1d and divided
+*     by the key quenching rates are: N2 = 3.30e-11 exp(55/T), O2 = 2.15e-11 exp(110/T)
+*     and H2O = 1.63e-10 exp(60/T), and then multiplied by the rates above.
+*  effectively k[uci1] = J(jo1d)*1.63e-10*exp(60/T) /
+*     (1.63e-10*exp(60/T)*[H2O] + 3.30e-11*exp(55/T)*[N2] + 2.15e-11*exp(110/T)*[O2])
+*  and rxt[uci1] = k[uci1]*[O3]*[H2O]
+[lco_h]      CO + OH -> H                                   ; 1.500E-13,  0
+[lco_ho2]    CO + OH + M -> HO2 + M                         ; 5.90e-33, 1.0, 1.10E-12, -1.3, 0.6
+[lh2_ho2]    H2 + OH -> HO2 + H2O                           ; 2.800E-12, -1800
+[lch4]       CH4LNZ + OH -> CH3O2 + H2O                     ; 2.450E-12, -1775
+[lc2h6]      C2H6 + OH -> C2H5O2                            ; 7.660E-12, -1020
+[lc3h8]      C3H8 + OH -> HO2 + 0.80*CH3COCH3 + 0.20*CH3CHO ; 8.700E-12, -615
+[lc2h4_oh]   C2H4 + OH + M -> ROHO2                         ; 1.10E-28, 3.5, 8.40E-12, 1.75, 0.6
+[lc2h4_o3]   C2H4 + O3 -> CH2O + CO + 0.5*CH3CHO            ; 1.200E-14, -2630
+[lisop_o3]   ISOP + O3 -> MVKMACR + CH2O + OH               ; 1.100e-14, -2000
+[lisop_oh]   ISOP + OH -> ISOPO2                            ; 3.000E-11, 360
+[lch2o]      CH2O + OH -> CO + H2O + HO2                    ; 5.500E-12, 125
+[lo3_oh]     OH + O3 -> HO2 + O2                            ; 1.700E-12, -940
+[po3_oh]     OH + OH -> O3 + H2O                            ; 1.800E-12, 0
+[lo3_ho2]    HO2 + O3 -> 2*O2 + OH                          ; 1.000E-14, -490
+[lho2_oh]    HO2 + OH -> H2O + O2                           ; 4.800E-11, 250
+[uci4]  HO2 + HO2 + M -> H2O2 + M                 ; 2.100E-33, 920
+*     k[uci4] -> k[uci4] * (1 + 1.4e-21*exp(2200/T)*[H2O])
+[uci5]  HO2 + HO2 -> H2O2                         ; 3.000E-13, 460
+*     k[uci5] -> k[uci5] * (1 + 1.4e-21*exp(2200/T)*[H2O])
+[ph2o2]     OH + OH + M -> H2O2 + M                        ; 6.90e-31, 1.0,  2.60e-11, 0.0, 0.6
+[lh2o2]     H2O2 + OH -> H2O + HO2                         ; 1.800E-12, 0
+[lo3_no]    NO + O3 -> NO2 + O2                            ; 3.000E-12, -1500
+[lno_ho2]   NO + HO2 -> NO2 + OH                           ; 3.300E-12, 270
+[lo3_no2]   NO2 + O3 -> NO3 + O2                           ; 1.200E-13, -2450
+[lno3_oh]   OH + NO3 -> HO2 + NO2                          ; 2.200e-11, 0
+[lno3_no]   NO + NO3 -> 2.*NO2                             ; 1.500e-11, 170
+[lhno4]     HO2NO2 + OH -> NO2 + H2O + O2                  ; 1.300E-12, 380
+[lhno3]     HNO3 + OH -> NO3 + H2O                         ; 2.400E-14, 460
+*   fix needed to add this bimolec rate, missing from the one below
+[uci6] HNO3 + OH -> NO3 + H2O
+*    k[uci6] = (k2*k3*[M])/(k2 + k3*[M])  k2=2.7e-17*exp(2199/T)  k3=6.5e-34*exp(1335/T)*[M]
+[lno2_oh]   NO2 + OH + M -> HNO3 + M              ; 1.80e-30, 3.0,  2.80e-11, 0.0, 0.6
+[HO2NO2f]  NO2 + HO2 + M -> HO2NO2 + M            ; 1.90e-31, 3.4,  4.00e-12, 0.3, 0.6
+[N2O5f]  NO2 + NO3 + M -> N2O5 + M                ; 2.40E-30, 3.0,  1.60E-12,-0.1, 0.6
+[PANf]   CH3CO3 + NO2 + M -> PAN + M              ; 9.70E-29, 5.6,  9.30E-12, 1.5, 0.6
+[uci7]   HO2NO2 + M -> HO2 + NO2 + M              ; 2.10E-27, 10900
+*     k[uci7] -> k[HO2NO2] / k[uci7]
+[uci8]   N2O5 + M -> NO2 + NO3 + M                ; 5.80E-27, 10840
+*     k[uci8] -> k[N2O5] / k[uci8]
+[uci9]   PAN + M -> CH3CO3 + NO2 + M              ; 9.00E-29, 14000
+*     k[uci9] -> k[PAN] / k[uci9]
+[lch3o2_ho2]   CH3O2 + HO2 -> CH3OOH + O2                     ; 4.100E-13, 750
+[lch3o2_no]    CH3O2 + NO -> CH2O + HO2 + NO2                 ; 2.800E-12, 300
+[lch3o2]       CH3O2 + CH3O2 -> 2*CH2O +  2*HO2               ; 9.500E-14, 390
+[lch3ooh]      CH3OOH + OH -> 0.7*CH3O2 + 0.3*CH2O + 0.3*OH   ; 3.800E-12, 200
+[lc2h5o2_no]   C2H5O2 + NO -> CH3CHO + HO2 + NO2              ; 2.600E-12, 365
+[lc2h5o2]      C2H5O2 + C2H5O2 -> 2*CH3CHO + 2*HO2            ; 6.800E-14, 0
+[lc2h5o2_ch3]  C2H5O2 + CH3O2 -> CH3CHO + CH2O + 2*HO2        ; 2.500E-14, 0
+[lc2h5o2_ho2]  C2H5O2 + HO2 -> C2H5OOH                        ; 7.500E-13, 700
+[lc2h5ooh_a]   C2H5OOH + OH -> C2H5O2                         ; 1.900E-12, 190
+[lc2h5ooh_b]   C2H5OOH + OH -> CH3CHO + OH                    ; 8.010E-12, 0
+[lch3cho_oh]   CH3CHO + OH -> 0.5*CH3CO3 + 0.5*CH3O2 + 0.5*CO ; 4.630E-12, 350
+[lch3cho_no3]  CH3CHO + NO3 -> CH3CO3 + HNO3                  ; 1.400E-12, -1900
+[lch3co3_no]   CH3CO3 + NO -> CH3O2 + NO2                     ; 8.100E-12, 270
+[lch3co3_ch3]  CH3CO3 + CH3O2 -> CH2O + CH3O2 + HO2           ; 2.000E-12, 500
+[lch3co3]      CH3CO3 + CH3CO3 -> 2*CH3O2                     ; 2.900E-12, 500
+[lch3coch3_a]  CH3COCH3 + OH ->  CH3CO3 + CH2O                ; 1.330e-13, 0
+[lch3coch3_b]  CH3COCH3 + OH ->  CH3CO3 + CH2O                ; 3.820e-11, -2000
+[lroho2_no]    ROHO2 + NO -> CH3CHO + CH2O + NO2              ; 2.700E-12, 360
+[lroho2_ho2]   ROHO2 + HO2 -> CH3CHO + CH2O + OH              ; 1.500E-13, 1300
+[lroho2_ch3o2] ROHO2 + CH3O2 -> CH3CO + 2*CH2O + HO2          ; 1.000E-13, 0
+[lisopo2_no]   ISOPO2 + NO -> MVKMACR + CH2O + NO2            ; 2.700E-12, 360
+[lisopo2_ho2]  ISOPO2 + HO2 -> C2H5OOH + 2*CO                 ; 2.050E-13, 1300
+[lisopo2_ch3]  ISOPO2 + CH3O2 -> MVKMACR + 2*CH2O + 2*HO2     ; 1.000E-13, 0
+[lmvkmacr_o3]  MVKMACR + O3 -> 0.5*CH3CO3 + CH2O + CH3O2      ; 8.500E-16, -1520
+[lmvkmacr_oh]  MVKMACR + OH -> MVKO2                          ; 2.600E-12, 610
+[lmvko2_no]    MVKO2 + NO -> 0.5*CH3CO3 + CH2O + NO2          ; 2.700E-12, 360
+[lmvko2_ho2]   MVKO2 + HO2 -> C2H5OOH + CO                    ; 1.820E-13, 1300
+
+* UCI heterogeneous reactions has problems with E3SM MAM4 aerosols
+* comment out for now. To be fixed with the aerosol team.
+*[ucih1]  N2O5  -> 2*HNO3                          ; 0.05E+00
+*[ucih2]  NO3   -> HNO3                            ; 0.03E+00
+*[ucih3]  HO2   ->                                 ; 0.10E+00
+
+[usr_e90]  E90 ->                                 ; 1.286E-7, 0.
+
+* MAM4 chemistry below
+[ldms_oh]     DMS + OH -> SO2                    ; 9.600E-12, -234
+[usr_DMS_OH]  DMS + OH ->  .5 * SO2 + .5 * HO2
+[usr_SO2_OH]  SO2 + OH -> H2SO4
+[ldms_no3]    DMS + NO3 -> SO2 + HNO3            ; 1.9e-13,  520.
+[NH3_OH]      NH3 + OH -> H2O                    ; 1.70e-12,    -710.
+ End Reactions
+
+ Ext Forcing
+      NO2 <- dataset
+      SO2 <- dataset
+      so4_a1 <- dataset
+      so4_a2 <- dataset
+      pom_a4 <- dataset
+      bc_a4 <- dataset
+      num_a1 <- dataset
+      num_a2 <- dataset
+      num_a4 <- dataset
+      SOAG <- dataset
+ End Ext Forcing
+
+END CHEMISTRY
+
+SIMULATION PARAMETERS
+
+     Version Options
+        model   = cam
+        machine = intel
+        architecture = hybrid
+        vec_ftns  = on
+        multitask = on
+        namemod = on
+        modules = on
+     End Version Options
+
+   END SIMULATION PARAMETERS
+
+ENDSIM

--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -850,7 +850,7 @@ contains
     ! POM mode
     !
     index_tot_mass(4,1) = get_spc_ndx('pom_a4')
-    index_tot_mass(4,2) = get_spc_ndx('bc_a4')
+    index_tot_mass(4,2) = get_spc_ndx('bc_a4' )
     index_tot_mass(4,3) = get_spc_ndx('mom_a4')
     index_chm_mass(4,1) = get_spc_ndx('bc_a4' )
     !
@@ -894,9 +894,9 @@ contains
     ! POM mode
     !
     index_tot_mass(4,1) = get_spc_ndx('pom_a4')
-    index_tot_mass(4,2) = get_spc_ndx('bc_a4')
+    index_tot_mass(4,2) = get_spc_ndx('bc_a4' )
     index_tot_mass(4,3) = get_spc_ndx('mom_a4')
-    index_chm_mass(4,1) = get_spc_ndx('bc_a1' )
+    index_chm_mass(4,1) = get_spc_ndx('bc_a4' )
     !
 #elif ( defined MODAL_AERO_4MODE_MOM )
     !
@@ -932,9 +932,9 @@ contains
     ! POM mode
     !
     index_tot_mass(4,1) = get_spc_ndx('pom_a4')
-    index_tot_mass(4,2) = get_spc_ndx('bc_a4')
+    index_tot_mass(4,2) = get_spc_ndx('bc_a4' )
     index_tot_mass(4,3) = get_spc_ndx('mom_a4')
-    index_chm_mass(4,1) = get_spc_ndx('bc_a1' )
+    index_chm_mass(4,1) = get_spc_ndx('bc_a4' )
     !
 #elif ( ( defined MODAL_AERO_5MODE ) && ( defined RAIN_EVAP_TO_COARSE_AERO ) && ( defined MOSAIC_SPECIES ) )
     !
@@ -995,7 +995,7 @@ contains
     ! POM mode
     !
     index_tot_mass(4,1) = get_spc_ndx('pom_a4')
-    index_tot_mass(4,2) = get_spc_ndx('bc_a4')
+    index_tot_mass(4,2) = get_spc_ndx('bc_a4' )
     index_tot_mass(4,3) = get_spc_ndx('mom_a4')
     index_chm_mass(4,1) = get_spc_ndx('bc_a4' )
     !
@@ -1043,9 +1043,9 @@ contains
     ! POM mode
     !
     index_tot_mass(4,1) = get_spc_ndx('pom_a4')
-    index_tot_mass(4,2) = get_spc_ndx('bc_a4')
+    index_tot_mass(4,2) = get_spc_ndx('bc_a4' )
     index_tot_mass(4,3) = get_spc_ndx('mom_a4')
-    index_chm_mass(4,1) = get_spc_ndx('bc_a1' )
+    index_chm_mass(4,1) = get_spc_ndx('bc_a4' )
     !
     ! strat_coarse
     !
@@ -1086,9 +1086,9 @@ contains
     ! POM mode
     !
     index_tot_mass(4,1) = get_spc_ndx('pom_a4')
-    index_tot_mass(4,2) = get_spc_ndx('bc_a4')
+    index_tot_mass(4,2) = get_spc_ndx('bc_a4' )
     index_tot_mass(4,3) = get_spc_ndx('mom_a4')
-    index_chm_mass(4,1) = get_spc_ndx('bc_a1' )
+    index_chm_mass(4,1) = get_spc_ndx('bc_a4' )
     !
     ! strat_coarse
     !
@@ -1127,8 +1127,8 @@ contains
     ! POM mode
     !
     index_tot_mass(4,1) = get_spc_ndx('pom_a4')
-    index_tot_mass(4,2) = get_spc_ndx('bc_a4')
-    index_chm_mass(4,1) = get_spc_ndx('bc_a1' )
+    index_tot_mass(4,2) = get_spc_ndx('bc_a4' )
+    index_chm_mass(4,1) = get_spc_ndx('bc_a4' )
     !
 #elif ( defined MODAL_AERO_7MODE )
     !

--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -501,9 +501,7 @@ contains
           endif
        enddo
 
-!!#if (defined MODAL_AERO_9MODE || MODAL_AERO_4MODE_MOM)  ! kzm-
-#if (defined MODAL_AERO_9MODE || defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_7MODE_S || defined MODAL_AERO_5MODE)
-! kzm+
+#if ( defined MODAL_AERO_9MODE || defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_7MODE_S || defined MODAL_AERO_5MODE )
        dummy = 'SSTSFMBL_OM'
        call addfld (dummy,horiz_only, 'A','kg/m2/s','Mobilization flux of marine organic matter at surface')
        if (history_aerosol) then
@@ -856,6 +854,50 @@ contains
     index_tot_mass(4,3) = get_spc_ndx('mom_a4')
     index_chm_mass(4,1) = get_spc_ndx('bc_a4' )
     !
+#elif ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined RAIN_EVAP_TO_COARSE_AERO ) )
+    !
+    ! accumulation mode #1
+    !
+    index_tot_mass(1,1) = get_spc_ndx('so4_a1')
+    index_tot_mass(1,2) = get_spc_ndx('pom_a1')
+    index_tot_mass(1,3) = get_spc_ndx('soa_a1')
+    index_tot_mass(1,4) = get_spc_ndx('bc_a1' )
+    index_tot_mass(1,5) = get_spc_ndx('dst_a1')
+    index_tot_mass(1,6) = get_spc_ndx('ncl_a1')
+    index_tot_mass(1,7) = get_spc_ndx('mom_a1')
+    index_chm_mass(1,1) = get_spc_ndx('so4_a1')
+    index_chm_mass(1,2) = get_spc_ndx('soa_a1')
+    index_chm_mass(1,3) = get_spc_ndx('bc_a1' )
+    !
+    ! aitken mode
+    !
+    index_tot_mass(2,1) = get_spc_ndx('so4_a2')
+    index_tot_mass(2,2) = get_spc_ndx('soa_a2')
+    index_tot_mass(2,3) = get_spc_ndx('ncl_a2')
+    index_tot_mass(2,4) = get_spc_ndx('mom_a2')
+    index_chm_mass(2,1) = get_spc_ndx('so4_a2')
+    index_chm_mass(2,2) = get_spc_ndx('soa_a2')
+    !
+    ! coarse mode
+    !
+    index_tot_mass(3,1)  = get_spc_ndx('dst_a3')
+    index_tot_mass(3,2)  = get_spc_ndx('ncl_a3')
+    index_tot_mass(3,3)  = get_spc_ndx('so4_a3')
+    index_tot_mass(3,4)  = get_spc_ndx('bc_a3')
+    index_tot_mass(4,5)  = get_spc_ndx('pom_a3')
+    index_tot_mass(4,6)  = get_spc_ndx('soa_a3')
+    index_tot_mass(4,7)  = get_spc_ndx('mom_a3')
+    index_chm_mass(3,1)  = get_spc_ndx('so4_a3')
+    index_chm_mass(3,2)  = get_spc_ndx('soa_a3')
+    index_chm_mass(3,3)  = get_spc_ndx('bc_a3')
+    !
+    ! POM mode
+    !
+    index_tot_mass(4,1) = get_spc_ndx('pom_a4')
+    index_tot_mass(4,2) = get_spc_ndx('bc_a4')
+    index_tot_mass(4,3) = get_spc_ndx('mom_a4')
+    index_chm_mass(4,1) = get_spc_ndx('bc_a1' )
+    !
 #elif ( defined MODAL_AERO_4MODE_MOM )
     !
     ! accumulation mode #1
@@ -894,8 +936,75 @@ contains
     index_tot_mass(4,3) = get_spc_ndx('mom_a4')
     index_chm_mass(4,1) = get_spc_ndx('bc_a1' )
     !
-!kzm ++
-#elif ( defined MODAL_AERO_5MODE )
+#elif ( ( defined MODAL_AERO_5MODE ) && ( defined RAIN_EVAP_TO_COARSE_AERO ) && ( defined MOSAIC_SPECIES ) )
+    !
+    ! accumulation mode #1
+    !
+    index_tot_mass(1,1)  = get_spc_ndx('so4_a1')
+    index_tot_mass(1,2)  = get_spc_ndx('pom_a1')
+    index_tot_mass(1,3)  = get_spc_ndx('soa_a1')
+    index_tot_mass(1,4)  = get_spc_ndx('bc_a1' )
+    index_tot_mass(1,5)  = get_spc_ndx('dst_a1')
+    index_tot_mass(1,6)  = get_spc_ndx('ncl_a1')
+    index_tot_mass(1,7)  = get_spc_ndx('mom_a1')
+    index_tot_mass(1,8)  = get_spc_ndx('nh4_a1')
+    index_tot_mass(1,9)  = get_spc_ndx('no3_a1')
+    index_tot_mass(1,10) = get_spc_ndx('ca_a1')
+    index_tot_mass(1,11) = get_spc_ndx('co3_a1')
+    index_tot_mass(1,12) = get_spc_ndx('cl_a1')
+    index_chm_mass(1,1)  = get_spc_ndx('so4_a1')
+    index_chm_mass(1,2)  = get_spc_ndx('nh4_a1')
+    index_chm_mass(1,3)  = get_spc_ndx('soa_a1')
+    index_chm_mass(1,4)  = get_spc_ndx('bc_a1' )
+    !
+    ! aitken mode
+    !
+    index_tot_mass(2,1) = get_spc_ndx('so4_a2')
+    index_tot_mass(2,2) = get_spc_ndx('soa_a2')
+    index_tot_mass(2,3) = get_spc_ndx('dst_a2')
+    index_tot_mass(2,4) = get_spc_ndx('ncl_a2')
+    index_tot_mass(2,5) = get_spc_ndx('mom_a2')
+    index_tot_mass(2,6) = get_spc_ndx('nh4_a2')
+    index_tot_mass(2,7) = get_spc_ndx('no3_a2')
+    index_tot_mass(2,8) = get_spc_ndx('ca_a2')
+    index_tot_mass(2,9) = get_spc_ndx('co3_a2')
+    index_tot_mass(2,10)= get_spc_ndx('cl_a2')
+    index_chm_mass(2,1) = get_spc_ndx('so4_a2')
+    index_chm_mass(2,2) = get_spc_ndx('nh4_a2')
+    index_chm_mass(2,3) = get_spc_ndx('soa_a2')
+    !
+    ! coarse mode
+    !
+    index_tot_mass(3,1)  = get_spc_ndx('dst_a3')
+    index_tot_mass(3,2)  = get_spc_ndx('ncl_a3')
+    index_tot_mass(3,3)  = get_spc_ndx('so4_a3')
+    index_tot_mass(3,4)  = get_spc_ndx('bc_a3')
+    index_tot_mass(4,5)  = get_spc_ndx('pom_a3')
+    index_tot_mass(4,6)  = get_spc_ndx('soa_a3')
+    index_tot_mass(4,7)  = get_spc_ndx('mom_a3')
+    index_tot_mass(3,8)  = get_spc_ndx('nh4_a3')
+    index_tot_mass(3,9)  = get_spc_ndx('no3_a3')
+    index_tot_mass(3,10) = get_spc_ndx('ca_a3')
+    index_tot_mass(3,11) = get_spc_ndx('co3_a3')
+    index_tot_mass(3,12) = get_spc_ndx('cl_a3')
+    index_chm_mass(3,1)  = get_spc_ndx('so4_a3')
+    index_chm_mass(3,2)  = get_spc_ndx('nh4_a3')
+    index_chm_mass(3,3)  = get_spc_ndx('soa_a3')
+    index_chm_mass(3,4)  = get_spc_ndx('bc_a3')
+    !
+    ! POM mode
+    !
+    index_tot_mass(4,1) = get_spc_ndx('pom_a4')
+    index_tot_mass(4,2) = get_spc_ndx('bc_a4')
+    index_tot_mass(4,3) = get_spc_ndx('mom_a4')
+    index_chm_mass(4,1) = get_spc_ndx('bc_a4' )
+    !
+    ! strat_coarse
+    index_tot_mass(5,1) = get_spc_ndx('so4_a5')
+    index_chm_mass(5,1) = get_spc_ndx('so4_a5')
+    !
+#elif ( ( defined MODAL_AERO_5MODE ) && ( defined RAIN_EVAP_TO_COARSE_AERO ) )
+    !
     ! accumulation mode #1
     !
     index_tot_mass(1,1) = get_spc_ndx('so4_a1')
@@ -908,7 +1017,7 @@ contains
     index_chm_mass(1,1) = get_spc_ndx('so4_a1')
     index_chm_mass(1,2) = get_spc_ndx('soa_a1')
     index_chm_mass(1,3) = get_spc_ndx('bc_a1' )
-     !
+    !
     ! aitken mode
     !
     index_tot_mass(2,1) = get_spc_ndx('so4_a2')
@@ -917,6 +1026,56 @@ contains
     index_tot_mass(2,4) = get_spc_ndx('mom_a2')
     index_chm_mass(2,1) = get_spc_ndx('so4_a2')
     index_chm_mass(2,2) = get_spc_ndx('soa_a2')
+    !
+    ! coarse mode
+    !
+    index_tot_mass(3,1)  = get_spc_ndx('dst_a3')
+    index_tot_mass(3,2)  = get_spc_ndx('ncl_a3')
+    index_tot_mass(3,3)  = get_spc_ndx('so4_a3')
+    index_tot_mass(3,4)  = get_spc_ndx('bc_a3')
+    index_tot_mass(4,5)  = get_spc_ndx('pom_a3')
+    index_tot_mass(4,6)  = get_spc_ndx('soa_a3')
+    index_tot_mass(4,7)  = get_spc_ndx('mom_a3')
+    index_chm_mass(3,1)  = get_spc_ndx('so4_a3')
+    index_chm_mass(3,2)  = get_spc_ndx('soa_a3')
+    index_chm_mass(3,3)  = get_spc_ndx('bc_a3')
+    !
+    ! POM mode
+    !
+    index_tot_mass(4,1) = get_spc_ndx('pom_a4')
+    index_tot_mass(4,2) = get_spc_ndx('bc_a4')
+    index_tot_mass(4,3) = get_spc_ndx('mom_a4')
+    index_chm_mass(4,1) = get_spc_ndx('bc_a1' )
+    !
+    ! strat_coarse
+    !
+    index_tot_mass(5,1) = get_spc_ndx('so4_a5')
+    index_chm_mass(5,1) = get_spc_ndx('so4_a5')
+    !
+#elif ( defined MODAL_AERO_5MODE )
+    !
+    ! accumulation mode #1
+    !
+    index_tot_mass(1,1) = get_spc_ndx('so4_a1')
+    index_tot_mass(1,2) = get_spc_ndx('pom_a1')
+    index_tot_mass(1,3) = get_spc_ndx('soa_a1')
+    index_tot_mass(1,4) = get_spc_ndx('bc_a1' )
+    index_tot_mass(1,5) = get_spc_ndx('dst_a1')
+    index_tot_mass(1,6) = get_spc_ndx('ncl_a1')
+    index_tot_mass(1,7) = get_spc_ndx('mom_a1')
+    index_chm_mass(1,1) = get_spc_ndx('so4_a1')
+    index_chm_mass(1,2) = get_spc_ndx('soa_a1')
+    index_chm_mass(1,3) = get_spc_ndx('bc_a1' )
+    !
+    ! aitken mode
+    !
+    index_tot_mass(2,1) = get_spc_ndx('so4_a2')
+    index_tot_mass(2,2) = get_spc_ndx('soa_a2')
+    index_tot_mass(2,3) = get_spc_ndx('ncl_a2')
+    index_tot_mass(2,4) = get_spc_ndx('mom_a2')
+    index_chm_mass(2,1) = get_spc_ndx('so4_a2')
+    index_chm_mass(2,2) = get_spc_ndx('soa_a2')
+    !
     ! coarse mode
     !
     index_tot_mass(3,1) = get_spc_ndx('dst_a3')
@@ -932,8 +1091,10 @@ contains
     index_chm_mass(4,1) = get_spc_ndx('bc_a1' )
     !
     ! strat_coarse
+    !
     index_tot_mass(5,1) = get_spc_ndx('so4_a5')
     index_chm_mass(5,1) = get_spc_ndx('so4_a5')
+    !
 #elif ( defined MODAL_AERO_4MODE )
     !
     ! accumulation mode #1
@@ -1530,14 +1691,8 @@ contains
 
     if ( mam_prevap_resusp_optaa == 30 ) then
 
-#if ( defined MODAL_AERO_3MODE ) || ( defined MODAL_AERO_4MODE ) || ( defined MODAL_AERO_4MODE_MOM )
+#if ( ( defined MODAL_AERO_3MODE ) || ( defined MODAL_AERO_4MODE ) || ( defined MODAL_AERO_4MODE_MOM ) || ( defined MODAL_AERO_5MODE ) || ( defined MODAL_AERO_7MODE_S ) )
        ntoo = modeptr_coarse
-!kzm ++
-#elif (defined MODAL_AERO_5MODE)
-       ntoo = modeptr_coarse
-#elif ( defined MODAL_AERO_7MODE_S )
-       ntoo = modeptr_coarse
-!kzm --
 #else
        call endrun( 'modal_aero_wetscav_init: new resuspension not implemented for 7-mode or 9-mode MAM.')
 #endif

--- a/components/eam/src/chemistry/modal_aero/dust_model.F90
+++ b/components/eam/src/chemistry/modal_aero/dust_model.F90
@@ -26,33 +26,22 @@ module dust_model
   integer, parameter :: dust_nnum = 2
 #endif
 
-#if ( ( defined MODAL_AERO_3MODE || defined MODAL_AERO_4MODE || defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_3MODE || defined MODAL_AERO_4MODE || defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
   character(len=6), parameter :: dust_names(dust_nbin+dust_nnum) = (/ 'dst_a1', 'dst_a3', &
                                                                       'ca_a1 ', 'ca_a3 ', &
                                                                       'co3_a1', 'co3_a3', &
                                                                       'num_a1', 'num_a3' /)
-  real(r8),         parameter :: dust_dmt_grd(3) = (/0.1e-6_r8, 1.0e-6_r8, 10.0e-6_r8/)
+  real(r8),         parameter :: dust_dmt_grd(dust_nnum+1) = (/0.1e-6_r8, 1.0e-6_r8, 10.0e-6_r8/)
   real(r8),         parameter :: dust_emis_sclfctr(dust_nbin) = (/ 0.011_r8, 0.989_r8, &
                                                                    0.011_r8, 0.989_r8, &
                                                                    0.011_r8, 0.989_r8 /)
-#elif  ( defined MODAL_AERO_3MODE || defined MODAL_AERO_4MODE || defined MODAL_AERO_4MODE_MOM )
+#elif  ( defined MODAL_AERO_3MODE || defined MODAL_AERO_4MODE || defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
   character(len=6), parameter :: dust_names(dust_nbin+dust_nnum) = (/ 'dst_a1', 'dst_a3', 'num_a1', 'num_a3' /)
   real(r8),         parameter :: dust_dmt_grd(dust_nbin+1) = (/ 0.1e-6_r8, 1.0e-6_r8, 10.0e-6_r8/)
 ! Zender03: fractions of bin (0.1-1) and bin (1-10) in size 0.1-10
 !  real(r8),         parameter :: dust_emis_sclfctr(dust_nbin) = (/ 0.032_r8,0.968_r8 /)
 ! Kok11: fractions of bin (0.1-1) and bin (1-10) in size 0.1-10
   real(r8),         parameter :: dust_emis_sclfctr(dust_nbin) = (/ 0.011_r8,0.989_r8 /)
-!kzm++
-#elif ( defined MODAL_AERO_5MODE )
-  character(len=6), parameter :: dust_names(dust_nbin+dust_nnum) = (/ 'dst_a1', 'dst_a3', 'num_a1', 'num_a3' /)
-  real(r8),         parameter :: dust_dmt_grd(dust_nbin+1) = (/ 0.1e-6_r8, 1.0e-6_r8, 10.0e-6_r8/)
-  real(r8),         parameter :: dust_emis_sclfctr(dust_nbin) = (/ 0.011_r8,0.989_r8 /)
-!kzm--
-
-
-
-
-
 #elif ( defined MODAL_AERO_7MODE || defined MODAL_AERO_9MODE )
   character(len=6), parameter :: dust_names(dust_nbin+dust_nnum) = (/ 'dst_a5', 'dst_a7', 'num_a5', 'num_a7' /)
   real(r8),         parameter :: dust_dmt_grd(dust_nbin+1) = (/ 0.1e-6_r8, 2.0e-6_r8, 10.0e-6_r8/)
@@ -61,8 +50,8 @@ module dust_model
 
   integer  :: dust_indices(dust_nbin+dust_nnum)
 #if ( defined MOSAIC_SPECIES )
-  real(r8) :: dust_dmt_vwr(2)
-  real(r8) :: dust_stk_crc(2)
+  real(r8) :: dust_dmt_vwr(dust_nnum)
+  real(r8) :: dust_stk_crc(dust_nnum)
 #else
   real(r8) :: dust_dmt_vwr(dust_nbin)
   real(r8) :: dust_stk_crc(dust_nbin)

--- a/components/eam/src/chemistry/modal_aero/modal_aero_amicphys.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_amicphys.F90
@@ -107,21 +107,14 @@
   integer, parameter :: max_gas = nsoa + 1
   ! the +3 in max_aer are dst, ncl, so4
   integer, parameter :: max_aer = nsoa + npoa + nbc + 3
-#elif ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#elif ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
   integer, parameter :: max_gas = nsoa + 4
   ! the +9 in max_aer are dst, ncl, so4, mom, nh4, no3, cl, ca, co3
   integer, parameter :: max_aer = nsoa + npoa + nbc + 9  
-#elif ( defined MODAL_AERO_4MODE_MOM )
+#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
   integer, parameter :: max_gas = nsoa + 1
   ! the +4 in max_aer are dst, ncl, so4, mom
   integer, parameter :: max_aer = nsoa + npoa + nbc + 4
-#elif ( defined MODAL_AERO_5MODE)
-  integer, parameter :: max_gas = nsoa + 1
-  ! the +4 in max_aer are dst, ncl, so4, mom
-  integer, parameter :: max_aer = nsoa + npoa + nbc + 4
-!  logical, parameter :: kzm_nucleation_switch = .true.
-!  logical, parameter :: kzm_coag_switch = .true.
-!  logical, parameter :: kzm_renaming_switch = .true.
 #elif ( ( defined MODAL_AERO_7MODE ) && ( defined MOSAIC_SPECIES ) )
   integer, parameter :: max_gas = nsoa + 4
   ! the +8 in max_aer are dst, ncl(=na), so4, no3, cl, nh4, ca, co3 
@@ -140,12 +133,8 @@
   integer, parameter :: max_aer = nsoa + npoa + nbc + 4 + 5
 #endif
 
-#if (( defined MODAL_AERO_8MODE ) || ( defined MODAL_AERO_4MODE ) || ( defined MODAL_AERO_4MODE_MOM ))
-  integer, parameter :: ntot_amode_extd = ntot_amode
-!kzm ++
-#elif (defined MODAL_AERO_5MODE)
-  integer, parameter :: ntot_amode_extd = ntot_amode
-!kzm --  
+#if (( defined MODAL_AERO_8MODE ) || ( defined MODAL_AERO_4MODE ) || ( defined MODAL_AERO_4MODE_MOM ) || ( defined MODAL_AERO_5MODE ) )
+  integer, parameter :: ntot_amode_extd = ntot_amode  
 #else
   integer, parameter :: ntot_amode_extd = ntot_amode + 1
 ! integer, parameter :: ntot_amode_extd = ntot_amode
@@ -5932,7 +5921,7 @@ dr_so4_monolayers_pcage = n_so4_monolayers_pcage * 4.76e-10
          iaer_nh4 = naer
       end if
 
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
       ngas = ngas + 1
       name_gas(ngas) = 'NH3'
       naer = naer + 1
@@ -5941,7 +5930,7 @@ dr_so4_monolayers_pcage = n_so4_monolayers_pcage * 4.76e-10
       iaer_nh4 = naer
 #endif
 
-#if ( ( defined MODAL_AERO_7MODE || defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_7MODE || defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
       ngas = ngas + 1
       name_gas(ngas) = 'HNO3'
       naer = naer + 1
@@ -5990,7 +5979,7 @@ dr_so4_monolayers_pcage = n_so4_monolayers_pcage * 4.76e-10
       name_aerpfx(naer) = 'dst'
       iaer_dst = naer
 
-#if ( ( defined MODAL_AERO_7MODE || defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_7MODE || defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
       naer = naer + 1
       name_aerpfx(naer) = 'ca'
       iaer_ca = naer
@@ -5998,8 +5987,8 @@ dr_so4_monolayers_pcage = n_so4_monolayers_pcage * 4.76e-10
       name_aerpfx(naer) = 'co3'
       iaer_co3 = naer
 #endif
-!kzm++
-#if ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_7MODE_S || defined MODAL_AERO_5MODE)
+
+#if ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_7MODE_S || defined MODAL_AERO_5MODE )
       naer = naer + 1
       name_aerpfx(naer) = 'mom'
       iaer_mom = naer

--- a/components/eam/src/chemistry/modal_aero/modal_aero_coag.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_coag.F90
@@ -25,12 +25,8 @@
 ! !PUBLIC DATA MEMBERS:
   integer, parameter :: pcnstxx = gas_pcnst
 
-#if ( defined MODAL_AERO_9MODE || defined MODAL_AERO_7MODE || defined MODAL_AERO_4MODE || defined MODAL_AERO_4MODE_MOM )
+#if ( defined MODAL_AERO_9MODE || defined MODAL_AERO_7MODE || defined MODAL_AERO_4MODE || defined MODAL_AERO_4MODE_MOM || MODAL_AERO_5MODE )
   integer, parameter, public :: pair_option_acoag = 3
-!kzm ++
-#elif (defined MODAL_AERO_5MODE)
-  integer, parameter, public :: pair_option_acoag = 3
-!kzm --  
 #elif ( defined MODAL_AERO_3MODE )
   integer, parameter, public :: pair_option_acoag = 1
 #endif

--- a/components/eam/src/chemistry/modal_aero/modal_aero_data.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_data.F90
@@ -28,7 +28,7 @@
 #endif
 
 !kzm ++
-#if ((( defined MODAL_AERO_3MODE ) || ( defined MODAL_AERO_4MODE ) || ( defined MODAL_AERO_4MODE_MOM ) || (defined MODAL_AERO_5MODE_MOM) ) && ( defined RAIN_EVAP_TO_COARSE_AERO ))
+#if ((( defined MODAL_AERO_3MODE ) || ( defined MODAL_AERO_4MODE ) || ( defined MODAL_AERO_4MODE_MOM ) || (defined MODAL_AERO_5MODE) ) && ( defined RAIN_EVAP_TO_COARSE_AERO ))
 !kzm --
     logical, parameter :: rain_evap_to_coarse_aero = .true.
 #else
@@ -62,13 +62,13 @@
        'p-organic ', 's-organic ', 'black-c   ', &
        'seasalt   ', 'dust      ', &
        'm-poly    ', 'm-prot    ', 'm-lip     ' /)
-#elif ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#elif ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
   integer, parameter ::  ntot_aspectype = 12
   character(len=*),parameter ::  specname_amode(ntot_aspectype) = (/ 'sulfate   ', 'ammonium  ', 'nitrate   ', &
        'p-organic ', 's-organic ', 'black-c   ', &
        'seasalt   ', 'dust      ', 'm-organic ', &
        'calcium   ', 'carbonate ', 'chloride  ' /)
-#elif ( defined MODAL_AERO_4MODE_MOM  || defined MODAL_AERO_5MODE)
+#elif ( defined MODAL_AERO_4MODE_MOM  || defined MODAL_AERO_5MODE )
   integer, parameter ::  ntot_aspectype = 9
   character(len=*),parameter ::  specname_amode(ntot_aspectype) = (/ 'sulfate   ', 'ammonium  ', 'nitrate   ', &
        'p-organic ', 's-organic ', 'black-c   ', &
@@ -90,7 +90,7 @@
     real(r8), parameter :: specmw_amode(ntot_aspectype)   = (/  96.0_r8,  18.0_r8,  62.0_r8, &
        12.0_r8,   12.0_r8,   12.0_r8,  58.5_r8, 135.0_r8, &
        250092.0_r8, 66528.0_r8,  284.0_r8 /)
-#elif ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#elif ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
     real(r8), parameter :: specmw_amode(ntot_aspectype)   = (/  96.0_r8,  18.0_r8,  62.0_r8, &
        12.0_r8,   12.0_r8,   12.0_r8,  23.0_r8, 135.0_r8, &
        250092.0_r8,  40.0_r8, 60.0_r8, 35.5_r8 /)
@@ -125,9 +125,6 @@
          'coarse          ', &
          'primary_carbon  ', &
          'strat_coarse  '/)
-
-
-
 !kzm -- 
 #elif ( defined MODAL_AERO_9MODE )
     character(len=*), parameter :: modename_amode(ntot_amode) = (/ &
@@ -163,18 +160,12 @@
     integer, parameter :: nspec_amode(ntot_amode)           = (/ 7, 4, 7, 3 /)
 #elif ( defined MODAL_AERO_4MODE_MOM )
     integer, parameter :: nspec_amode(ntot_amode)           = (/ 7, 4, 3, 3 /)
-
-!kzm ++
-#elif ( defined MODAL_AERO_5MODE )
-#if (defined RAIN_EVAP_TO_COARSE_AERO)
+#elif ( ( defined MODAL_AERO_5MODE ) && ( defined RAIN_EVAP_TO_COARSE_AERO ) && ( defined MOSAIC_SPECIES ) )
+    integer, parameter :: nspec_amode(ntot_amode)           = (/12, 7,12, 3, 1 /)
+#elif ( ( defined MODAL_AERO_5MODE ) && ( defined RAIN_EVAP_TO_COARSE_AERO ) )
     integer, parameter :: nspec_amode(ntot_amode)           = (/ 7, 4, 7, 3, 1 /)
-#else
+#elif ( defined MODAL_AERO_5MODE )
     integer, parameter :: nspec_amode(ntot_amode)           = (/ 7, 4, 3, 3, 1 /)
-#endif
-
-
-!kzm --
-
 #elif ( defined MODAL_AERO_4MODE )
     integer, parameter :: nspec_amode(ntot_amode)           = (/ 6, 3, 3, 2 /)
 #elif ( ( defined MODAL_AERO_3MODE ) && ( defined RAIN_EVAP_TO_COARSE_AERO ) )
@@ -204,15 +195,13 @@
     integer, parameter ::     mdiagnum_amode(ntot_amode)   = (/ 0, 0, 0/)
     integer, parameter ::     mprogsfc_amode(ntot_amode)   = (/ 0, 0, 0/)
     integer, parameter ::     mcalcwater_amode(ntot_amode) = (/ 0, 0, 0/)
-
 !kzm ++
 #elif ( (defined MODAL_AERO_5MODE)  )
     integer, parameter ::     mprognum_amode(ntot_amode)   = (/ 1, 1, 1, 1, 1/)
     integer, parameter ::     mdiagnum_amode(ntot_amode)   = (/ 0, 0, 0, 0, 0/)
     integer, parameter ::     mprogsfc_amode(ntot_amode)   = (/ 0, 0, 0, 0, 0/)
     integer, parameter ::     mcalcwater_amode(ntot_amode) = (/ 0, 0, 0, 0, 0/)
-!kzm --
-    
+!kzm --    
 #endif
 
     !   input dgnum_amode, dgnumlo_amode, dgnumhi_amode (units = m)

--- a/components/eam/src/chemistry/modal_aero/modal_aero_initialize_data.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_initialize_data.F90
@@ -40,14 +40,11 @@ contains
          'num_a4  ', 'num_a5  ', 'num_a6  ', 'num_a7  ' /)
     character(len=*), parameter ::     xname_numptrcw(ntot_amode) = (/ 'num_c1  ', 'num_c2  ', 'num_c3  ', &
          'num_c4  ', 'num_c5  ', 'num_c6  ', 'num_c7  ' /)
-! kzm ++
 #elif ( defined MODAL_AERO_5MODE )
     character(len=*), parameter :: xname_numptr(ntot_amode)   = (/ 'num_a1  ', 'num_a2  ', 'num_a3  ', &
          'num_a4  ', 'num_a5  ' /)
     character(len=*), parameter ::     xname_numptrcw(ntot_amode) = (/ 'num_c1  ', 'num_c2  ', 'num_c3  ', &
          'num_c4  ', 'num_c5  ' /)
-
-! kzm --
 #elif ( defined MODAL_AERO_9MODE )
     character(len=*), parameter :: xname_numptr(ntot_amode)   = (/ 'num_a1  ', 'num_a2  ', 'num_a3  ', &
          'num_a4  ', 'num_a5  ', 'num_a6  ', 'num_a7  ', &
@@ -87,19 +84,6 @@ contains
             'pom_c1  ', 'soa_c1  ', 'bc_c1   ', 'ncl_c1  ' /)
        xname_spectype(:nspec_amode(1),1)  = (/ 'sulfate   ', 'ammonium  ', &
             'p-organic ', 's-organic ', 'black-c   ', 'seasalt   ' /)
-!kzm ++
-#elif ( defined MODAL_AERO_5MODE)
-       xname_massptr(:nspec_amode(1),1)   = (/ 'so4_a1  ', &
-            'pom_a1  ', 'soa_a1  ', 'bc_a1   ', &
-            'dst_a1  ', 'ncl_a1  ', 'mom_a1  ' /)
-       xname_massptrcw(:nspec_amode(1),1) = (/ 'so4_c1  ', &
-            'pom_c1  ', 'soa_c1  ', 'bc_c1   ', &
-            'dst_c1  ', 'ncl_c1  ', 'mom_c1  ' /)
-       xname_spectype(:nspec_amode(1),1)  = (/ 'sulfate   ', &
-            'p-organic ', 's-organic ', 'black-c   ', &
-            'dust      ', 'seasalt   ', 'm-organic ' /)
-!kzm--
-
 #elif ( defined MODAL_AERO_9MODE )
        xname_massptr(:nspec_amode(1),1)   = (/ 'so4_a1  ', 'nh4_a1  ', &
             'pom_a1  ', 'soa_a1  ', 'bc_a1   ', 'ncl_a1  ', &
@@ -110,7 +94,7 @@ contains
        xname_spectype(:nspec_amode(1),1)  = (/ 'sulfate   ', 'ammonium  ', &
             'p-organic ', 's-organic ', 'black-c   ', 'seasalt   ', &
             'm-poly    ', 'm-prot    ', 'm-lip     ' /)
-#elif ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#elif ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
        xname_massptr(:nspec_amode(1),1)   = (/ 'so4_a1  ', &
             'pom_a1  ', 'soa_a1  ', 'bc_a1   ', &
             'dst_a1  ', 'ncl_a1  ', 'mom_a1  ', &
@@ -126,7 +110,7 @@ contains
             'dust      ', 'seasalt   ', 'm-organic ', &
             'ammonium  ', 'nitrate   ', 'calcium   ', &
             'carbonate ', 'chloride  ' /)
-#elif ( defined MODAL_AERO_4MODE_MOM )
+#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
        xname_massptr(:nspec_amode(1),1)   = (/ 'so4_a1  ', &
             'pom_a1  ', 'soa_a1  ', 'bc_a1   ', &
             'dst_a1  ', 'ncl_a1  ', 'mom_a1  ' /)
@@ -166,7 +150,7 @@ contains
        xname_spectype(:nspec_amode(2),2)  = (/ 'sulfate   ', 'ammonium  ', &
             's-organic ', 'seasalt   ', &
             'm-poly    ', 'm-prot    ', 'm-lip     ' /)
-#elif ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#elif ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
        xname_massptr(:nspec_amode(2),2)   = (/ 'so4_a2  ', &
             'soa_a2  ', 'ncl_a2  ', 'mom_a2  ', &
             'nh4_a2  ', 'no3_a2  ', 'cl_a2   ' /)
@@ -176,7 +160,7 @@ contains
        xname_spectype(:nspec_amode(2),2)  = (/ 'sulfate   ', &
             's-organic ', 'seasalt   ', 'm-organic ', & 
             'ammonium  ', 'nitrate   ', 'chloride  ' /)
-#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE)
+#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
        xname_massptr(:nspec_amode(2),2)   = (/ 'so4_a2  ', &
             'soa_a2  ', 'ncl_a2  ', 'mom_a2  ' /)
        xname_massptrcw(:nspec_amode(2),2) = (/ 'so4_c2  ', &
@@ -218,7 +202,7 @@ contains
        xname_massptr(:nspec_amode(3),3)   = (/ 'dst_a3  ', 'ncl_a3  ', 'so4_a3  ' /)
        xname_massptrcw(:nspec_amode(3),3) = (/ 'dst_c3  ', 'ncl_c3  ', 'so4_c3  ' /)
        xname_spectype(:nspec_amode(3),3)  = (/ 'dust      ', 'seasalt   ', 'sulfate   ' /)
-#elif ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined RAIN_EVAP_TO_COARSE_AERO ) && ( defined MOSAIC_SPECIES ) )
+#elif ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined RAIN_EVAP_TO_COARSE_AERO ) && ( defined MOSAIC_SPECIES ) )
        ! mode 3 (coarse dust & seasalt) species
        xname_massptr(:nspec_amode(3),3)   = (/ 'dst_a3  ', 'ncl_a3  ', 'so4_a3  ', &
                                                'bc_a3   ', 'pom_a3  ', 'soa_a3  ', &
@@ -242,14 +226,14 @@ contains
        xname_spectype(:nspec_amode(3),3)  = (/ 'dust      ', 'seasalt   ', 'sulfate   ', &
                                                'black-c   ', 'p-organic ', 's-organic ', &
                                                'm-organic ' /)
-#elif ( defined MODAL_AERO_4MODE_MOM )
+#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
        xname_massptr(:nspec_amode(3),3)   = (/ 'dst_a3  ', 'ncl_a3  ', 'so4_a3  ' /)
        xname_massptrcw(:nspec_amode(3),3) = (/ 'dst_c3  ', 'ncl_c3  ', 'so4_c3  ' /)
        xname_spectype(:nspec_amode(3),3)  = (/ 'dust      ', 'seasalt   ', 'sulfate   ' /)
 #endif
 
 
-#if ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE)
+#if ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
        ! mode 4 (primary carbon) species
        xname_massptr(:nspec_amode(4),4)   = (/ 'pom_a4  ', 'bc_a4   ', 'mom_a4  ' /)
        xname_massptrcw(:nspec_amode(4),4) = (/ 'pom_c4  ', 'bc_c4   ', 'mom_c4  ' /)
@@ -261,15 +245,12 @@ contains
        xname_spectype(:nspec_amode(4),4)  = (/ 'p-organic ', 'black-c   ' /)
 #endif
 
-!kzm ++
 #if ( defined MODAL_AERO_5MODE)
       ! mode 5
        xname_massptr(:nspec_amode(5),5)   = (/ 'so4_a5  ' /)
        xname_massptrcw(:nspec_amode(5),5) = (/ 'so4_c5  ' /)
        xname_spectype(:nspec_amode(5),5)  = (/ 'sulfate   ' /)
 #endif
-!kzm --
-
 
 #if ( defined MODAL_AERO_7MODE || defined MODAL_AERO_9MODE )
        ! mode 4 (fine seasalt) species

--- a/components/eam/src/chemistry/modal_aero/seasalt_model.F90
+++ b/components/eam/src/chemistry/modal_aero/seasalt_model.F90
@@ -32,14 +32,12 @@ module seasalt_model
 
 #if  ( defined MODAL_AERO_9MODE )
   integer, parameter :: nslt = 4
-#elif ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#elif ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
   integer, parameter :: nslt = 9
-#elif ( defined MODAL_AERO_5MODE)
-  integer, parameter :: nslt = 3  !kzm
 #else
   integer, parameter :: nslt = max(3,ntot_amode-3)
 #endif
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
   integer, parameter :: nnum = 3
 #else
   integer, parameter :: nnum = nslt
@@ -60,7 +58,7 @@ module seasalt_model
        (/ 'ncl_a1', 'ncl_a2', 'ncl_a3', &
           'num_a1', 'num_a2', 'num_a3'/)
   integer, parameter :: om_num_ind = 0
-#elif ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#elif ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
   integer, parameter :: nslt_om = 3
   integer, parameter :: nnum_om = 1
   integer, parameter :: om_num_modes = 3
@@ -71,7 +69,7 @@ module seasalt_model
           'mom_a1', 'mom_a2', 'mom_a4', &
           'num_a1', 'num_a2', 'num_a3', 'num_a4'/)
   integer, dimension(om_num_modes), parameter :: om_num_ind =  (/ 1, 2, 4 /)
-#elif ( defined MODAL_AERO_4MODE_MOM ||  defined MODAL_AERO_5MODE)
+#elif ( defined MODAL_AERO_4MODE_MOM ||  defined MODAL_AERO_5MODE )
   integer, parameter :: nslt_om = 3
   integer, parameter :: nnum_om = 1
   integer, parameter :: om_num_modes = 3
@@ -195,7 +193,7 @@ module seasalt_model
          (/ 0.08e-6_r8,  0.02e-6_r8,  1.0e-6_r8 /)  ! accu, aitken, coarse
     real(r8), parameter :: sst_sz_range_hi (nslt+nslt_om) = &
          (/ 1.0e-6_r8,   0.08e-6_r8, 10.0e-6_r8 /)  ! accu, aitken, coarse
-#elif ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#elif ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
     real(r8), parameter :: sst_sz_range_lo (nslt+nslt_om) = &
          (/ 0.08e-6_r8,  0.02e-6_r8,  1.0e-6_r8, &  ! accu, aitken, coarse
             0.08e-6_r8,  0.02e-6_r8,  1.0e-6_r8, &
@@ -653,7 +651,7 @@ end subroutine ocean_data_readnl
 
 enddo tracer_loop
 
-#if ( defined MODAL_AERO_9MODE || defined MODAL_AERO_4MODE_MOM ||  defined MODAL_AERO_5MODE)
+#if ( defined MODAL_AERO_9MODE || defined MODAL_AERO_4MODE_MOM ||  defined MODAL_AERO_5MODE )
 
 add_om_species: if ( has_mam_mom ) then
 ! Calculate emission of MOM mass.
@@ -738,7 +736,7 @@ add_om_species: if ( has_mam_mom ) then
     om_mode_loop: do m_om=1,nslt_om
 #if ( defined MODAL_AERO_9MODE )
        mm = seasalt_indices(nslt+(n-1)*om_num_modes+m_om)
-#elif ( defined MODAL_AERO_4MODE_MOM ||  defined MODAL_AERO_5MODE)
+#elif ( defined MODAL_AERO_4MODE_MOM ||  defined MODAL_AERO_5MODE )
        mm = seasalt_indices(nslt+m_om)
 #endif
 
@@ -1272,7 +1270,7 @@ subroutine init_ocean_data()
        om_mode_loop: do m_om=1,nslt_om
 #if ( defined MODAL_AERO_9MODE )
           m = nslt+(n-1)*om_num_modes+m_om
-#elif ( defined MODAL_AERO_4MODE_MOM ||  defined MODAL_AERO_5MODE)
+#elif ( defined MODAL_AERO_4MODE_MOM ||  defined MODAL_AERO_5MODE )
           m = nslt+m_om
 #endif
           call addfld('cflx_'//trim(seasalt_names(m))//'_debug', horiz_only, 'A', ' ', 'accumulation organic mass emissions' ) 

--- a/components/eam/src/chemistry/modal_aero/sox_cldaero_mod.F90
+++ b/components/eam/src/chemistry/modal_aero/sox_cldaero_mod.F90
@@ -185,13 +185,20 @@ contains
             + qcw(:ncol,:,id_nh4_5a) &
             + qcw(:ncol,:,id_nh4_6a) 
     else
+#if ( defined MODAL_AERO_5MODE )
        id_so4_1a = lptr_so4_cw_amode(1) - loffset
        id_so4_2a = lptr_so4_cw_amode(2) - loffset
        id_so4_3a = lptr_so4_cw_amode(3) - loffset
+       id_so4_4a = lptr_so4_cw_amode(5) - loffset
+#else
+       id_so4_1a = lptr_so4_cw_amode(1) - loffset
+       id_so4_2a = lptr_so4_cw_amode(2) - loffset
+       id_so4_3a = lptr_so4_cw_amode(3) - loffset
+#endif
 
 #if ( defined MOSAIC_SPECIES )
-       if (ntot_amode /= 4) then
-          call endrun('sox_cldaero_create_obj:  MOSAIC_SPECIES defined but ntot_amode /= 4' )
+       if ( (ntot_amode /= 4) .and. (ntot_amode /= 5) ) then
+          call endrun('sox_cldaero_create_obj:  MOSAIC_SPECIES defined but ntot_amode /= 4 and 5' )
        endif
 
        id_nh4_1a = lptr_nh4_cw_amode(1) - loffset
@@ -217,10 +224,18 @@ contains
        id_co3_3a = lptr_co3_cw_amode(3) - loffset
 #endif
 
+#if ( defined MODAL_AERO_5MODE )
+       conc_obj%so4c(:ncol,:) &
+            = qcw(:,:,id_so4_1a) &
+            + qcw(:,:,id_so4_2a) &
+            + qcw(:,:,id_so4_3a) &
+            + qcw(:,:,id_so4_4a)
+#else
        conc_obj%so4c(:ncol,:) &
             = qcw(:,:,id_so4_1a) &
             + qcw(:,:,id_so4_2a) &
             + qcw(:,:,id_so4_3a)
+#endif
 
 #if ( defined MOSAIC_SPECIES )
        if (mosaic_aqchem_optaa > 0) then
@@ -259,26 +274,6 @@ contains
 #else
         ! for 3-mode, so4 is assumed to be nh4hso4
         ! the partial neutralization of so4 is handled by using a 
-        !    -1 charge (instead of -2) in the electro-neutrality equation
-       conc_obj%nh4c(:ncol,:) = 0._r8
-
-       ! with 3-mode, assume so4 is nh4hso4, and so half-neutralized
-       conc_obj%so4_fact = 1._r8
-#endif
-    !kzm ++
-#if (defined MODAL_AERO_5MODE)
-        id_so4_1a = lptr_so4_cw_amode(1) - loffset
-       id_so4_2a = lptr_so4_cw_amode(2) - loffset
-       id_so4_3a = lptr_so4_cw_amode(3) - loffset
-       id_so4_4a = lptr_so4_cw_amode(5) - loffset
-       conc_obj%so4c(:ncol,:) &
-            = qcw(:,:,id_so4_1a) &
-            + qcw(:,:,id_so4_2a) &
-            + qcw(:,:,id_so4_3a) &
-            + qcw(:,:,id_so4_4a)
-
-        ! for 3-mode, so4 is assumed to be nh4hso4
-        ! the partial neutralization of so4 is handled by using a
         !    -1 charge (instead of -2) in the electro-neutrality equation
        conc_obj%nh4c(:ncol,:) = 0._r8
 

--- a/components/eam/src/chemistry/utils/prescribed_volcaero.F90
+++ b/components/eam/src/chemistry/utils/prescribed_volcaero.F90
@@ -212,11 +212,6 @@ end subroutine prescribed_volcaero_readnl
     is_cmip6_volc = .false.
     if (trim(adjustl(file_type))== 'VOLC_CMIP6') then
        is_cmip6_volc = .true.
-#if (defined MODAL_AERO_5MODE)
-     write(iulog,*)'kzm_rescribed_volcaero_mam5 '
-     is_cmip6_volc = .false.
-#endif
-
        ispf = 1
        specifier_sw(ispf) = trim(adjustl(ext_sun_name))
        ispf = ispf + 1

--- a/components/eam/src/physics/cam/hetfrz_classnuc_cam.F90
+++ b/components/eam/src/physics/cam/hetfrz_classnuc_cam.F90
@@ -612,10 +612,40 @@ subroutine hetfrz_classnuc_cam_init(mincld_in)
       pom_pcarbon  = 16
       num_pcarbon  = 17
 #endif
-
-!kzm ++
-#if (( defined MODAL_AERO_5MODE  ) && (defined RAIN_EVAP_TO_COARSE_AERO) )
 else if (nmodes == MAM5_nmodes) then
+#if ( ( defined MODAL_AERO_5MODE  ) && ( defined RAIN_EVAP_TO_COARSE_AERO ) && ( defined MOSAIC_SPECIES ) ) 
+      ncnst = 30
+      so4_accum  =  1
+      bc_accum   =  2
+      pom_accum  =  3
+      soa_accum  =  4
+      dst_accum  =  5
+      ncl_accum  =  6
+      mom_accum  =  7
+      nh4_accum  =  8
+      no3_accum  =  9
+      ca_accum   =  10
+      co3_accum  =  11
+      cl_accum   =  12
+      num_accum  =  13
+      dst_coarse =  14
+      ncl_coarse =  15
+      so4_coarse =  16
+      bc_coarse  =  17
+      pom_coarse =  18
+      soa_coarse =  19
+      mom_coarse =  20
+      nh4_coarse =  21
+      no3_coarse =  22
+      ca_coarse  =  23
+      co3_coarse =  24
+      cl_coarse  =  25
+      num_coarse =  26
+      bc_pcarbon   = 27
+      pom_pcarbon  = 28
+      mom_pcarbon  = 29
+      num_pcarbon  = 30
+#elif ( ( defined MODAL_AERO_5MODE  ) && ( defined RAIN_EVAP_TO_COARSE_AERO ) )
       ncnst = 20
       so4_accum  =  1
       bc_accum   =  2
@@ -638,9 +668,7 @@ else if (nmodes == MAM5_nmodes) then
       mom_pcarbon  = 19
       num_pcarbon  = 20
 #endif
-
-!kzm --
-  end if
+   end if
 
    ! Allocate arrays to hold specie and mode indices for all constitutents (mass and number) 
    ! needed in this module.
@@ -1282,25 +1310,24 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
          as_soa = aer(ii,kk,soa_accum)
          as_ss  = aer(ii,kk,ncl_accum)
          as_du  = aer(ii,kk,dst_accum)
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
          as_mom = aer(ii,kk,mom_accum)
          as_nh4 = aer(ii,kk,nh4_accum)
          as_no3 = aer(ii,kk,no3_accum)
          as_ca  = aer(ii,kk,ca_accum)
          as_co3 = aer(ii,kk,co3_accum)
          as_cl  = aer(ii,kk,cl_accum)
-!kzm++
-#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE)
+#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
          as_mom = aer(ii,kk,mom_accum)
 #endif
 
          if (as_du > 0._r8) then
 
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
             dst1_num = (as_du+as_ca+as_co3)/(as_so4+as_bc+as_pom+as_soa+as_ss+as_du+as_mom+&
                                              as_nh4+as_no3+as_ca+as_co3+as_cl)  &
                        * aer(ii,kk,num_accum)*1.0e-6_r8 ! #/cm^3
-#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE)
+#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
             dst1_num = as_du/(as_so4+as_bc+as_pom+as_soa+as_ss+as_du+as_mom)  &
                        * aer(ii,kk,num_accum)*1.0e-6_r8 ! #/cm^3
 #else
@@ -1314,12 +1341,11 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
 
          if (as_bc > 0._r8) then
 
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
             bc_num = as_bc/(as_so4+as_bc+as_pom+as_soa+as_ss+as_du+as_mom+&
                             as_nh4+as_no3+as_ca+as_co3+as_cl)  &
                      * aer(ii,kk,num_accum)*1.0e-6_r8 ! #/cm^3
-!kzm++
-#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE)
+#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
             bc_num = as_bc/(as_so4+as_bc+as_pom+as_soa+as_ss+as_du+as_mom)  &
                      * aer(ii,kk,num_accum)*1.0e-6_r8 ! #/cm^3
 #else
@@ -1343,14 +1369,14 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
       dmc = aer(ii,kk,dst_coarse)
       ssmc = aer(ii,kk,ncl_coarse)
 
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
       mommc = aer(ii,kk,mom_coarse)
       nh4mc = aer(ii,kk,nh4_coarse)
       no3mc = aer(ii,kk,no3_coarse)
       camc  = aer(ii,kk,ca_coarse)
       co3mc = aer(ii,kk,co3_coarse)
       clmc  = aer(ii,kk,cl_coarse)
-#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE)
+#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
       mommc = aer(ii,kk,mom_coarse)
 #endif
 
@@ -1362,10 +1388,9 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
  
       if (dmc > 0._r8 ) then
 
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined RAIN_EVAP_TO_COARSE_AERO ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined RAIN_EVAP_TO_COARSE_AERO ) && ( defined MOSAIC_SPECIES ) )
          dst3_num = (dmc+camc+co3mc)/(ssmc+dmc+bcmc+pommc+soamc+mommc+nh4mc+no3mc+camc+co3mc+clmc) * aer(ii,kk,num_coarse)*1.0e-6_r8 ! #/cm^3
-!kzm++
-#elif ( (defined MODAL_AERO_4MODE_MOM ||  defined MODAL_AERO_5MODE) && defined RAIN_EVAP_TO_COARSE_AERO )
+#elif ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined RAIN_EVAP_TO_COARSE_AERO ) )
          dst3_num = dmc/(ssmc+dmc+bcmc+pommc+soamc+mommc) * aer(ii,kk,num_coarse)*1.0e-6_r8 ! #/cm^3
 #elif ( defined MODAL_AERO_4MODE_MOM )
          dst3_num = dmc/(ssmc+dmc+mommc)                  * aer(ii,kk,num_coarse)*1.0e-6_r8 ! #/cm^3
@@ -1400,23 +1425,23 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
       as_soa = aer_cb(ii,kk,soa_accum)
       as_ss  = aer_cb(ii,kk,ncl_accum)
       as_du  = aer_cb(ii,kk,dst_accum)
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
       as_mom = aer_cb(ii,kk,mom_accum)
       as_nh4 = aer_cb(ii,kk,nh4_accum)
       as_no3 = aer_cb(ii,kk,no3_accum)
       as_ca  = aer_cb(ii,kk,ca_accum)
       as_co3 = aer_cb(ii,kk,co3_accum)
       as_cl  = aer_cb(ii,kk,cl_accum)
-#elif (defined MODAL_AERO_4MODE_MOM ||  defined MODAL_AERO_5MODE )
+#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
       as_mom = aer_cb(ii,kk,mom_accum)
 #endif
 
       if (as_du > 0._r8) then
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
          dst1_num_imm = (as_du+as_ca+as_co3)/(as_so4+as_bc+as_pom+as_soa+as_ss+as_du+as_mom+&
                                               as_nh4+as_no3+as_ca+as_co3+as_cl)  &
                        * aer_cb(ii,kk,num_accum)*1.0e-6_r8 ! #/cm^3
-#elif (defined MODAL_AERO_4MODE_MOM ||  defined MODAL_AERO_5MODE)
+#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
          dst1_num_imm = as_du/(as_so4+as_bc+as_pom+as_soa+as_ss+as_du+as_mom)  &
                        * aer_cb(ii,kk,num_accum)*1.0e-6_r8 ! #/cm^3
 #else
@@ -1428,11 +1453,11 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
       end if
 
       if (as_bc > 0._r8) then
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
          bc_num_imm = as_bc/(as_so4+as_bc+as_pom+as_soa+as_ss+as_du+as_mom+&
                              as_nh4+as_no3+as_ca+as_co3+as_cl) &
                     * aer_cb(ii,kk,num_accum)*1.0e-6_r8 ! #/cm^3
-#elif (defined MODAL_AERO_4MODE_MOM ||  defined MODAL_AERO_5MODE)
+#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
          bc_num_imm = as_bc/(as_so4+as_bc+as_pom+as_soa+as_ss+as_du+as_mom)  &
                     * aer_cb(ii,kk,num_accum)*1.0e-6_r8 ! #/cm^3
 #else
@@ -1445,14 +1470,14 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
        
       dmc_imm = aer_cb(ii,kk,dst_coarse)
       ssmc_imm = aer_cb(ii,kk,ncl_coarse)
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
       mommc_imm = aer_cb(ii,kk,mom_coarse)
       nh4mc_imm = aer_cb(ii,kk,nh4_coarse)
       no3mc_imm = aer_cb(ii,kk,mom_coarse)
       camc_imm  = aer_cb(ii,kk,ca_coarse)
       co3mc_imm = aer_cb(ii,kk,co3_coarse)
       clmc_imm  = aer_cb(ii,kk,cl_coarse)
-#elif (defined MODAL_AERO_4MODE_MOM ||  defined MODAL_AERO_5MODE)
+#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
       mommc_imm = aer_cb(ii,kk,mom_coarse)
 #endif
 
@@ -1463,10 +1488,10 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
 #endif
 
       if (dmc_imm > 0._r8) then
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined RAIN_EVAP_TO_COARSE_AERO ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined RAIN_EVAP_TO_COARSE_AERO ) && ( defined MOSAIC_SPECIES ) )
          dst3_num_imm = (dmc_imm+camc_imm+co3mc_imm)/(ssmc_imm+dmc_imm+bcmc_imm+pommc_imm+soamc_imm+mommc_imm+nh4mc_imm+no3mc_imm+camc_imm+co3mc_imm+clmc_imm) & 
                       * aer_cb(ii,kk,num_coarse)*1.0e-6_r8 ! #/cm^3
-#elif ((defined MODAL_AERO_4MODE_MOM ||  defined MODAL_AERO_5MODE) && defined RAIN_EVAP_TO_COARSE_AERO )
+#elif ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && defined RAIN_EVAP_TO_COARSE_AERO )
          dst3_num_imm = dmc_imm/(ssmc_imm+dmc_imm+bcmc_imm+pommc_imm+soamc_imm+mommc_imm) &
                       * aer_cb(ii,kk,num_coarse)*1.0e-6_r8 ! #/cm^3
 #elif (defined MODAL_AERO_4MODE_MOM)
@@ -1591,14 +1616,14 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
       fac_volsfc_dust_a1 = exp(2.5_r8*alnsg_mode_accum**2)
       fac_volsfc_dust_a3 = exp(2.5_r8*alnsg_mode_coarse**2)
 
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
       vol_shell(2) = ( aer(ii,kk,so4_accum)/specdens_so4 + &
                        aer(ii,kk,nh4_accum)/specdens_nh4 + &
                        aer(ii,kk,no3_accum)/specdens_no3 + &
                        aer(ii,kk,pom_accum)*pom_equivso4_factor/specdens_pom + &
                        aer(ii,kk,mom_accum)*mom_equivso4_factor/specdens_mom + &
                        aer(ii,kk,soa_accum)*soa_equivso4_factor/specdens_soa )/rhoair
-#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE  )
+#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
       vol_shell(2) = ( aer(ii,kk,so4_accum)/specdens_so4 + &
                        aer(ii,kk,pom_accum)*pom_equivso4_factor/specdens_pom + &
                        aer(ii,kk,mom_accum)*mom_equivso4_factor/specdens_mom + &
@@ -1659,14 +1684,14 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
 
       ! dust_a3
 
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined RAIN_EVAP_TO_COARSE_AERO ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined RAIN_EVAP_TO_COARSE_AERO ) && ( defined MOSAIC_SPECIES ) )
       vol_shell(3) = aer(ii,kk,so4_coarse)/(specdens_so4*rhoair) + &
                      aer(ii,kk,nh4_coarse)/(specdens_nh4*rhoair) + &
                      aer(ii,kk,no3_coarse)/(specdens_no3*rhoair) + &
                      aer(ii,kk,pom_coarse)/(specdens_pom*rhoair) + &
                      aer(ii,kk,soa_coarse)/(specdens_soa*rhoair) + &
                      aer(ii,kk,mom_coarse)/(specdens_mom*rhoair) 
-#elif ( (defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE) && defined RAIN_EVAP_TO_COARSE_AERO )
+#elif ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined RAIN_EVAP_TO_COARSE_AERO ) )
       vol_shell(3) = aer(ii,kk,so4_coarse)/(specdens_so4*rhoair) + & 
                      aer(ii,kk,pom_coarse)/(specdens_pom*rhoair) + & 
                      aer(ii,kk,soa_coarse)/(specdens_soa*rhoair) + & 
@@ -1764,12 +1789,12 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
 
       ! accumulation mode for dust_a1 
       if (aer(ii,kk,num_accum) > 0._r8) then  
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
          awcam(2) = (dst1_num*1.0e6_r8)/aer(ii,kk,num_accum)* &
             ( aer(ii,kk,so4_accum) + aer(ii,kk,soa_accum) + &
               aer(ii,kk,no3_accum) + aer(ii,kk,nh4_accum) + &
               aer(ii,kk,pom_accum) + aer(ii,kk,bc_accum) + aer(ii,kk,mom_accum) )*1.0e9_r8 ! [mug m-3]
-#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE)
+#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
          awcam(2) = (dst1_num*1.0e6_r8)/aer(ii,kk,num_accum)* &
             ( aer(ii,kk,so4_accum) + aer(ii,kk,soa_accum) + &
               aer(ii,kk,pom_accum) + aer(ii,kk,bc_accum) + aer(ii,kk,mom_accum) )*1.0e9_r8 ! [mug m-3]
@@ -1783,12 +1808,12 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
       end if
 
       if (awcam(2) > 0._r8) then
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
          awfacm(2) = ( aer(ii,kk,bc_accum) + aer(ii,kk,soa_accum) + aer(ii,kk,pom_accum) + aer(ii,kk,mom_accum) )/ &
             ( aer(ii,kk,soa_accum) + aer(ii,kk,pom_accum) + aer(ii,kk,so4_accum) + &
               aer(ii,kk,no3_accum) + aer(ii,kk,nh4_accum) + &
               aer(ii,kk,bc_accum)  + aer(ii,kk,mom_accum) )
-#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE)
+#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
          awfacm(2) = ( aer(ii,kk,bc_accum) + aer(ii,kk,soa_accum) + aer(ii,kk,pom_accum) + aer(ii,kk,mom_accum) )/ &
             ( aer(ii,kk,soa_accum) + aer(ii,kk,pom_accum) + aer(ii,kk,so4_accum) + aer(ii,kk,bc_accum) + aer(ii,kk,mom_accum) )
 #else
@@ -1801,11 +1826,11 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
 
       ! accumulation mode for bc (if MAM4, primary carbon mode is insoluble)
       if (aer(ii,kk,num_accum) > 0._r8) then
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
          awcam(1) = (bc_num*1.0e6_r8)/aer(ii,kk,num_accum)* &
             ( aer(ii,kk,so4_accum) + aer(ii,kk,soa_accum) + aer(ii,kk,pom_accum) + aer(ii,kk,bc_accum) + &
               aer(ii,kk,no3_accum) + aer(ii,kk,nh4_accum) + aer(ii,kk,mom_accum) )*1.0e9_r8 ! [mug m-3]
-#elif (defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE)
+#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
          awcam(1) = (bc_num*1.0e6_r8)/aer(ii,kk,num_accum)* &
             ( aer(ii,kk,so4_accum) + aer(ii,kk,soa_accum) + aer(ii,kk,pom_accum) + aer(ii,kk,bc_accum) + &
               aer(ii,kk,mom_accum) )*1.0e9_r8 ! [mug m-3]
@@ -1820,12 +1845,12 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
 
       ! coarse mode for dust_a3
       if (aer(ii,kk,num_coarse) > 0._r8) then
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined RAIN_EVAP_TO_COARSE_AERO ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined RAIN_EVAP_TO_COARSE_AERO ) && ( defined MOSAIC_SPECIES ) )
          awcam(3) = (dst3_num*1.0e6_r8)/aer(ii,kk,num_coarse)* ( aer(ii,kk,so4_coarse) + &
                      aer(ii,kk,no3_coarse) + aer(ii,kk,nh4_coarse) + &
                      aer(ii,kk,mom_coarse) + aer(ii,kk,bc_coarse)  + &
                      aer(ii,kk,pom_coarse) + aer(ii,kk,soa_coarse) ) *1.0e9_r8
-#elif ((defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && defined RAIN_EVAP_TO_COARSE_AERO )
+#elif ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && defined RAIN_EVAP_TO_COARSE_AERO )
          awcam(3) = (dst3_num*1.0e6_r8)/aer(ii,kk,num_coarse)* ( aer(ii,kk,so4_coarse) + & 
                      aer(ii,kk,mom_coarse) + aer(ii,kk,bc_coarse) + aer(ii,kk,pom_coarse) + aer(ii,kk,soa_coarse) ) *1.0e9_r8
 #elif (defined MODAL_AERO_4MODE_MOM)
@@ -1842,13 +1867,13 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
       end if
 
       if (awcam(3) > 0._r8) then
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined RAIN_EVAP_TO_COARSE_AERO ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined RAIN_EVAP_TO_COARSE_AERO ) && ( defined MOSAIC_SPECIES ) )
          awfacm(3) = ( aer(ii,kk,bc_coarse) + aer(ii,kk,soa_coarse) + &
                        aer(ii,kk,pom_coarse) + aer(ii,kk,mom_coarse) )/ &
                      ( aer(ii,kk,soa_coarse) + aer(ii,kk,pom_coarse) + &
                        aer(ii,kk,no3_coarse) + aer(ii,kk,nh4_coarse) + &
                        aer(ii,kk,so4_coarse) + aer(ii,kk,bc_coarse) + aer(ii,kk,mom_coarse) )
-#elif ((defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && defined RAIN_EVAP_TO_COARSE_AERO )
+#elif ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && defined RAIN_EVAP_TO_COARSE_AERO )
          awfacm(3) = ( aer(ii,kk,bc_coarse) + aer(ii,kk,soa_coarse) + &
                        aer(ii,kk,pom_coarse) + aer(ii,kk,mom_coarse) )/ &
                      ( aer(ii,kk,soa_coarse) + aer(ii,kk,pom_coarse) + &

--- a/components/eam/src/physics/cam/modal_aer_opt.F90
+++ b/components/eam/src/physics/cam/modal_aer_opt.F90
@@ -231,11 +231,11 @@ subroutine modal_aer_opt_init()
    call addfld ('AODBC',horiz_only,    'A','  ','Aerosol optical depth 550 nm from BC', flag_xyfill=.true.)
    call addfld ('AODSS',horiz_only,    'A','  ','Aerosol optical depth 550 nm from seasalt', flag_xyfill=.true.)
    call addfld ('AODABSBC',horiz_only, 'A','  ','Aerosol absorption optical depth 550 nm from BC', flag_xyfill=.true.)
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
    call addfld ('AODMOM',horiz_only,    'A','  ','Aerosol optical depth 550 nm from marine organic', flag_xyfill=.true.)
    call addfld ('AODNO3',horiz_only,    'A','  ','Aerosol optical depth 550 nm from NO3', flag_xyfill=.true.)
    call addfld ('AODNH4',horiz_only,    'A','  ','Aerosol optical depth 550 nm from NH4', flag_xyfill=.true.)
-#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE)
+#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
    call addfld ('AODMOM',horiz_only,    'A','  ','Aerosol optical depth 550 nm from marine organic', flag_xyfill=.true.)
 #elif ( defined MODAL_AERO_9MODE )
    call addfld ('AODPOLY',horiz_only,    'A','  ','Aerosol optical depth 550 nm from marine poly', flag_xyfill=.true.)
@@ -251,11 +251,11 @@ subroutine modal_aer_opt_init()
    call addfld ('BURDENSOA',horiz_only,  'A','kg/m2'    ,'SOA aerosol burden'         , flag_xyfill=.true.)
    call addfld ('BURDENBC',horiz_only,  'A','kg/m2'     ,'Black carbon aerosol burden', flag_xyfill=.true.)
    call addfld ('BURDENSEASALT',horiz_only,  'A','kg/m2','Seasalt aerosol burden'     , flag_xyfill=.true.)
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
    call addfld ('BURDENMOM',horiz_only,  'A','kg/m2'    ,'Marine organic aerosol burden', flag_xyfill=.true.)
    call addfld ('BURDENNO3',horiz_only,  'A','kg/m2'    ,'Nitrate aerosol burden',        flag_xyfill=.true.)
    call addfld ('BURDENNH4',horiz_only,  'A','kg/m2'    ,'Ammonium aerosol burden',       flag_xyfill=.true.)
-#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE)
+#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
    call addfld ('BURDENMOM',horiz_only,  'A','kg/m2'    ,'Marine organic aerosol burden', flag_xyfill=.true.)
 #elif ( defined MODAL_AERO_9MODE )
    call addfld ('BURDENPOLY',horiz_only,  'A','kg/m2'   ,'Marine polysaccharide aerosol burden', flag_xyfill=.true.)
@@ -280,11 +280,11 @@ subroutine modal_aer_opt_init()
       call add_default ('BURDENSOA'    , 1, ' ')
       call add_default ('BURDENBC'     , 1, ' ')
       call add_default ('BURDENSEASALT', 1, ' ')
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
       call add_default ('BURDENMOM', 1, ' ')
       call add_default ('BURDENNO3', 1, ' ')
       call add_default ('BURDENNH4', 1, ' ')
-#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE)
+#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
       call add_default ('BURDENMOM', 1, ' ')
 #elif ( defined MODAL_AERO_9MODE )
       call add_default ('BURDENPOLY', 1, ' ')
@@ -327,7 +327,7 @@ subroutine modal_aer_opt_init()
       call add_default ('BURDENSOA'    , 1, ' ')
       call add_default ('BURDENBC'     , 1, ' ')
       call add_default ('BURDENSEASALT', 1, ' ')
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
       call add_default ('BURDENNO3'    , 1, ' ')
       call add_default ('BURDENNH4'    , 1, ' ')
 #elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
@@ -530,9 +530,9 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
    real(r8) :: burden(pcols)
    real(r8) :: burdendust(pcols), burdenso4(pcols), burdenbc(pcols), &
                burdenpom(pcols), burdensoa(pcols), burdenseasalt(pcols)
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
    real(r8) :: burdenmom(pcols), burdenno3(pcols), burdennh4(pcols)
-#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE)
+#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
    real(r8) :: burdenmom(pcols)
 #elif ( defined MODAL_AERO_9MODE )
    real(r8) :: burdenpoly(pcols), burdenprot(pcols), burdenlip(pcols)
@@ -544,27 +544,27 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
    real(r8) :: specrefr, specrefi
    real(r8) :: scatdust(pcols), scatso4(pcols), scatbc(pcols), &
                scatpom(pcols), scatsoa(pcols), scatseasalt(pcols)
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
    real(r8) :: scatmom(pcols), scatno3(pcols), scatnh4(pcols)
-#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE)
+#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
    real(r8) :: scatmom(pcols)
 #elif ( defined MODAL_AERO_9MODE )
    real(r8) :: scatpoly(pcols), scatprot(pcols), scatlip(pcols)
 #endif
    real(r8) :: absdust(pcols), absso4(pcols), absbc(pcols), &
                abspom(pcols), abssoa(pcols), absseasalt(pcols)
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
    real(r8) :: absmom(pcols), absno3(pcols), absnh4(pcols)
-#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE)
+#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
    real(r8) :: absmom(pcols)
 #elif ( defined MODAL_AERO_9MODE )
    real(r8) :: abspoly(pcols), absprot(pcols), abslip(pcols)
 #endif
    real(r8) :: hygrodust(pcols), hygroso4(pcols), hygrobc(pcols), &
                hygropom(pcols), hygrosoa(pcols), hygroseasalt(pcols)
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
    real(r8) :: hygromom(pcols), hygrono3(pcols), hygronh4(pcols)
-#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE)
+#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
    real(r8) :: hygromom(pcols)
 #elif ( defined MODAL_AERO_9MODE )
    real(r8) :: hygropoly(pcols), hygroprot(pcols), hygrolip(pcols)
@@ -576,9 +576,9 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
    ! total species AOD
    real(r8) :: dustaod(pcols), so4aod(pcols), bcaod(pcols), &
                pomaod(pcols), soaaod(pcols), seasaltaod(pcols)
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
    real(r8) :: momaod(pcols), no3aod(pcols), nh4aod(pcols)
-#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE)
+#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
    real(r8) :: momaod(pcols)
 #elif ( defined MODAL_AERO_9MODE )
    real(r8) :: polyaod(pcols), protaod(pcols), lipaod(pcols)
@@ -633,14 +633,14 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
    burdensoa(:ncol)      = 0.0_r8
    burdenbc(:ncol)       = 0.0_r8
    burdenseasalt(:ncol)  = 0.0_r8
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
    burdenmom(:ncol)      = 0.0_r8
    burdenno3(:ncol)      = 0.0_r8
    burdennh4(:ncol)      = 0.0_r8
    momaod(:ncol)         = 0.0_r8
    no3aod(:ncol)         = 0.0_r8
    nh4aod(:ncol)         = 0.0_r8
-#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE)
+#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
    burdenmom(:ncol)      = 0.0_r8
    momaod(:ncol)         = 0.0_r8
 #elif ( defined MODAL_AERO_9MODE )
@@ -741,7 +741,7 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
             scatseasalt(:ncol)  = 0._r8
             absseasalt(:ncol)   = 0._r8
             hygroseasalt(:ncol) = 0._r8
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
             scatmom(:ncol)      = 0._r8
             absmom(:ncol)       = 0._r8
             hygromom(:ncol)     = 0._r8
@@ -751,7 +751,7 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
             scatnh4(:ncol)      = 0._r8
             absnh4(:ncol)       = 0._r8
             hygronh4(:ncol)     = 0._r8
-#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE)
+#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
             scatmom(:ncol)  = 0._r8
             absmom(:ncol)   = 0._r8
             hygromom(:ncol) = 0._r8
@@ -880,7 +880,7 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
                       end do
                   end if
 #endif
-#if ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE)
+#if ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
                   if (trim(spectype) == 'm-organic') then
                      do i = 1, ncol
                         burdenmom(i) = burdenmom(i) + specmmr(i,k)*mass(i,k)
@@ -1020,7 +1020,7 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
 
                      scath2o        = watervol(i)*real(crefwsw(isw))
                      absh2o         = -watervol(i)*aimag(crefwsw(isw))
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
                      sumscat        = scatso4(i) + scatpom(i) + scatsoa(i) + scatbc(i) + &
                                       scatdust(i) + scatseasalt(i) + scath2o + &
                                       scatmom(i) + scatno3(i) + scatnh4(i)
@@ -1030,7 +1030,7 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
                      sumhygro       = hygroso4(i) + hygropom(i) + hygrosoa(i) + hygrobc(i) + &
                                       hygrodust(i) + hygroseasalt(i) + &
                                       hygromom(i) + hygrono3(i) + hygronh4(i)
-#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE)
+#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
 		     sumscat        = scatso4(i) + scatpom(i) + scatsoa(i) + scatbc(i) + &
                                       scatdust(i) + scatseasalt(i) + scath2o + &
                                       scatmom(i)
@@ -1077,7 +1077,7 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
                      scatseasalt(i) = (scatseasalt(i) + scath2o*hygroseasalt(i)/sumhygro)/sumscat
                      absseasalt(i)  = (absseasalt(i) + absh2o*hygroseasalt(i)/sumhygro)/sumabs
 
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
                      scatmom(i)     = (scatmom(i) + scath2o*hygromom(i)/sumhygro)/sumscat
                      absmom(i)      = (absmom(i) + absh2o*hygromom(i)/sumhygro)/sumabs
 
@@ -1087,7 +1087,7 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
                      scatnh4(i)     = (scatnh4(i) + scath2o*hygronh4(i)/sumhygro)/sumscat
                      absnh4(i)      = (absnh4(i) + absh2o*hygronh4(i)/sumhygro)/sumabs
 
-#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE)
+#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
                      scatmom(i) = (scatmom(i) + scath2o*hygromom(i)/sumhygro)/sumscat
                      absmom(i)  = (absmom(i) + absh2o*hygromom(i)/sumhygro)/sumabs
 
@@ -1122,7 +1122,7 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
                      aodc           = (absseasalt(i)*(1.0_r8 - palb(i)) + palb(i)*scatseasalt(i))*dopaer(i)
                      seasaltaod(i)  = seasaltaod(i) + aodc
 
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
                      aodc           = (absmom(i)*(1.0_r8 - palb(i)) + palb(i)*scatmom(i))*dopaer(i)
                      momaod(i)      = momaod(i) + aodc
 
@@ -1132,7 +1132,7 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
                      aodc           = (absnh4(i)*(1.0_r8 - palb(i)) + palb(i)*scatnh4(i))*dopaer(i)
                      nh4aod(i)      = nh4aod(i) + aodc
 
-#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE)
+#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
                      aodc           = (absmom(i)*(1.0_r8 - palb(i)) + palb(i)*scatmom(i))*dopaer(i)
                      momaod(i)  = momaod(i) + aodc
 
@@ -1302,11 +1302,11 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
          pomaod(idxnite(i))     = fillvalue
          soaaod(idxnite(i))     = fillvalue
          bcaod(idxnite(i))      = fillvalue
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
          momaod(idxnite(i))     = fillvalue
          no3aod(idxnite(i))     = fillvalue
          nh4aod(idxnite(i))     = fillvalue
-#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE)
+#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
          momaod(idxnite(i)) = fillvalue
 #elif ( defined MODAL_AERO_9MODE )
          polyaod(idxnite(i)) = fillvalue
@@ -1327,11 +1327,11 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
       call outfld('BURDENBC'  ,    burdenbc,      pcols, lchnk)
       call outfld('BURDENSEASALT', burdenseasalt, pcols, lchnk)
 
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
       call outfld('BURDENMOM',     burdenmom,     pcols, lchnk)
       call outfld('BURDENNO3',     burdenno3,     pcols, lchnk)
       call outfld('BURDENNH4',     burdennh4,     pcols, lchnk)
-#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE)
+#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) 
       call outfld('BURDENMOM', burdenmom, pcols, lchnk)
 #elif ( defined MODAL_AERO_9MODE )
       call outfld('BURDENPOLY', burdenpoly, pcols, lchnk)
@@ -1348,11 +1348,11 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
       call outfld('AODBC',         bcaod,         pcols, lchnk)
       call outfld('AODSS',         seasaltaod,    pcols, lchnk)
 
-#if ( ( defined MODAL_AERO_4MODE_MOM ) && ( defined MOSAIC_SPECIES ) )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
       call outfld('AODMOM',        momaod,        pcols, lchnk)
       call outfld('AODNO3',        no3aod,        pcols, lchnk)
       call outfld('AODNH4',        nh4aod,        pcols, lchnk)
-#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE)
+#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
       call outfld('AODMOM',         momaod,    pcols, lchnk)
 #elif ( defined MODAL_AERO_9MODE )
       call outfld('AODPOLY',         polyaod,    pcols, lchnk)

--- a/components/eam/src/physics/cam/nucleate_ice_cam.F90
+++ b/components/eam/src/physics/cam/nucleate_ice_cam.F90
@@ -407,7 +407,7 @@ subroutine nucleate_ice_cam_init(mincld_in, bulk_scale_in)
          end if
       end if
 
-#if (defined MODAL_AERO_4MODE_MOM  || defined MODAL_AERO_5MODE )
+#if ( defined MODAL_AERO_4MODE_MOM  || defined MODAL_AERO_5MODE )
       call rad_cnst_get_info(0, mode_coarse_idx, nspec=nspec)
       do n = 1, nspec
          call rad_cnst_get_info(0, mode_coarse_idx, n, spec_type=str32)
@@ -804,10 +804,9 @@ subroutine nucleate_ice_cam_calc( &
                   else
                      ! 3-mode -- needs weighting for dust since dust and seasalt
                      !           are combined in the "coarse" mode type
-#if (defined MODAL_AERO_4MODE_MOM && defined RAIN_EVAP_TO_COARSE_AERO )
-                     wght = dmc/(ssmc + dmc + so4mc + bcmc + pommc + soamc + mommc)
-!kzm ++
-#elif (defined MODAL_AERO_5MODE && defined RAIN_EVAP_TO_COARSE_AERO )
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined RAIN_EVAP_TO_COARSE_AERO ) && ( defined MOSAIC_SPECIES ) )
+                     wght = dmc/(ssmc + dmc + so4mc + no3mc + nh4mc + bcmc + pommc + soamc + mommc)
+#elif ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && defined RAIN_EVAP_TO_COARSE_AERO )
                      wght = dmc/(ssmc + dmc + so4mc + bcmc + pommc + soamc + mommc)
 #elif (defined MODAL_AERO_4MODE_MOM)
                      wght = dmc/(ssmc + dmc + so4mc + mommc)

--- a/components/eam/src/physics/cam/rad_constituents.F90
+++ b/components/eam/src/physics/cam/rad_constituents.F90
@@ -239,8 +239,19 @@ character(len=9), parameter :: spec_type_names(num_spec_types) = (/ &
    'sulfate  ', 'ammonium ', 'nitrate  ', 'p-organic', &
    's-organic', 'black-c  ', 'seasalt  ', 'dust     ', &
    'm-organic' /)
-!kzm ++
-#elif ( defined MODAL_AERO_5MODE)
+
+#elif ( ( defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
+integer, parameter :: num_mode_types = 9
+integer, parameter :: num_spec_types = 12
+character(len=14), parameter :: mode_type_names(num_mode_types) = (/ &
+   'accum         ', 'aitken        ', 'primary_carbon', 'fine_seasalt  ', &
+   'fine_dust     ', 'coarse        ', 'coarse_seasalt', 'coarse_dust   ', &
+   'strat_coarse  '  /)
+character(len=9), parameter :: spec_type_names(num_spec_types) = (/ &
+   'sulfate  ', 'ammonium ', 'nitrate  ', 'p-organic', &
+   's-organic', 'black-c  ', 'seasalt  ', 'dust     ', &
+   'm-organic', 'calcium  ', 'carbonate', 'chloride '/)
+#elif ( defined MODAL_AERO_5MODE )
 integer, parameter :: num_mode_types = 9
 integer, parameter :: num_spec_types = 9
 character(len=14), parameter :: mode_type_names(num_mode_types) = (/ &
@@ -251,8 +262,6 @@ character(len=9), parameter :: spec_type_names(num_spec_types) = (/ &
    'sulfate  ', 'ammonium ', 'nitrate  ', 'p-organic', &
    's-organic', 'black-c  ', 'seasalt  ', 'dust     ', &
    'm-organic' /)
-
-
 #else
 integer, parameter :: num_mode_types = 8
 integer, parameter :: num_spec_types = 8


### PR DESCRIPTION
This PR provides the capability of running MOSAIC nitrate and MAM5 stratospheric sulfate treatment together. This PR is a stealth feature which does not turn on MOSAIC and MAM5 by default.

Two conditional compilation if statements: MODAL_AERO_5MODE and MOSAIC_SPECIES

The code modifications are mainly for:

1. Moving conditional compilation if statements MODAL_AERO_5MODE together with MODAL_AERO_4MODE_MOM, because MAM5 only adds a strat coarse mode compared to MAM4. Minimize the code changes so that only 

( MODAL_AERO_4MODE_MOM || MODAL_AERO_5MODE ) && MOSAIC_SPECIES 
and 
( MODAL_AERO_4MODE_MOM || MODAL_AERO_5MODE )
work for most places.

2. Adding chem_mech.in files for chemUCI-MOSAIC and chemUCI-MOSAIC-MAM5.


Test suite results
https://acme-climate.atlassian.net/wiki/spaces/NGDAP/pages/3523149825/Couple+MOSAIC+and+MAM5+strat+sulfate 

It is BFB (stealth) for chemUCI only simulations.
test suites results compared with NGD_v3atm baseline (./create_test $TESTNAMES --compare -b NGD_v3atm):
/lcrc/group/e3sm/ac.mwu/scratch/chrys/

PASS
SMS_Ln5.ne30pg2, 
SMS_Ln.ne4pg2
ERS_Ln11.ne30pg2, 
ERS_Ln9.ne4pg2, 
ERS_ln11_P512x1.ne30.pg2
REP_Ln9 (FAIL for TPUTCOMP Error: TPUTCOMP: Computation time increase > 10% from baseline)
PET_Ln5_P256x2.ne30pg2

FAIL
PET_Ln5.ne30pg2
PET_Ln5.ne4pg2
PEM_Ln5.ne4pg2 (FAIL RUN time; PEND COMPARE_base_modpes)
PEM_Ln9.ne30pg2



It is BFB (stealth) for chemUCI-MOSAIC simulations.

It is not restart-BFB for chemUCI-MOSAIC-MAM5, and 1x10 and 2x5 test runs for NGD_v3atm branch also show non restart-BFB for MAM5 only simulations.



