### PR TITLE
A revised handling of cflx as a stealth feature

### DIFF
--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -2644,6 +2644,12 @@ Do radiative transfer and heating/cooling calculation.
 Default: TRUE
 </entry>
 
+<entry id="cflx_cpl_opt" type="integer" category="process_coupling"
+       group="phys_ctl_nl" valid_values="" >
+Numerical scheme for coupling surface tracer fluxes with the rest of model.
+Default: 1 
+</entry>
+
 <!-- Physics sub-column switches -->
 
 <entry id="use_subcol_microp" type="logical" category="conv"

--- a/components/eam/src/cpl/atm_import_export.F90
+++ b/components/eam/src/cpl/atm_import_export.F90
@@ -52,7 +52,19 @@ contains
        ! NOTE:overwrite_flds is .FALSE. for the first restart
        ! time step making cflx(:,1)=0.0 for the first restart time step.
        ! cflx(:,1) should not be zeroed out, start the second index of cflx from 2.
-       cam_in(c)%cflx(:,2:) = 0._r8 
+
+       ! +++ Update from 2022-09 +++
+       ! For some of the new process coupling options in EAM, some of the constituents'
+       ! cam_in%cflx are used not in tphysac but in the tphysbc call of the next time step. 
+       ! This means for an exact restart, we also need to write out cam_in%cflx(:,2:)
+       ! and then read them back in. Because the present subroutine is called after 
+       ! the cflx variables are read in in the subroutine read_restart_physics 
+       ! in physics/cam/restart_physics.F90, we need to move the following line 
+       ! to that read_restart_physics to avoid incorrectly zeroing out the needed values.
+       !
+       !cam_in(c)%cflx(:,2:) = 0._r8 
+       !
+       ! === Update from 2022-09 ===
                                                
        do i =1,ncols                                                               
           if (overwrite_flds) then

--- a/components/eam/src/physics/cam/cflx.F90
+++ b/components/eam/src/physics/cam/cflx.F90
@@ -1,0 +1,100 @@
+module cflx
+
+  !-----------------------------------------------------------------------------------------------------
+  ! History:
+  !  Separated from module clubb_intr, subroutine clubb_surface by Hui Wan (PNNL), 2022
+  !-----------------------------------------------------------------------------------------------------
+
+  use shr_kind_mod,  only: r8=>shr_kind_r8
+
+  implicit none
+  public
+
+contains
+
+    subroutine cflx_tend (state, cam_in, ztodt, ptend)
+
+    use physics_types,          only: physics_state, physics_ptend, &
+                                      physics_ptend_init, &
+                                      set_dry_to_wet, set_wet_to_dry
+    use physconst,              only: gravit
+    use ppgrid,                 only: pver, pcols
+    use constituents,           only: pcnst, cnst_get_ind, cnst_type
+    use co2_cycle,              only: co2_cycle_set_cnst_type
+    use camsrfexch,             only: cam_in_t
+
+    implicit none
+
+    ! Input Auguments
+
+    type(physics_state), intent(inout)  :: state                ! Physics state variables
+    type(cam_in_t),      intent(in)     :: cam_in               ! contains surface fluxes of constituents
+    real(r8),            intent(in)     :: ztodt                ! 2 delta-t        [ s ]
+
+    ! Output Auguments
+
+    type(physics_ptend), intent(out)    :: ptend                ! Individual parameterization tendencies
+
+    ! Local Variables
+
+    integer :: i                                                ! indicees
+    integer :: ncol                                             ! # of atmospheric columns
+
+    real(r8) :: tmp1(pcols)
+    real(r8) :: rztodt                                          ! 1./ztodt
+    integer  :: m
+
+    logical  :: lq(pcnst)
+
+    character(len=3), dimension(pcnst) :: cnst_type_loc         ! local override option for constituents cnst_type
+
+
+    ncol = state%ncol
+
+    !-------------------------------------------------------
+    ! Assume 'wet' mixing ratios in surface diffusion code.
+    ! don't convert co2 tracers to wet mixing ratios
+
+    cnst_type_loc(:) = cnst_type(:)
+    call co2_cycle_set_cnst_type(cnst_type_loc, 'wet')
+    call set_dry_to_wet(state, cnst_type_loc)
+
+    !-------------------------------------------------------
+    ! Initialize ptend
+
+    lq(:) = .TRUE.
+    call physics_ptend_init(ptend, state%psetcols, 'clubb_srf', lq=lq)
+
+    !-------------------------------------------------------
+    ! Calculate tracer mixing ratio tendencies from cflx
+
+    rztodt                 = 1._r8/ztodt
+    ptend%q(:ncol,:pver,:) = state%q(:ncol,:pver,:)
+    tmp1(:ncol)            = ztodt * gravit * state%rpdel(:ncol,pver)
+
+    do m = 2, pcnst
+      ptend%q(:ncol,pver,m) = ptend%q(:ncol,pver,m) + tmp1(:ncol) * cam_in%cflx(:ncol,m)
+    enddo
+
+    ptend%q(:ncol,:pver,:) = (ptend%q(:ncol,:pver,:) - state%q(:ncol,:pver,:)) * rztodt
+
+    ! Convert tendencies of dry constituents to dry basis.
+    do m = 1,pcnst
+       if (cnst_type(m).eq.'dry') then
+          ptend%q(:ncol,:pver,m) = ptend%q(:ncol,:pver,m)*state%pdel(:ncol,:pver)/state%pdeldry(:ncol,:pver)
+       endif
+    end do
+
+    !-------------------------------------------------------
+    ! convert wet mmr back to dry before conservation check
+    ! avoid converting co2 tracers again
+
+    cnst_type_loc(:) = cnst_type(:)
+    call co2_cycle_set_cnst_type(cnst_type_loc, 'wet')
+    call set_wet_to_dry(state, cnst_type_loc)
+
+    return
+
+  end subroutine cflx_tend
+
+end module

--- a/components/eam/src/physics/cam/phys_control.F90
+++ b/components/eam/src/physics/cam/phys_control.F90
@@ -189,6 +189,11 @@ logical :: l_st_mac        = .true.
 logical :: l_st_mic        = .true.
 logical :: l_rad           = .true.
 
+! Numerical schemes for process coupling
+
+integer :: cflx_cpl_opt = 1  ! When to apply surface tracer fluxes (not including water vapor).
+                             ! The default for aerosols is to do this 
+                             ! after tphysac:clubb_surface and before aerosol dry removal.
 
 !======================================================================= 
 contains
@@ -233,6 +238,7 @@ subroutine phys_ctl_readnl(nlfile)
       fix_g1_err_ndrop, ssalt_tuning, resus_fix, convproc_do_aer, &
       convproc_do_gas, convproc_method_activate, liqcf_fix, regen_fix, demott_ice_nuc, pergro_mods, pergro_test_active, &
       mam_amicphys_optaa, n_so4_monolayers_pcage,micro_mg_accre_enhan_fac, &
+      cflx_cpl_opt, &
       l_tracer_aero, l_vdiff, l_rayleigh, l_gw_drag, l_ac_energy_chk, &
       l_bc_energy_fix, l_dry_adj, l_st_mac, l_st_mic, l_rad, prc_coef1,prc_exp,prc_exp1,cld_sed,mg_prc_coeff_fix, &
       rrtmg_temp_fix
@@ -336,6 +342,7 @@ subroutine phys_ctl_readnl(nlfile)
    call mpibcast(demott_ice_nuc,                  1 , mpilog,  0, mpicom)
    call mpibcast(pergro_mods,                     1 , mpilog,  0, mpicom)
    call mpibcast(pergro_test_active,              1 , mpilog,  0, mpicom)
+   call mpibcast(cflx_cpl_opt,                    1 , mpiint,  0, mpicom)
    call mpibcast(l_tracer_aero,                   1 , mpilog,  0, mpicom)
    call mpibcast(l_vdiff,                         1 , mpilog,  0, mpicom)
    call mpibcast(l_rayleigh,                      1 , mpilog,  0, mpicom)
@@ -430,6 +437,12 @@ subroutine phys_ctl_readnl(nlfile)
       end if
    end if
 
+   ! Check settings for process coupling
+   if (masterproc) write(iulog,*) '**** phys_ctl_readnl: cflx_cpl_opt = ', cflx_cpl_opt
+   if (.not.( (cflx_cpl_opt==1).or.(cflx_cpl_opt==2) )) then
+      call endrun('phys_ctl_readnl: unsupported value of cflx_cpl_opt')
+   end if
+
    ! prog_modal_aero determines whether prognostic modal aerosols are present in the run.
    prog_modal_aero = (     cam_chempkg_is('trop_mam3') &
                       .or. cam_chempkg_is('trop_mam4') &
@@ -519,6 +532,7 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, &
                         fix_g1_err_ndrop_out, ssalt_tuning_out,resus_fix_out,convproc_do_aer_out,  &
                         convproc_do_gas_out, convproc_method_activate_out, mam_amicphys_optaa_out, n_so4_monolayers_pcage_out, &
                         micro_mg_accre_enhan_fac_out, liqcf_fix_out, regen_fix_out,demott_ice_nuc_out, pergro_mods_out, pergro_test_active_out &
+                       ,cflx_cpl_opt_out &
                        ,l_tracer_aero_out, l_vdiff_out, l_rayleigh_out, l_gw_drag_out, l_ac_energy_chk_out  &
                        ,l_bc_energy_fix_out, l_dry_adj_out, l_st_mac_out, l_st_mic_out, l_rad_out  &
                        ,prc_coef1_out,prc_exp_out,prc_exp1_out, cld_sed_out,mg_prc_coeff_fix_out,rrtmg_temp_fix_out)
@@ -608,7 +622,7 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, &
    logical,           intent(out), optional :: pergro_mods_out     
    logical,           intent(out), optional :: pergro_test_active_out     
 
-
+   integer,           intent(out), optional :: cflx_cpl_opt_out
    logical,           intent(out), optional :: l_tracer_aero_out
    logical,           intent(out), optional :: l_vdiff_out
    logical,           intent(out), optional :: l_rayleigh_out
@@ -706,6 +720,7 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, &
    if ( present(pergro_mods_out         ) ) pergro_mods_out          = pergro_mods
    if ( present(pergro_test_active_out  ) ) pergro_test_active_out   = pergro_test_active
 
+   if ( present(cflx_cpl_opt_out        ) ) cflx_cpl_opt_out      = cflx_cpl_opt
    if ( present(l_tracer_aero_out       ) ) l_tracer_aero_out     = l_tracer_aero
    if ( present(l_vdiff_out             ) ) l_vdiff_out           = l_vdiff
    if ( present(l_rayleigh_out          ) ) l_rayleigh_out        = l_rayleigh

--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -1525,6 +1525,12 @@ subroutine tphysac (ztodt,   cam_in,  &
     logical :: l_gw_drag
     logical :: l_ac_energy_chk
 
+    ! Numerical schemes for process coupling
+    integer :: cflx_cpl_opt  ! When to apply surface tracer fluxes  (not including water vapor).
+                             ! The default for aerosols is to do this 
+                             ! after tphysac:clubb_surface and before aerosol dry removal.
+                             ! For chemical gases, different versions of EAM 
+                             ! might use different process ordering.
     !
     !-----------------------------------------------------------------------
     !
@@ -1536,6 +1542,7 @@ subroutine tphysac (ztodt,   cam_in,  &
     call phys_getopts( do_clubb_sgs_out       = do_clubb_sgs, &
                        state_debug_checks_out = state_debug_checks &
                       ,deep_scheme_out        = deep_scheme        &
+                      ,cflx_cpl_opt_out       = cflx_cpl_opt       &
                       ,l_tracer_aero_out      = l_tracer_aero      &
                       ,l_vdiff_out            = l_vdiff            &
                       ,l_rayleigh_out         = l_rayleigh         &
@@ -1659,9 +1666,18 @@ end if ! l_tracer_aero
        ! calculate surface friction velocity (ustar) and Obukhov length
        call clubb_surface ( state, cam_in, surfric, obklen)
 
-       ! Diagnose tracer mixing ratio tendencies from surface fluxes, then update the mixing ratios
-       call cflx_tend( state, cam_in, ztodt, ptend)       
-       call physics_update(state, ptend, ztodt, tend)
+       ! Diagnose tracer mixing ratio tendencies from surface fluxes, 
+       ! then update the mixing ratios. (If cflx_cpl_opt==2, these are done in 
+       ! tphysbc after deep convection before the cloud mac-mic subcycles
+       ! so that the emission-induced updates of state can be closer to turbulent transport.)
+       ! Note that the two subroutine calls below do not touch water vapor. 
+       ! They also have no effects on tracers for which cam_in%cflx(:,m) 
+       ! is zero at this point.
+
+       if (cflx_cpl_opt==1) then
+          call cflx_tend( state, cam_in, ztodt, ptend)       
+          call physics_update(state, ptend, ztodt, tend)
+       end if
 
     else
     if (l_vdiff) then
@@ -1924,6 +1940,7 @@ subroutine tphysbc (ztodt,               &
     use subcol_utils,    only: subcol_ptend_copy, is_subcol_on
     use phys_control,    only: use_qqflx_fixer, use_mass_borrower
     use nudging,         only: Nudge_Model,Nudge_Loc_PhysOut,nudging_calc_tend
+    use cflx,            only: cflx_tend
 
     implicit none
 
@@ -2079,12 +2096,19 @@ subroutine tphysbc (ztodt,               &
     logical :: l_rad
     !HuiWan (2014/15): added for a short-term time step convergence test ==
 
+    ! Numerical schemes for process coupling
+    integer :: cflx_cpl_opt  ! When to apply surface tracer fluxes  (not including water vapor).
+                             ! The default for aerosols is to do this 
+                             ! after tphysac:clubb_surface and before aerosol dry removal.
+                             ! For chemical gases, different versions of EAM 
+                             ! might use different process ordering.
 
     call phys_getopts( microp_scheme_out      = microp_scheme, &
                        macrop_scheme_out      = macrop_scheme, &
                        use_subcol_microp_out  = use_subcol_microp, &
                        deep_scheme_out        = deep_scheme,       &
                        state_debug_checks_out = state_debug_checks &
+                      ,cflx_cpl_opt_out       = cflx_cpl_opt       &
                       ,l_bc_energy_fix_out    = l_bc_energy_fix    &
                       ,l_dry_adj_out          = l_dry_adj          &
                       ,l_tracer_aero_out      = l_tracer_aero      &
@@ -2393,6 +2417,9 @@ if (l_tracer_aero) then
 end if
 
 
+    !========================================================================================
+    ! Stratiform cloud macro and microphysics, turbulence, aerosol activation-resuspension
+    !========================================================================================
     if( microp_scheme == 'RK' ) then
 
      if (l_st_mac.or.l_st_mic) then
@@ -2416,6 +2443,21 @@ end if
      end if !l_st_mac
 
     elseif( microp_scheme == 'MG' ) then
+
+       !========================================================================================
+       ! Apply surface tracer fluxes to update tracer mixing ratios before turbulent tranport 
+       !========================================================================================
+       ! Diagnose tracer mixing ratio tendencies from surface fluxes, then update the mixing ratios.
+       ! Note that these subroutine calls do not touch water vapor. They also have no effects
+       ! on tracers for which cam_in%cflx(:,m) is zero at this point.
+
+      !if ( do_clubb_sgs .and. (cflx_cpl_opt==2) ) then
+       if ( cflx_cpl_opt==2 ) then
+          call cflx_tend( state, cam_in, ztodt, ptend)
+          call physics_update(state, ptend, ztodt, tend)
+       end if
+
+       !========================================================================================
        ! Start co-substepping of macrophysics and microphysics
        cld_macmic_ztodt = ztodt/cld_macmic_num_steps
 

--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -1444,6 +1444,7 @@ subroutine tphysac (ztodt,   cam_in,  &
     use qbo,                only: qbo_relax
     use iondrag,            only: iondrag_calc, do_waccm_ions
     use clubb_intr,         only: clubb_surface
+    use cflx,               only: cflx_tend
     use perf_mod
     use flux_avg,           only: flux_avg_run
     use nudging,            only: Nudge_Model,Nudge_ON,nudging_timestep_tend
@@ -1652,15 +1653,14 @@ end if ! l_tracer_aero
     ! Vertical diffusion/pbl calculation
     ! Call vertical diffusion code (pbl, free atmosphere and molecular)
     !===================================================
-
-    ! If CLUBB is called, do not call vertical diffusion, but obukov length and
-    !   surface friction velocity still need to be computed.  In addition, 
-    !   surface fluxes need to be updated here for constituents 
     if (do_clubb_sgs) then
 
-       call clubb_surface ( state, ptend, ztodt, cam_in, surfric, obklen)
-       
-       ! Update surface flux constituents 
+       ! If CLUBB is called, do not call vertical diffusion, but still
+       ! calculate surface friction velocity (ustar) and Obukhov length
+       call clubb_surface ( state, cam_in, surfric, obklen)
+
+       ! Diagnose tracer mixing ratio tendencies from surface fluxes, then update the mixing ratios
+       call cflx_tend( state, cam_in, ztodt, ptend)       
        call physics_update(state, ptend, ztodt, tend)
 
     else

--- a/components/eam/src/physics/cam/restart_physics.F90
+++ b/components/eam/src/physics/cam/restart_physics.F90
@@ -637,6 +637,22 @@ module restart_physics
         ! and if the values are used in the tphysbc physics before the 
         ! tphysac code has a chance to update the values that are 
         ! coming from boundary datasets.
+
+       ! +++ Update from 2022-09 +++
+       ! For some of the new process coupling options in EAM, some of the constituents'
+       ! cam_in%cflx are used not in tphysac but in the tphysbc call of the next time step. 
+       ! This means for an exact restart, we also need to write out cam_in%cflx(:,2:)
+       ! and then read them back in. Because the present subroutine is called before 
+       ! the atm_import subroutine in cpl/atm_import_export.F90, the following
+       ! initialize was moved from atm_import to here to avoid incorrectly zeroing out 
+       ! the values read from restart files
+       !
+       do c= begchunk, endchunk
+          cam_in(c)%cflx(:,2:) = 0._r8
+       end do
+       !
+       ! === Update from 2022-09 ===
+
         do m = 1, pcnst
 
            write(num,'(i4.4)') m


### PR DESCRIPTION
**This PR replaces PR #4**

This PR includes the same essential changes in the old PR, but
- The implementation is based off Wuyin's <NGD_atm> branch (which has updated test capabilities).
- Comments in the code have been improved to clarify which tracers are affected and which are not.
- Initialization of `cam_in%cflx` is revised to ensure BFB restart.

------

This PR adds an optional revision to the numerical process coupling at the `tphysbc`/`tphysac` level to couple the surface emissions of tracers more tightly with the turbulent transport. This is done by revising where in the time integration loop the surface fluxes in `cam_in%cflx(:,2:)` are applied to update the tracer mixing ratios.

The revision was motivated by the known issues of overly short dust lifetime in EAMv1 and the very strong sensitivity of the dust lifetime to vertical resolution, see [Feng et al., 2022](https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2021MS002909) for the v1 results.

The implementation of the revised coupling is described below in the "code modifications" section.

Impacts of the revised coupling was initially evaluated in v1. More recently, evaluation was done in v2 using a 5-year F2010 simulation and a 30-year AMIP (F20TR) simulation using the [huiwanpnnl/atm/aerosol_process_coupling branch in the E3SM repo](https://github.com/E3SM-Project/E3SM/tree/huiwanpnnl/atm/aerosol_process_coupling). Highlights of the results can be found on [this Confluence page](https://acme-climate.atlassian.net/wiki/spaces/NGDAP/pages/3469312014/Revised+aerosol+process+coupling+for+E3SMv3) and in [this slide deck](https://acme-climate.atlassian.net/wiki/spaces/NGDAP/pages/3469312014/Revised+aerosol+process+coupling+for+E3SMv3).


**Code modifications**

- The subroutine `clubb_surface` in `clubb_intr.F90` was split into two parts:
   - The calculations of `ustar` and the Obukhov length remain in `clubb_surface`.
   - The calculation of tracer mixing ratio tendencies using `cam_in%clfx` was moved to a new subroutine `cflx_tend` in a new module in `cflx.F90`
  
- A new namelist variable `cflx_cpl_opt` was added.
   - _`cflx_cpl_opt = 1` (default) gives the original coupling in v2._ 
   
   There, the subroutine `cflx_tend` is called immediately after `clubb_surface` followed by a `call physics_update(...)`. This gives the original process coupling in EAMv2 and the results are BFB.
   
   - _`cflx_cpl_opt = 2` activates the revised coupling._ 
   
   The call of `cflx_tend` and the corresponding `call physics_update(...)` are moved to right before the cloud macro-microphysics sub-cycles in `tphysbc`, so that the tracers emitted to the lowest model layer can be transported to upper layers by `CLUBB` or `dropmixnuc`.

    Note that `cflx_cpl_opt = 2` does __not__ affect water vapor. Neither does it affect tracers whose portion of `cam_in%cflx` is zero when `clubb_surface` is called.

- The initialization of `cam_in%cflx(:,2:)` with zeros was moved from the `atm_import` subroutine in `components/eam/src/cpl/atm_import_export.F90` to the `read_restart_physics` subroutine in `components/eam/src/physics/cam/restart_physics.F90` to avoid incorrectly zeroing out the values read in from a restart file. This ensures BFB restart for both the default model and for `cflx_cpl_opt = 2`. 

