### PR TITLE
fixed the shape of dummy array pdeldry in lin_strat_chem.F90

### DIFF
--- a/components/eam/src/chemistry/mozart/lin_strat_chem.F90
+++ b/components/eam/src/chemistry/mozart/lin_strat_chem.F90
@@ -277,7 +277,7 @@ end subroutine linoz_readnl
     real(r8), intent(in)                           :: delta_t             ! timestep size (secs)
     real(r8), intent(in)                           :: rlats(ncol)         ! column latitudes (radians)
     integer,  intent(in)   , dimension(pcols)      :: ltrop               ! chunk index    
-    real(r8), intent(in)   , dimension(ncol ,pver) :: pdeldry             !  dry pressure delta about midpoints (Pa) 
+    real(r8), intent(in)   , dimension(pcols,pver) :: pdeldry             !  dry pressure delta about midpoints (Pa) 
     logical, optional, intent(in)                  :: tropFlag(pcols,pver)! 3D tropospheric level flag
     !
     integer  :: i,k,n,ll,lt0,lt, n_dl !,index_lat,index_month


### PR DESCRIPTION
The caller passes in the array in the shape of (pcols,pver) while the shape of the dummy array in the subroutine is (ncol,pver) and used as such inside subroutine linv3_strat_chem_solve.

When pcols > ncol, undefined values would be used in the calculations for do3_linoz_du and do3_linoz_psc_du.

While this will fix rin with debug mode, it has no impact on simulation results as the array involved, pdeldry, is only used for computing several diagnostic variables do3_linoz_du and do3_linoz_psc_du, which are not output by default.

[BFB]