### PR TITLE
Fix tracer types for correct answer and faster throughput

### DIFF
--- a/components/eam/chem_proc/inputs/pp_chemUCI_linozv3_mam5_resus_mom_cnst_no3_oh_mosaic_vbs_tag.in
+++ b/components/eam/chem_proc/inputs/pp_chemUCI_linozv3_mam5_resus_mom_cnst_no3_oh_mosaic_vbs_tag.in
@@ -120,23 +120,13 @@ End SPECIES
 Solution Classes
 
  Explicit
-   E90, N2OLNZ, NOYLNZ, CH4LNZ, H2OLNZ
- End Explicit
-
- Implicit
    CO, C2H6, C3H8, CH3COCH3
-   O3, OH, HO2, H2O2, CH2O, CH3O2, CH3OOH
-   NO, NO2, NO3, N2O5, HNO3, HO2NO2, PAN
-   C2H5O2, C2H5OOH, CH3CHO, CH3CO3, C2H4, ROHO2
-   ISOP, ISOPO2, C10H16, MVKMACR, MVKO2, NH3, HCL
-   DMS, SO2, H2SO4 
-   SOAG0, SOAG15, SOAG24, SOAG31 
-   SOAG32, SOAG33, SOAG34, SOAG35
+   E90, N2OLNZ, NOYLNZ, CH4LNZ, H2OLNZ
+   DMS, SO2, H2SO4
    so4_a1,  so4_a2,  so4_a3,  so4_a5
    nh4_a1,  nh4_a2,  nh4_a3
    no3_a1,  no3_a2,  no3_a3
    pom_a1,           pom_a3,  pom_a4
-   soa_a1,  soa_a2,  soa_a3
    bc_a1,            bc_a3,   bc_a4
    dst_a1,           dst_a3
    ca_a1,            ca_a3
@@ -145,6 +135,16 @@ Solution Classes
    cl_a1,   cl_a2,   cl_a3
    mom_a1,  mom_a2,  mom_a3,  mom_a4
    num_a1,  num_a2,  num_a3,  num_a4, num_a5
+ End Explicit
+
+ Implicit
+   O3, OH, HO2, H2O2, CH2O, CH3O2, CH3OOH
+   NO, NO2, NO3, N2O5, HNO3, HO2NO2, PAN
+   C2H5O2, C2H5OOH, CH3CHO, CH3CO3, C2H4, ROHO2
+   ISOP, ISOPO2, C10H16, MVKMACR, MVKO2, NH3, HCL
+   soa_a1,  soa_a2,  soa_a3
+   SOAG0, SOAG15, SOAG24, SOAG31
+   SOAG32, SOAG33, SOAG34, SOAG35
  End Implicit
 
 End Solution Classes


### PR DESCRIPTION
Some explicit tracers were wrongly defined as "implicit" type in the mechanism file. This causes 1) wrong ansowers for those should be solved with the explicit solver; 2) slow throughput by adding unnecessary tracers in the implicit array. This commit fixes these issues by defining the following tracers as the explicity type.

We will need to propagate similar changes to other NGD mechanism files later. 

* DMS, SO2, H2SO4
   Fix MAM5 stratospheric sulfate solutions

* CO, C2H6, C3H8, CH3COCH3 
   These tracers have slow reaction rates, so solve them explicitly

* MAM tracers (i.e., *_a[1-5], expect SOA ones)
   Have no reactions. They are in the mechanism file only for the purpose of creating them.

* SOA tracers to be discussed

[Non-BFB]