### PR TITLE
Quick fix for non-BFB results when all ZM enhancements are turned off

### DIFF
--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -4002,15 +4002,14 @@ add_default($nl, 'zmconv_alfa');
 add_default($nl, 'zmconv_trigdcape_ull');
 add_default($nl, 'zmconv_microp');
 add_default($nl, 'zmconv_clos_dyn_adj');
+add_default($nl, 'zmconv_tpert_fix');
 add_default($nl, 'zmconv_auto_fac');
 add_default($nl, 'zmconv_accr_fac');
 add_default($nl, 'zmconv_micro_dcs');
-#++ MCSP
 add_default($nl, 'zmconv_MCSP_heat_coeff');
 add_default($nl, 'zmconv_MCSP_moisture_coeff');
 add_default($nl, 'zmconv_MCSP_uwind_coeff');
 add_default($nl, 'zmconv_MCSP_vwind_coeff');
-#-- MCSP
 #
 # moist convection rainwater coefficients
 # These no more needed for EAM, including uwshcu_rpen. No need to reset for 'cam5'

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -1139,10 +1139,10 @@
 <zmconv_accr_fac                                                      >1.5D0 </zmconv_accr_fac>
 <zmconv_micro_dcs                                                     >150.E-6</zmconv_micro_dcs>
 <!-- MCSP -->
-<zmconv_MCSP_heat_coeff                                               >0.0</zmconv_MCSP_heat_coeff>
-<zmconv_MCSP_moisture_coeff                                           >0.0</zmconv_MCSP_moisture_coeff>
-<zmconv_MCSP_uwind_coeff                                              >0.0</zmconv_MCSP_uwind_coeff>
-<zmconv_MCSP_vwind_coeff                                              >0.0</zmconv_MCSP_vwind_coeff>
+<zmconv_MCSP_heat_coeff                                               >0.0D0</zmconv_MCSP_heat_coeff>
+<zmconv_MCSP_moisture_coeff                                           >0.0D0</zmconv_MCSP_moisture_coeff>
+<zmconv_MCSP_uwind_coeff                                              >0.0D0</zmconv_MCSP_uwind_coeff>
+<zmconv_MCSP_vwind_coeff                                              >0.0D0</zmconv_MCSP_vwind_coeff>
 
 <!-- Cloud sedimentation -->
 

--- a/components/eam/src/physics/cam/conv_water.F90
+++ b/components/eam/src/physics/cam/conv_water.F90
@@ -323,8 +323,10 @@ module conv_water
             case default ! Area weighted 'arithmetic in emissivity' average.
 !               call endrun ('CONV_WATER_4_RAD: Unknown option for conv_water_in_rad - exiting')
             end select
+          end if  !zm_microp
+      end if
 
-      
+     if (.not.zm_microp) then     
       !BSINGH - Logic by Phil R. to account for insignificant condensate in large scale clouds
       if (ls_icwmr < 100._r8*ic_limit .and. pergro_mods) then ! if there is virtually  no stratiform condensate
          if (state%t(i,k) < 243._r8) then           ! if very cold assume convective condensate is ice
@@ -349,9 +351,8 @@ module conv_water
 
       totg_ice(i,k) = tot0_frac * tot_icwmr * wrk1
       totg_liq(i,k) = tot0_frac * tot_icwmr * (1._r8-wrk1)
-
-       endif  !zm_microp
-      endif
+    
+     endif
    end do
    end do
 

--- a/components/eam/src/physics/cam/zm_conv.F90
+++ b/components/eam/src/physics/cam/zm_conv.F90
@@ -72,12 +72,10 @@ module zm_conv
    real(r8) :: zmconv_auto_fac       = unset_r8
    real(r8) :: zmconv_accr_fac       = unset_r8
    real(r8) :: zmconv_micro_dcs      = unset_r8
-!++ MCSP
    real(r8) :: zmconv_MCSP_heat_coeff = 0._r8
    real(r8) :: zmconv_MCSP_moisture_coeff = 0._r8
    real(r8) :: zmconv_MCSP_uwind_coeff = 0._r8
    real(r8) :: zmconv_MCSP_vwind_coeff = 0._r8   
-!-- MCSP
 
    real(r8) rl         ! wg latent heat of vaporization.
    real(r8) cpres      ! specific heat at constant pressure in j/kg-degk.
@@ -135,7 +133,6 @@ module zm_conv
    real(r8) :: MCSP_moisture_coeff = unset_r8
    real(r8) :: MCSP_uwind_coeff = unset_r8
    real(r8) :: MCSP_vwind_coeff = unset_r8
-!-- MCSP
 
 contains
 
@@ -156,10 +153,8 @@ subroutine zmconv_readnl(nlfile)
            zmconv_cape_cin, zmconv_mx_bot_lyr_adj, zmconv_tp_fac, zmconv_trigdcape_ull, &
            zmconv_trig_dcape_only, zmconv_trig_ull_only, zmconv_microp, zmconv_auto_fac,&
            zmconv_accr_fac, zmconv_micro_dcs, zmconv_clos_dyn_adj, zmconv_tpert_fix,    &
-!++ MCSP 
            zmconv_MCSP_heat_coeff, zmconv_MCSP_moisture_coeff, &
            zmconv_MCSP_uwind_coeff, zmconv_MCSP_vwind_coeff   
-!-- MCSP
    !-----------------------------------------------------------------------------
 
    zmconv_tau = 3600._r8
@@ -246,14 +241,12 @@ subroutine zmconv_readnl(nlfile)
    call mpibcast(tp_fac,            1, mpir8,  0, mpicom)
    call mpibcast(auto_fac,          1, mpir8,  0, mpicom)
    call mpibcast(accr_fac,          1, mpir8,  0, mpicom)
-   call mpibcast(micro_dcs,         1, mpir8,  0, mpicom)
-!++ MCSP   
+   call mpibcast(micro_dcs,         1, mpir8,  0, mpicom)  
    call mpibcast(MCSP,              1, mpilog, 0, mpicom)
    call mpibcast(MCSP_heat_coeff,   1, mpir8,  0, mpicom)
    call mpibcast(MCSP_moisture_coeff,1, mpir8,  0, mpicom)
    call mpibcast(MCSP_uwind_coeff,  1, mpir8,  0, mpicom)
    call mpibcast(MCSP_vwind_coeff,  1, mpir8,  0, mpicom)  
-!-- MCSP   
 #endif
 
 end subroutine zmconv_readnl

--- a/components/eam/src/physics/cam/zm_conv.F90
+++ b/components/eam/src/physics/cam/zm_conv.F90
@@ -72,12 +72,12 @@ module zm_conv
    real(r8) :: zmconv_auto_fac       = unset_r8
    real(r8) :: zmconv_accr_fac       = unset_r8
    real(r8) :: zmconv_micro_dcs      = unset_r8
-
+!++ MCSP
    real(r8) :: zmconv_MCSP_heat_coeff = 0._r8
    real(r8) :: zmconv_MCSP_moisture_coeff = 0._r8
    real(r8) :: zmconv_MCSP_uwind_coeff = 0._r8
    real(r8) :: zmconv_MCSP_vwind_coeff = 0._r8   
-
+!-- MCSP
 
    real(r8) rl         ! wg latent heat of vaporization.
    real(r8) cpres      ! specific heat at constant pressure in j/kg-degk.
@@ -130,12 +130,13 @@ module zm_conv
    real(r8) :: accr_fac = unset_r8
    real(r8) :: micro_dcs= unset_r8
 
+!++ MCSP   
    logical :: MCSP
    real(r8) :: MCSP_heat_coeff = unset_r8
    real(r8) :: MCSP_moisture_coeff = unset_r8
    real(r8) :: MCSP_uwind_coeff = unset_r8
    real(r8) :: MCSP_vwind_coeff = unset_r8
-
+!-- MCSP
 
 contains
 
@@ -155,10 +156,11 @@ subroutine zmconv_readnl(nlfile)
            zmconv_dmpdz, zmconv_alfa, zmconv_tiedke_add,     &
            zmconv_cape_cin, zmconv_mx_bot_lyr_adj, zmconv_tp_fac, zmconv_trigdcape_ull, &
            zmconv_trig_dcape_only, zmconv_trig_ull_only, zmconv_microp, zmconv_auto_fac,&
-           zmconv_accr_fac, zmconv_micro_dcs, zmconv_clos_dyn_adj, zmconv_tpert_fix,    & 
+           zmconv_accr_fac, zmconv_micro_dcs, zmconv_clos_dyn_adj, zmconv_tpert_fix,    &
+!++ MCSP 
            zmconv_MCSP_heat_coeff, zmconv_MCSP_moisture_coeff, &
            zmconv_MCSP_uwind_coeff, zmconv_MCSP_vwind_coeff   
-
+!-- MCSP
    !-----------------------------------------------------------------------------
 
    zmconv_tau = 3600._r8
@@ -194,12 +196,14 @@ subroutine zmconv_readnl(nlfile)
       auto_fac       = zmconv_auto_fac
       accr_fac       = zmconv_accr_fac
       micro_dcs      = zmconv_micro_dcs
+!++ MCSP
       MCSP_heat_coeff = zmconv_MCSP_heat_coeff
       MCSP_moisture_coeff = zmconv_MCSP_moisture_coeff
       MCSP_uwind_coeff = zmconv_MCSP_uwind_coeff
       MCSP_vwind_coeff = zmconv_MCSP_vwind_coeff     
  
       if( abs(MCSP_heat_coeff)+abs(MCSP_moisture_coeff)+abs(MCSP_uwind_coeff)+abs(MCSP_vwind_coeff) > 0._r8 ) MCSP = .true.
+!-- MCSP
 
       if ( zmconv_alfa /= unset_r8 ) then
            alfa_scalar = zmconv_alfa
@@ -241,12 +245,14 @@ subroutine zmconv_readnl(nlfile)
    call mpibcast(tp_fac,            1, mpir8,  0, mpicom)
    call mpibcast(auto_fac,          1, mpir8,  0, mpicom)
    call mpibcast(accr_fac,          1, mpir8,  0, mpicom)
-   call mpibcast(micro_dcs,         1, mpir8,  0, mpicom)   
+   call mpibcast(micro_dcs,         1, mpir8,  0, mpicom)
+!++ MCSP   
    call mpibcast(MCSP,              1, mpilog, 0, mpicom)
    call mpibcast(MCSP_heat_coeff,   1, mpir8,  0, mpicom)
    call mpibcast(MCSP_moisture_coeff,1, mpir8,  0, mpicom)
    call mpibcast(MCSP_uwind_coeff,  1, mpir8,  0, mpicom)
    call mpibcast(MCSP_vwind_coeff,  1, mpir8,  0, mpicom)  
+!-- MCSP   
 #endif
 
 end subroutine zmconv_readnl
@@ -3646,7 +3652,7 @@ subroutine cldprp(lchnk   , &
       end do
       do i = 1,il2g
           totpcp(i) = 0._r8
-          hu(i,jb(i)) = hmn(i,jb(i)) + cp*tiedke_add
+          if (zm_microp)  hu(i,jb(i)) = hmn(i,jb(i)) + cp*tiedke_add
       end do
 
 !
@@ -4084,7 +4090,7 @@ subroutine cldprp(lchnk   , &
    end do
 !
    do i = 1,il2g
-     if (jt(i)>=jlcl(i)) then
+     if ( zm_microp .and. jt(i)>=jlcl(i)) then
        do k = msg + 1,pver  
           mu(i,k)   = 0._r8
           eu(i,k)   = 0._r8
@@ -4107,21 +4113,19 @@ subroutine cldprp(lchnk   , &
           nsde(i,k) = 0._r8
           frz(i,k)  = 0._r8
           frz1(i,k) = 0._r8
-          if (zm_microp) then            
-            loc_microp_st%wu(i,k)   = 0._r8      
-            loc_microp_st%cmel(i,k) = 0._r8
-            loc_microp_st%cmei(i,k) = 0._r8
-            loc_microp_st%qliq(i,k) = 0._r8
-            loc_microp_st%qice(i,k) = 0._r8
-            loc_microp_st%qrain(i,k)= 0._r8
-            loc_microp_st%qsnow(i,k)= 0._r8
-            loc_microp_st%qgraupel(i,k) = 0._r8
-            loc_microp_st%qnl(i,k)  = 0._r8
-            loc_microp_st%qni(i,k)  = 0._r8
-            loc_microp_st%qnr(i,k)  = 0._r8
-            loc_microp_st%qns(i,k)  = 0._r8
-            loc_microp_st%qng(i,k)  = 0._r8
-          end if   
+          loc_microp_st%wu(i,k)   = 0._r8      
+          loc_microp_st%cmel(i,k) = 0._r8
+          loc_microp_st%cmei(i,k) = 0._r8
+          loc_microp_st%qliq(i,k) = 0._r8
+          loc_microp_st%qice(i,k) = 0._r8
+          loc_microp_st%qrain(i,k)= 0._r8
+          loc_microp_st%qsnow(i,k)= 0._r8
+          loc_microp_st%qgraupel(i,k) = 0._r8
+          loc_microp_st%qnl(i,k)  = 0._r8
+          loc_microp_st%qni(i,k)  = 0._r8
+          loc_microp_st%qnr(i,k)  = 0._r8
+          loc_microp_st%qns(i,k)  = 0._r8
+          loc_microp_st%qng(i,k)  = 0._r8
        end do
      end if
    end do       
@@ -4338,7 +4342,7 @@ subroutine closure(lchnk   , &
    do i = il1g,il2g
       dltaa = -1._r8* (cape(i)-capelmt)
       if (dadt(i) /= 0._r8) mb(i) = max(dltaa/tau/dadt(i),0._r8)
-      if (mx(i)-jt(i) < 2._r8) mb(i) =0.0_r8
+      if (zm_microp .and. mx(i)-jt(i) < 2._r8) mb(i) =0.0_r8
    end do
 !
    return

--- a/components/eam/src/physics/cam/zm_conv.F90
+++ b/components/eam/src/physics/cam/zm_conv.F90
@@ -130,8 +130,7 @@ module zm_conv
    real(r8) :: accr_fac = unset_r8
    real(r8) :: micro_dcs= unset_r8
 
-!++ MCSP   
-   logical :: MCSP
+   logical  :: MCSP
    real(r8) :: MCSP_heat_coeff = unset_r8
    real(r8) :: MCSP_moisture_coeff = unset_r8
    real(r8) :: MCSP_uwind_coeff = unset_r8
@@ -178,32 +177,34 @@ subroutine zmconv_readnl(nlfile)
       call freeunit(unitn)
 
       ! set local variables
-      c0_lnd         = zmconv_c0_lnd
-      c0_ocn         = zmconv_c0_ocn
-      ke             = zmconv_ke
-      tau            = zmconv_tau
-      trigdcape_ull  = zmconv_trigdcape_ull
+      c0_lnd           = zmconv_c0_lnd
+      c0_ocn           = zmconv_c0_ocn
+      ke               = zmconv_ke
+      tau              = zmconv_tau
+      trigdcape_ull    = zmconv_trigdcape_ull
       trig_dcape_only  = zmconv_trig_dcape_only
-      trig_ull_only  = zmconv_trig_ull_only
-      zm_microp      = zmconv_microp
-      clos_dyn_adj   = zmconv_clos_dyn_adj
-      tpert_fix      = zmconv_tpert_fix
-      tiedke_add     = zmconv_tiedke_add
-      num_cin        = zmconv_cape_cin
-      mx_bot_lyr_adj = zmconv_mx_bot_lyr_adj
-      dmpdz          = zmconv_dmpdz
-      tp_fac         = zmconv_tp_fac
-      auto_fac       = zmconv_auto_fac
-      accr_fac       = zmconv_accr_fac
-      micro_dcs      = zmconv_micro_dcs
-!++ MCSP
-      MCSP_heat_coeff = zmconv_MCSP_heat_coeff
+      trig_ull_only    = zmconv_trig_ull_only
+      zm_microp        = zmconv_microp
+      clos_dyn_adj     = zmconv_clos_dyn_adj
+      tpert_fix        = zmconv_tpert_fix
+      tiedke_add       = zmconv_tiedke_add
+      num_cin          = zmconv_cape_cin
+      mx_bot_lyr_adj   = zmconv_mx_bot_lyr_adj
+      dmpdz            = zmconv_dmpdz
+      tp_fac           = zmconv_tp_fac
+      auto_fac         = zmconv_auto_fac
+      accr_fac         = zmconv_accr_fac
+      micro_dcs        = zmconv_micro_dcs
+      MCSP_heat_coeff  = zmconv_MCSP_heat_coeff
       MCSP_moisture_coeff = zmconv_MCSP_moisture_coeff
       MCSP_uwind_coeff = zmconv_MCSP_uwind_coeff
       MCSP_vwind_coeff = zmconv_MCSP_vwind_coeff     
  
-      if( abs(MCSP_heat_coeff)+abs(MCSP_moisture_coeff)+abs(MCSP_uwind_coeff)+abs(MCSP_vwind_coeff) > 0._r8 ) MCSP = .true.
-!-- MCSP
+      if( abs(MCSP_heat_coeff)+abs(MCSP_moisture_coeff)+abs(MCSP_uwind_coeff)+abs(MCSP_vwind_coeff) > 0._r8 ) then
+           MCSP = .true.
+      else
+           MCSP = .false.
+      end if 
 
       if ( zmconv_alfa /= unset_r8 ) then
            alfa_scalar = zmconv_alfa

--- a/components/eam/src/physics/cam/zm_conv_intr.F90
+++ b/components/eam/src/physics/cam/zm_conv_intr.F90
@@ -236,14 +236,14 @@ subroutine zm_conv_init(pref_edge)
     call addfld ('ZMICVU',     (/ 'lev' /), 'A', 'm/s', 'ZM in-cloud V updrafts')
     call addfld ('ZMICVD',     (/ 'lev' /), 'A', 'm/s', 'ZM in-cloud V downdrafts')
 
-    if( MCSP ) then 
-    call addfld ('MCSP_DT',(/ 'lev' /), 'A','K/s','T tedency due to MCSP')
-    call addfld ('MCSP_freq',horiz_only, 'A','1','frequency of MCSP activated')
-    call addfld ('MCSP_DU',(/ 'lev' /), 'A','m/s/day','U tedency due to MCSP')
-    call addfld ('MCSP_DV',(/ 'lev' /), 'A','m/s/day','V tedency due to MCSP')
-    call addfld ('ZM_freq',horiz_only, 'A','1','frequency for ZM to be activated')
-    call addfld ('ZM_depth',horiz_only,'A','Pa','ZM depth')
-    call addfld ('MCSP_shear',horiz_only,'A','m/s','vertical zonal wind shear')
+    if (MCSP) then 
+       call addfld ('MCSP_DT',(/ 'lev' /), 'A','K/s','T tedency due to MCSP')
+       call addfld ('MCSP_freq',horiz_only, 'A','1','frequency of MCSP activated')
+       call addfld ('MCSP_DU',(/ 'lev' /), 'A','m/s/day','U tedency due to MCSP')
+       call addfld ('MCSP_DV',(/ 'lev' /), 'A','m/s/day','V tedency due to MCSP')
+       call addfld ('ZM_freq',horiz_only, 'A','1','frequency for ZM to be activated')
+       call addfld ('ZM_depth',horiz_only,'A','Pa','ZM depth')
+       call addfld ('MCSP_shear',horiz_only,'A','m/s','vertical zonal wind shear')
     end if
 
 !Convective microphysics
@@ -968,10 +968,11 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
     end if
 
 
-   doslop_heat = .false.
+   doslop          = .false.
+   doslop_heat     = .false.
    doslop_moisture = .false.
-   doslop_uwind = .false.
-   doslop_vwind = .false.
+   doslop_uwind    = .false.
+   doslop_vwind    = .false.
    if( MCSP ) then
         if( MCSP_heat_coeff > 0._r8 ) then
                 doslop_heat = .true.
@@ -992,7 +993,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
     end if
 
    if (doslop_heat .or. doslop_moisture .or. doslop_uwind .or. doslop_vwind) then
-     doslop = .true.
+      doslop = .true.
    endif
 
 
@@ -1014,7 +1015,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    lq(:) = .FALSE.
    lq(1) = .TRUE.
  
-   if(doslop) then
+   if (doslop) then
         call physics_ptend_init(ptend_loc, state%psetcols, 'zm_convr', ls=.true., lu = doslop_uwind, lv = doslop_vwind, lq=lq)! initialize local ptend type
    else
         call physics_ptend_init(ptend_loc, state%psetcols, 'zm_convr', ls=.true., lq=lq)! initialize local ptend type
@@ -1116,34 +1117,32 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    call outfld('DCAPE', dcape, pcols, lchnk)
 
 
-   if( doslop ) then
-!   
-!  Begin MCSP parameterization here 
-!
-   du600 = 0._r8
-   dv600 = 0._r8
-   ZM_depth = 0._r8
-   MCSP_shear = 0._r8
-
-   call vertinterp(ncol, pcols, pver, state%pmid, 60000._r8, state%u,du600)
-   call vertinterp(ncol, pcols, pver, state%pmid, 60000._r8, state%v,dv600)
-
-   do i=1,ncol
-      if(state%pmid(i,pver).gt.60000._r8) then
-        du600(i) = du600(i)-state%u(i,pver)
-        dv600(i) = dv600(i)-state%v(i,pver)
-      else
-        du600(i) = -999._r8
-        dv600(i) = -999._r8
-      end if
-   end do
-
-   MCSP_shear = du600
-   do i=1,ncol
-      if( jctop(i).ne.pver ) ZM_depth(i) = state%pint(i,pver+1)-state%pmid(i,jctop(i))
-   end do
-
    if (doslop) then
+  !   
+  !  Begin MCSP parameterization here 
+  !
+     du600 = 0._r8
+     dv600 = 0._r8
+     ZM_depth = 0._r8
+     MCSP_shear = 0._r8
+
+     call vertinterp(ncol, pcols, pver, state%pmid, 60000._r8, state%u,du600)
+     call vertinterp(ncol, pcols, pver, state%pmid, 60000._r8, state%v,dv600)
+
+     do i=1,ncol
+        if(state%pmid(i,pver).gt.60000._r8) then
+          du600(i) = du600(i)-state%u(i,pver)
+          dv600(i) = dv600(i)-state%v(i,pver)
+        else
+          du600(i) = -999._r8
+          dv600(i) = -999._r8
+        end if
+     end do
+
+     MCSP_shear = du600
+     do i=1,ncol
+        if( jctop(i).ne.pver ) ZM_depth(i) = state%pint(i,pver+1)-state%pmid(i,jctop(i))
+     end do
 
      ! Define parameters
 
@@ -1240,19 +1239,19 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
        enddo
      enddo
 
-   endif
-!   
-! End the MCSP parameterization here 
-!   
    
+   !   
+   ! End the MCSP parameterization here 
+   !   
+      
 
-  MCSP_DT(:ncol,:pver) = MCSP_DT(:ncol,:pver)/cpair
-   call outfld('MCSP_DT    ',MCSP_DT           ,pcols   ,lchnk   )
-   call outfld('MCSP_freq    ',MCSP_freq           ,pcols   ,lchnk   )
-   call outfld('MCSP_DU    ',ptend_loc%u*86400._r8           ,pcols   ,lchnk   )
-   call outfld('MCSP_DV    ',ptend_loc%v*86400._r8           ,pcols   ,lchnk   )
-   call outfld('ZM_depth   ',ZM_depth                        ,pcols   ,lchnk   )
-   call outfld('MCSP_shear ',MCSP_shear                      ,pcols   ,lchnk   )
+      MCSP_DT(:ncol,:pver) = MCSP_DT(:ncol,:pver)/cpair
+      call outfld('MCSP_DT    ',MCSP_DT           ,pcols   ,lchnk   )
+      call outfld('MCSP_freq    ',MCSP_freq           ,pcols   ,lchnk   )
+      call outfld('MCSP_DU    ',ptend_loc%u*86400._r8           ,pcols   ,lchnk   )
+      call outfld('MCSP_DV    ',ptend_loc%v*86400._r8           ,pcols   ,lchnk   )
+      call outfld('ZM_depth   ',ZM_depth                        ,pcols   ,lchnk   )
+      call outfld('MCSP_shear ',MCSP_shear                      ,pcols   ,lchnk   )
 
    end if
 !


### PR DESCRIPTION
This PR makes fixes to the ZM microphysics to make sure results are BFB when ZM enhancements are turned off. It also includes some code cleanup to make sure all variables are explicitly declared. 