### PR TITLE
Improve wet removal and add low Nc limit 

### DIFF
--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -3923,6 +3923,7 @@ if ($cfg->get('microphys') =~ /^p3/) {
     add_default($nl, 'p3_accret_coeff');
     add_default($nl, 'p3_qc_accret_expon');
     add_default($nl, 'p3_wbf_coeff');
+    add_default($nl, 'p3_mincdnc');
     add_default($nl, 'p3_max_mean_rain_size');
     add_default($nl, 'p3_embryonic_rain_size');
     add_default($nl, 'do_prescribed_CCN');

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -850,6 +850,7 @@
 <micro_nccons         microphys="mg2">  100.D6      </micro_nccons>
 <micro_nicons         microphys="mg2">  0.1D6       </micro_nicons>
 <micro_mincdnc        microphys="mg2">  -999.       </micro_mincdnc>
+<p3_mincdnc        microphys="p3">  -999.       </p3_mincdnc>
 
 <!-- P3 specific namelist variables (using v2 defaults rather than KK defaults) -->
 <micro_p3_lookup_dir	    > atm/cam/physprops </micro_p3_lookup_dir>
@@ -870,7 +871,7 @@
 
 <!-- special defaults for MMF, which now sets all other physics scheme options to "off" -->
 <micro_mincdnc        use_MMF="1">  -999.       </micro_mincdnc>
-
+<p3_mincdnc        use_MMF="1">  -999.       </p3_mincdnc>
 <rrtmg_temp_fix                      > .false.      </rrtmg_temp_fix>
 
 <micro_mg_precip_frac_method                  >  max_overlap </micro_mg_precip_frac_method>
@@ -1727,6 +1728,7 @@ with se_tstep, dt_remap_factor, dt_tracer_factor set to -1
 <dust_emis_fact phys="default"> 1.50D0     </dust_emis_fact>
 <linoz_psc_T phys="default"> 197.5      </linoz_psc_T>
 <micro_mincdnc phys="default" microphys="mg2"> 10.D6      </micro_mincdnc>
+<p3_mincdnc phys="default" microphys="p3"> 10.D6      </p3_mincdnc>
 <clubb_C1 phys="default"> 2.4        </clubb_C1>
 <clubb_C11 phys="default"> 0.70       </clubb_C11>
 <clubb_C11b phys="default"> 0.20       </clubb_C11b>

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -2242,6 +2242,13 @@ Minimum droplet number conc (#/m3) imposed when micro_mincdnc > 0.
 Default: -999.
 </entry>
 
+<entry id="p3_mincdnc" type="real" category="microphys"
+       group="micro_nl" valid_values="" >
+Minimum droplet number conc (#/m3) imposed when p3_mincdnc > 0.
+Default: -999.
+</entry>
+
+
 <entry id="micro_mg_version" type="integer" category="microphys"
        group="micro_mg_nl" valid_values="" >
 Version number for MG microphysics

--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -1807,7 +1807,7 @@ contains
                                                                ! that gets passed to modal_aero_wateruptake_dr
 
    real(r8),intent(in),optional :: wuc(pcols,pver)
-   real(r8) :: dcondt_resusp3d(2*pcnst,pcols, pver)
+   real(r8) :: dcon_resusp3d(2*pcnst,pcols, pver)
 
     ! local vars
 
@@ -1913,7 +1913,7 @@ contains
 
     lchnk = state%lchnk
     ncol  = state%ncol
-    dcondt_resusp3d(:,:,:) = 0._r8
+    dcon_resusp3d(:,:,:) = 0._r8
 
 
     call physics_ptend_init(ptend, state%psetcols, 'aero_model_wetdep_ma', lq=wetdep_lq)
@@ -2058,7 +2058,7 @@ contains
             mu, md, du, eu, ed, dp, dsubcld, jt, maxg, ideep, lengath,  &
             species_class, mam_prevap_resusp_optaa,                     &
             history_aero_prevap_resusp, &
-            dcondt_resusp3d=dcondt_resusp3d,wuc=wuc)
+            dcon_resusp3d=dcon_resusp3d,wuc=wuc)
 
     do m = 1, ntot_amode ! main loop over aerosol modes
      do lphase = strt_loop,end_loop, stride_loop
@@ -2079,10 +2079,10 @@ contains
        endif
        if (lphase .eq. 2) then
         fldcw => qqcw_get_field(pbuf, mm,lchnk)
-        fldcw(:,:) = fldcw(:,:) + dcondt_resusp3d(mm+pcnst,:,:) !*dt
-!The dcondt_resusp3d is detrained aerosol AMOUNT (i.e., both mass
+        fldcw(:,:) = fldcw(:,:) + dcon_resusp3d(mm+pcnst,:,:) !*dt
+!The dcon_resusp3d is detrained aerosol AMOUNT (i.e., both mass
 !and number for four modals).
-!For dcondt_resusp3d(idx,:,:), idx=16,...,40 -> interstial aerosols
+!For dcon_resusp3d(idx,:,:), idx=16,...,40 -> interstial aerosols
 !                              idx=56,...,80 -> cloud-borne aerosols
 ! Currently, we assume that no aerosol resuspension occurrs during convective
 ! cloud water detrainment. So, 100% of cloud-borne aerosols will be added to

--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -107,6 +107,7 @@ module aero_model
   real(r8)          :: sol_factb_interstitial  = 0.1_r8
   real(r8)          :: sol_factic_interstitial = 0.4_r8
   real(r8)          :: seasalt_emis_scale
+  real(r8)          :: small = 1.e-36
 
   integer :: ndrydep = 0
   integer,allocatable :: drydep_indices(:)
@@ -1760,7 +1761,7 @@ contains
        cam_out,                                                                 & !Intent-inout
        pbuf,                                                                    & !Pointer
        ptend,                                                                   & !Intent-out
-       clear_rh                                                                 ) !optional 
+       clear_rh, wuc                                                            ) !optional 
 
     use modal_aero_deposition, only: set_srf_wetdep
     use wetdep,                only: wetdepa_v2, wetdep_inputs_set, &
@@ -1805,6 +1806,8 @@ contains
     real(r8), optional,  intent(in)    :: clear_rh(pcols,pver) ! optional clear air relative humidity 
                                                                ! that gets passed to modal_aero_wateruptake_dr
 
+   real(r8),intent(in),optional :: wuc(pcols,pver)
+   real(r8) :: dcondt_resusp3d(2*pcnst,pcols, pver)
 
     ! local vars
 
@@ -1910,6 +1913,8 @@ contains
 
     lchnk = state%lchnk
     ncol  = state%ncol
+    dcondt_resusp3d(:,:,:) = 0._r8
+
 
     call physics_ptend_init(ptend, state%psetcols, 'aero_model_wetdep_ma', lq=wetdep_lq)
 
@@ -2035,6 +2040,61 @@ contains
        rtscavt_sv(:,:,:) = 0.0_r8
        rcscavt_cn_sv(:,:) = 0.0_r8
        rsscavt_cn_sv(:,:) = 0.0_r8
+    endif
+
+    if (convproc_do_aer) then
+
+       call pbuf_get_field(pbuf, icwmrdp_idx,     icwmrdp )
+       call pbuf_get_field(pbuf, icwmrsh_idx,     icwmrsh )
+       call pbuf_get_field(pbuf, sh_frac_idx,     sh_frac )
+       call pbuf_get_field(pbuf, dp_frac_idx,     dp_frac )
+
+       call t_startf('ma_convproc')
+       call ma_convproc_intr( state, ptend, pbuf, dt,                   &
+            dp_frac, icwmrdp, rprddp, evapcdp,                          &
+            sh_frac, icwmrsh, rprdsh, evapcsh,                          &
+            dlf, dlf2, cmfmc2, sh_e_ed_ratio,                           &
+            nsrflx_mzaer2cnvpr, qsrflx_mzaer2cnvpr, aerdepwetis,        &
+            mu, md, du, eu, ed, dp, dsubcld, jt, maxg, ideep, lengath,  &
+            species_class, mam_prevap_resusp_optaa,                     &
+            history_aero_prevap_resusp, &
+            dcondt_resusp3d=dcondt_resusp3d,wuc=wuc)
+
+    do m = 1, ntot_amode ! main loop over aerosol modes
+     do lphase = strt_loop,end_loop, stride_loop
+      ! loop over interstitial (1) and cloud-borne (2) forms
+      do lspec = 0, nspec_amode(m) !+1 ! loop over number + chem constituents + water
+       if (lspec == 0) then ! number
+        if (lphase == 1) then
+         mm = numptr_amode(m)
+        else
+         mm = numptrcw_amode(m)
+        endif
+       else if (lspec <= nspec_amode(m)) then ! non-water mass
+        if (lphase == 1) then
+         mm = lmassptr_amode(lspec,m)
+        else
+         mm = lmassptrcw_amode(lspec,m)
+        endif
+       endif
+       if (lphase .eq. 2) then
+        fldcw => qqcw_get_field(pbuf, mm,lchnk)
+        fldcw(:,:) = fldcw(:,:) + dcondt_resusp3d(mm+pcnst,:,:) !*dt
+!The dcondt_resusp3d is detrained aerosol AMOUNT (i.e., both mass
+!and number for four modals).
+!For dcondt_resusp3d(idx,:,:), idx=16,...,40 -> interstial aerosols
+!                              idx=56,...,80 -> cloud-borne aerosols
+! Currently, we assume that no aerosol resuspension occurrs during convective
+! cloud water detrainment. So, 100% of cloud-borne aerosols will be added to
+! stratiform cloud-borne aerosols and detrained interstial aerosol amount is
+! zero.
+       end if
+      end do ! loop over number + chem constituents + water <shanyp the loop is
+             ! changed: no aerosol water is considered.
+     end do  ! lphase
+    end do   ! m aerosol modes
+
+    call t_stopf('ma_convproc')
     endif
 
 mmode_loop_aa: &
@@ -2282,6 +2342,9 @@ lphase_jnmw_conditional: &
                 dqdt_tmp(:,:) = 0.0_r8
                 ! q_tmp reflects changes from modal_aero_calcsize and is the "most current" q
                 q_tmp(1:ncol,:) = state%q(1:ncol,:,mm) + ptend%q(1:ncol,:,mm)*dt
+                where(q_tmp(1:ncol,:).lt.small)
+                 q_tmp(1:ncol,:)=small
+                end where
                 if (convproc_do_aer) then
                    !Feed in the saved cloudborne mixing ratios from phase 2
                    qqcw_in(:,:) = qqcw_sav(:,:,lspec)
@@ -2352,9 +2415,9 @@ lphase_jnmw_conditional: &
                       sflx(i)=sflx(i)+dqdt_tmp(i,k)*state%pdel(i,k)/gravit
                    enddo
                 enddo
-                if ( .not. convproc_do_aer ) call outfld( trim(cnst_name(mm))//'SFWET', sflx, pcols, lchnk)
-                aerdepwetis(:ncol,mm) = sflx(:ncol)
-
+!                if ( .not. convproc_do_aer ) call outfld( trim(cnst_name(mm))//'SFWET', sflx, pcols, lchnk)
+                aerdepwetis(:,mm) = aerdepwetis(:,mm)+sflx(:)
+                if ( convproc_do_aer ) call outfld(trim(cnst_name(mm))//'SFWET', aerdepwetis(:,mm), pcols, lchnk)
                 sflx(:)=0._r8
                 do k=1,pver
                    do i=1,ncol
@@ -2661,26 +2724,26 @@ do_lphase2_conditional: &
     if (.not.aerodep_flx_prescribed()) then
        call set_srf_wetdep(aerdepwetis, aerdepwetcw, cam_out)
     endif
-
-    if (convproc_do_aer) then 
-       
-       call pbuf_get_field(pbuf, icwmrdp_idx,     icwmrdp )
-       call pbuf_get_field(pbuf, icwmrsh_idx,     icwmrsh )
-       call pbuf_get_field(pbuf, sh_frac_idx,     sh_frac )
-       call pbuf_get_field(pbuf, dp_frac_idx,     dp_frac )
-
-       call t_startf('ma_convproc')
-       call ma_convproc_intr( state, ptend, pbuf, dt,                   &
-            dp_frac, icwmrdp, rprddp, evapcdp,                          &
-            sh_frac, icwmrsh, rprdsh, evapcsh,                          &
-            dlf, dlf2, cmfmc2, sh_e_ed_ratio,                           &
-            nsrflx_mzaer2cnvpr, qsrflx_mzaer2cnvpr, aerdepwetis,        &
-            mu, md, du, eu, ed, dp, dsubcld, jt, maxg, ideep, lengath,  &
-            species_class, mam_prevap_resusp_optaa,                     &
-            history_aero_prevap_resusp                                  )
-       call t_stopf('ma_convproc')       
-    endif
-
+!<shanyp reorder the wet removal schemes, call deep convection wet removal first
+!then the stratiform wet removal.
+!    if (convproc_do_aer) then 
+!       
+!       call pbuf_get_field(pbuf, icwmrdp_idx,     icwmrdp )
+!       call pbuf_get_field(pbuf, icwmrsh_idx,     icwmrsh )
+!       call pbuf_get_field(pbuf, sh_frac_idx,     sh_frac )
+!       call pbuf_get_field(pbuf, dp_frac_idx,     dp_frac )
+!
+!       call t_startf('ma_convproc')
+!       call ma_convproc_intr( state, ptend, pbuf, dt,                   &
+!            dp_frac, icwmrdp, rprddp, evapcdp,                          &
+!            sh_frac, icwmrsh, rprdsh, evapcsh,                          &
+!            dlf, dlf2, cmfmc2, sh_e_ed_ratio,                           &
+!            nsrflx_mzaer2cnvpr, qsrflx_mzaer2cnvpr, aerdepwetis,        &
+!            mu, md, du, eu, ed, dp, dsubcld, jt, maxg, ideep, lengath,  &
+!            species_class, mam_prevap_resusp_optaa,                     &
+!            history_aero_prevap_resusp                                  )
+!       call t_stopf('ma_convproc')       
+!    endif
     call wetdep_inputs_unset(dep_inputs)
 
   end subroutine aero_model_wetdep

--- a/components/eam/src/chemistry/modal_aero/modal_aero_convproc.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_convproc.F90
@@ -22,7 +22,7 @@ module modal_aero_convproc
    use cam_logfile,  only: iulog
    use cam_abortutils, only: endrun
    use physconst,    only: spec_class_aerosol, spec_class_gas
-
+   use constituents,  only: pcnst
    implicit none
 
    save
@@ -194,7 +194,8 @@ subroutine ma_convproc_intr( state, ptend, pbuf, ztodt,             &
                            ed, dp, dsubcld,                         &
                            jt, maxg, ideep, lengath, species_class, &
                            mam_prevap_resusp_optaa,                 &
-                           history_aero_prevap_resusp               )
+                           history_aero_prevap_resusp, &
+                           dcondt_resusp3d,wuc  )
 !----------------------------------------------------------------------- 
 ! 
 ! Purpose: 
@@ -215,7 +216,8 @@ subroutine ma_convproc_intr( state, ptend, pbuf, ztodt,             &
    use physics_types, only: physics_state, physics_ptend, physics_ptend_init
    use time_manager,  only: get_nstep
    use physics_buffer, only: physics_buffer_desc, pbuf_get_index
-   use constituents,  only: pcnst, cnst_name
+!   use constituents,  only: pcnst
+   use constituents,  only: cnst_name
    use error_messages, only: alloc_err	
 
    use modal_aero_data, only: lmassptr_amode, nspec_amode, ntot_amode, numptr_amode
@@ -260,6 +262,8 @@ subroutine ma_convproc_intr( state, ptend, pbuf, ztodt,             &
    integer,  intent(in)    :: species_class(:)
    integer,  intent(in)    :: mam_prevap_resusp_optaa
    logical,  intent(in)    :: history_aero_prevap_resusp
+   real(r8), intent(in),optional :: wuc(pcols,pver)
+   real(r8), intent(inout),optional :: dcondt_resusp3d(2*pcnst,pcols,pver)
 
 
 ! Local variables
@@ -290,6 +294,7 @@ subroutine ma_convproc_intr( state, ptend, pbuf, ztodt,             &
 !
 ! Initialize
 !
+   dcondt_resusp3d(:,:,:) = 0._r8
 
 ! apply this minor fix when doing resuspend to coarse mode
    if (mam_prevap_resusp_optaa >= 30) convproc_prevap_resusp_fixaa = .true.
@@ -363,8 +368,8 @@ subroutine ma_convproc_intr( state, ptend, pbuf, ztodt,             &
      ed, dp, dsubcld,                          &
      jt, maxg, ideep, lengath,                 &
      qb, dqdt, dotend, nsrflx, qsrflx,         &
-     species_class, mam_prevap_resusp_optaa    )
-
+     species_class, mam_prevap_resusp_optaa,   &
+     dcondt_resusp3d=dcondt_resusp3d,wuc=wuc   )
 
 ! apply deep conv processing tendency and prepare for shallow conv processing
   do l = 1, pcnst
@@ -472,8 +477,7 @@ subroutine ma_convproc_intr( state, ptend, pbuf, ztodt,             &
         else
            l = lmassptr_amode(ll,n)
         end if
-
-        call outfld( trim(cnst_name(l))//'SFWET', aerdepwetis(:,l), pcols, lchnk )
+!        call outfld( trim(cnst_name(l))//'SFWET', aerdepwetis(:,l), pcols, lchnk )
         call outfld( trim(cnst_name(l))//'SFSIC', sflxic(:,l), pcols, lchnk )
         if ( history_aero_prevap_resusp ) &
         call outfld( trim(cnst_name(l))//'SFSEC', sflxec(:,l), pcols, lchnk )
@@ -500,7 +504,8 @@ subroutine ma_convproc_dp_intr(                &
      ed, dp, dsubcld,                          &
      jt, maxg, ideep, lengath,                 &
      q, dqdt, dotend, nsrflx, qsrflx,          &
-     species_class, mam_prevap_resusp_optaa    )
+     species_class, mam_prevap_resusp_optaa,   &
+     dcondt_resusp3d,wuc )
 !----------------------------------------------------------------------- 
 ! 
 ! Purpose: 
@@ -563,7 +568,8 @@ subroutine ma_convproc_dp_intr(                &
    integer,  intent(in)    :: lengath           ! Gathered min lon indices over which to operate
    integer,  intent(in)    :: species_class(:)
    integer,  intent(in)    :: mam_prevap_resusp_optaa
-
+   real(r8), intent(in),optional :: wuc(pcols,pver)
+   real(r8), intent(inout),optional :: dcondt_resusp3d(pcnst*2,pcols,pver)
 !  real(r8), intent(in)    :: concld(pcols,pver) ! Convective cloud cover
 
 ! Local variables
@@ -841,7 +847,8 @@ subroutine ma_convproc_dp_intr(                &
                      dqdt,       dotend,     nsrflx,     qsrflx,     &
                      species_class, mam_prevap_resusp_optaa,         & ! REASTER 08/05/2015
                      xx_mfup_max, xx_wcldbase, xx_kcldbase,          &
-                     lun,        itmpveca                            )
+                     lun,        itmpveca,                           &
+                     dcondt_resusp3d=dcondt_resusp3d,wuc=wuc )
 !                    ed,         dp,         dsubcld,    jt,         &   
 
 
@@ -1470,8 +1477,8 @@ subroutine ma_convproc_tend(                                           &
                      dqdt,       doconvproc, nsrflx,     qsrflx,     &
                      species_class, mam_prevap_resusp_optaa,         & ! REASTER 08/05/2015
                      xx_mfup_max, xx_wcldbase, xx_kcldbase,          &
-                     lun,        idiag_in                            )
-
+                     lun,        idiag_in,                           &
+                     dcondt_resusp3d,wuc)
 !----------------------------------------------------------------------- 
 ! 
 ! Purpose: 
@@ -1581,6 +1588,8 @@ subroutine ma_convproc_tend(                                           &
    real(r8), intent(out):: xx_kcldbase(pcols)
    integer,  intent(in) :: lun               ! unit number for diagnostic output
    integer,  intent(in) :: idiag_in(pcols)   ! flag for diagnostic output
+   real(r8), intent(in), optional :: wuc(pcols,pver)
+   real(r8), intent(inout),optional :: dcondt_resusp3d(pcnst*2,pcols,pver)
 
 
 !--------------------------Local Variables------------------------------
@@ -2055,6 +2064,9 @@ k_loop_main_bb: &
                end if
                wup(k) = max( 0.1_r8, min( 4.0_r8, wup(k) ) )
             end if
+! update the vertical velocity from convective cloud microphysics scheme
+            wup(k) = wuc(icol,k)
+            wup(k) = max( 0.1_r8, min( 15.0_r8, wup(k) ) )
 
 ! compute lagrangian transport time (dt_u) and updraft fractional area (fa_u)
 ! *** these must obey    dt_u(k)*mu_p_eudp(k) = dp_i(k)*fa_u(k)
@@ -2222,7 +2234,9 @@ k_loop_main_bb: &
             cdt(k) = 0.0_r8
             if ((icwmr(icol,k) > clw_cut) .and. (rprd(icol,k) > 0.0)) then 
 !              if (iconvtype == 1) then
-                  tmpf = 0.5_r8*cldfrac_i(k)
+!              fa_u(k) = dt_u(k)*(mu_p_eudp(k)/dp_i(k)) =>
+!              dt_u(k) = tmpf*dp(i,k)/mu_p_eudp(k)
+                  tmpf = fa_u(k) !0.5_r8*cldfrac_i(k)
                   cdt(k) = (tmpf*dp(i,k)/mu_p_eudp(k)) * rprd(icol,k) / &
                         (tmpf*icwmr(icol,k) + dt*rprd(icol,k))
 !              else if (k < pver) then
@@ -2242,6 +2256,10 @@ k_loop_main_bb: &
             end if
 
          end if    ! "(mu_p_eudp(k) > mbsth)"
+!               write(lun,'(a,i9,3i4,1p,6e10.3)') &
+!                  'qakr - l,i,k,jt; cdt, cldfrac, icwmr, rprd, ...', lchnk,icol, k, jtsub, &
+!                   cdt(k), fa_u(k), icwmr(icol,k), rprd(icol,k), wup(k), mu_p_eudp(k)
+!                  cdt(k), cldfrac_i(k), icwmr(icol,k), rprd(icol,k), wup(k),mu_p_eudp(k)
       end do k_loop_main_bb ! "k = kbot, ktop, -1"
 
 ! when doing updraft calcs twice, only need to go this far on the first pass
@@ -2434,6 +2452,10 @@ k_loop_main_cc: &
 !    pairs to account any (or total) resuspension of convective-cloudborne aerosol
       call ma_resuspend_convproc( dcondt, dcondt_resusp,   &
                                   const, dp_i, ktop, kbot_prevap, pcnst_extd ) ! REASTER 08/05/2015
+     dcondt_resusp3d(pcnst+1:pcnst_extd,icol,:) = dcondt_resusp3d(pcnst+1:pcnst_extd,icol,:) &
+                                                + dcondt(pcnst+1:pcnst_extd,:)*dtsub
+!     dcondt_resusp(pcnst+1:pcnst_extd,:) = 0._r8
+
       if ( idiag_in(icol)>0 ) then
          k = 26
          do m = 16, 23, 7
@@ -3712,7 +3734,8 @@ end subroutine ma_convproc_tend
       call activate_modal(                                                 &
          wbar, sigw, wdiab, wminf, wmaxf, tair, rhoair,                    &
          naerosol, ntot_amode, vaerosol, hygro,                            &
-         fn, fm, fluxn, fluxm, flux_fullact, smax_prescribed               )
+!         fn, fm, fluxn, fluxm, flux_fullact, smax_prescribed               )
+         fn, fm, fluxn, fluxm, flux_fullact)
    end if
 
 
@@ -3866,11 +3889,20 @@ end subroutine ma_convproc_tend
 !           end if
 
 ! cam5 approach
-            dcondt(la,k) = qdotac
-            dcondt(lc,k) = 0.0
-
-            dcondt_resusp(la,k) = (dcondt(la,k) - qdota)
-            dcondt_resusp(lc,k) = (dcondt(lc,k) - qdotc)
+!            dcondt(la,k) = qdotac
+!            dcondt(lc,k) = 0.0
+!
+!            dcondt_resusp(la,k) = (dcondt(la,k) - qdota)
+!            dcondt_resusp(lc,k) = (dcondt(lc,k) - qdotc)
+            if(qdotc.gt.0._r8) then
+             dcondt(la,k) = qdota
+             dcondt(lc,k) = qdotc
+            else
+             dcondt(la,k) = qdota+qdotc
+             dcondt(lc,k) = 0._r8
+            end if
+            dcondt_resusp(la,k) = 0._r8 !dcondt(la,k)
+            dcondt_resusp(lc,k) = 0._r8 !dcondt(lc,k)
          end do
 
       end do   ! "ll = -1, nspec_amode(n)"

--- a/components/eam/src/chemistry/modal_aero/modal_aero_convproc.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_convproc.F90
@@ -195,7 +195,7 @@ subroutine ma_convproc_intr( state, ptend, pbuf, ztodt,             &
                            jt, maxg, ideep, lengath, species_class, &
                            mam_prevap_resusp_optaa,                 &
                            history_aero_prevap_resusp, &
-                           dcondt_resusp3d,wuc  )
+                           dcon_resusp3d,wuc  )
 !----------------------------------------------------------------------- 
 ! 
 ! Purpose: 
@@ -263,7 +263,7 @@ subroutine ma_convproc_intr( state, ptend, pbuf, ztodt,             &
    integer,  intent(in)    :: mam_prevap_resusp_optaa
    logical,  intent(in)    :: history_aero_prevap_resusp
    real(r8), intent(in),optional :: wuc(pcols,pver)
-   real(r8), intent(inout),optional :: dcondt_resusp3d(2*pcnst,pcols,pver)
+   real(r8), intent(inout),optional :: dcon_resusp3d(2*pcnst,pcols,pver)
 
 
 ! Local variables
@@ -294,7 +294,7 @@ subroutine ma_convproc_intr( state, ptend, pbuf, ztodt,             &
 !
 ! Initialize
 !
-   dcondt_resusp3d(:,:,:) = 0._r8
+   dcon_resusp3d(:,:,:) = 0._r8
 
 ! apply this minor fix when doing resuspend to coarse mode
    if (mam_prevap_resusp_optaa >= 30) convproc_prevap_resusp_fixaa = .true.
@@ -369,7 +369,7 @@ subroutine ma_convproc_intr( state, ptend, pbuf, ztodt,             &
      jt, maxg, ideep, lengath,                 &
      qb, dqdt, dotend, nsrflx, qsrflx,         &
      species_class, mam_prevap_resusp_optaa,   &
-     dcondt_resusp3d=dcondt_resusp3d,wuc=wuc   )
+     dcon_resusp3d=dcon_resusp3d,wuc=wuc   )
 
 ! apply deep conv processing tendency and prepare for shallow conv processing
   do l = 1, pcnst
@@ -505,7 +505,7 @@ subroutine ma_convproc_dp_intr(                &
      jt, maxg, ideep, lengath,                 &
      q, dqdt, dotend, nsrflx, qsrflx,          &
      species_class, mam_prevap_resusp_optaa,   &
-     dcondt_resusp3d,wuc )
+     dcon_resusp3d,wuc )
 !----------------------------------------------------------------------- 
 ! 
 ! Purpose: 
@@ -569,7 +569,7 @@ subroutine ma_convproc_dp_intr(                &
    integer,  intent(in)    :: species_class(:)
    integer,  intent(in)    :: mam_prevap_resusp_optaa
    real(r8), intent(in),optional :: wuc(pcols,pver)
-   real(r8), intent(inout),optional :: dcondt_resusp3d(pcnst*2,pcols,pver)
+   real(r8), intent(inout),optional :: dcon_resusp3d(pcnst*2,pcols,pver)
 !  real(r8), intent(in)    :: concld(pcols,pver) ! Convective cloud cover
 
 ! Local variables
@@ -848,7 +848,7 @@ subroutine ma_convproc_dp_intr(                &
                      species_class, mam_prevap_resusp_optaa,         & ! REASTER 08/05/2015
                      xx_mfup_max, xx_wcldbase, xx_kcldbase,          &
                      lun,        itmpveca,                           &
-                     dcondt_resusp3d=dcondt_resusp3d,wuc=wuc )
+                     dcon_resusp3d=dcon_resusp3d,wuc=wuc )
 !                    ed,         dp,         dsubcld,    jt,         &   
 
 
@@ -1478,7 +1478,7 @@ subroutine ma_convproc_tend(                                           &
                      species_class, mam_prevap_resusp_optaa,         & ! REASTER 08/05/2015
                      xx_mfup_max, xx_wcldbase, xx_kcldbase,          &
                      lun,        idiag_in,                           &
-                     dcondt_resusp3d,wuc)
+                     dcon_resusp3d,wuc)
 !----------------------------------------------------------------------- 
 ! 
 ! Purpose: 
@@ -1589,7 +1589,7 @@ subroutine ma_convproc_tend(                                           &
    integer,  intent(in) :: lun               ! unit number for diagnostic output
    integer,  intent(in) :: idiag_in(pcols)   ! flag for diagnostic output
    real(r8), intent(in), optional :: wuc(pcols,pver)
-   real(r8), intent(inout),optional :: dcondt_resusp3d(pcnst*2,pcols,pver)
+   real(r8), intent(inout),optional :: dcon_resusp3d(pcnst*2,pcols,pver)
 
 
 !--------------------------Local Variables------------------------------
@@ -2452,7 +2452,7 @@ k_loop_main_cc: &
 !    pairs to account any (or total) resuspension of convective-cloudborne aerosol
       call ma_resuspend_convproc( dcondt, dcondt_resusp,   &
                                   const, dp_i, ktop, kbot_prevap, pcnst_extd ) ! REASTER 08/05/2015
-     dcondt_resusp3d(pcnst+1:pcnst_extd,icol,:) = dcondt_resusp3d(pcnst+1:pcnst_extd,icol,:) &
+     dcon_resusp3d(pcnst+1:pcnst_extd,icol,:) = dcon_resusp3d(pcnst+1:pcnst_extd,icol,:) &
                                                 + dcondt(pcnst+1:pcnst_extd,:)*dtsub
 !     dcondt_resusp(pcnst+1:pcnst_extd,:) = 0._r8
 

--- a/components/eam/src/physics/cam/convect_deep.F90
+++ b/components/eam/src/physics/cam/convect_deep.F90
@@ -169,8 +169,7 @@ subroutine convect_deep_tend( &
      rliq    ,rice     , &
      ztodt   , &
      state   ,ptend   ,landfrac ,pbuf, mu, eu, &
-     du, md, ed, dp, dsubcld, jt, maxg, ideep,lengath ) 
-
+     du, md, ed, dp, dsubcld, jt, maxg, ideep,lengath,wuc ) 
 
 
    use physics_types, only: physics_state, physics_ptend, physics_tend, physics_ptend_init
@@ -222,6 +221,7 @@ subroutine convect_deep_tend( &
    
    ! w holds position of gathered points vs longitude index   
    integer, intent(out) :: lengath
+   real(r8),intent(inout),optional :: wuc(pcols,pver)
 
    real(r8), pointer :: prec(:)   ! total precipitation
    real(r8), pointer :: snow(:)   ! snow from ZM convection 
@@ -308,7 +308,7 @@ subroutine convect_deep_tend( &
           ztodt   , &
           jctop, jcbot , &
           state   ,ptend   ,landfrac, pbuf, mu, eu, &
-          du, md, ed, dp, dsubcld, jt, maxg, ideep, lengath)
+          du, md, ed, dp, dsubcld, jt, maxg, ideep, lengath, wuc)
      call t_stopf('zm_conv_tend')
 
 

--- a/components/eam/src/physics/cam/micro_p3.F90
+++ b/components/eam/src/physics/cam/micro_p3.F90
@@ -1082,15 +1082,14 @@ end function bfb_expm1
       rho, inv_rho, rhofaci, qv, th_atm, qc, nc, qr, nr, qi, ni, qm, bm, latent_heat_vapor, latent_heat_sublim,            &
       mu_c, nu, lamc, mu_r, lamr, vap_liq_exchange,                                                                        &
       ze_rain, ze_ice, diag_vm_qi, diag_eff_radius_qi, diag_diam_qi, rho_qi, diag_equiv_reflectivity, diag_eff_radius_qc,  & 
-      diag_ze_rain,diag_ze_ice)
+      diag_ze_rain,diag_ze_ice,mincdnc)
 
    implicit none
 
    ! args
 
    integer, intent(in) :: kts, kte, kbot, ktop, kdir
-
-   real(rtype), intent(in) :: p3_max_mean_rain_size
+   real(rtype), intent(in) :: p3_max_mean_rain_size,mincdnc
 
    real(rtype), intent(in), dimension(kts:kte) :: exner, cld_frac_l, cld_frac_r, cld_frac_i
 
@@ -1129,6 +1128,8 @@ end function bfb_expm1
          nc_incld = nc(k)/cld_frac_l(k)
          call get_cloud_dsd2(qc_incld,nc_incld,mu_c(k),rho(k),nu(k),dnu,lamc(k),  &
               tmp1,tmp2)
+       if (mincdnc.gt.0._rtype) nc_incld = max(nc_incld,mincdnc/rho(k))
+
 
          diag_eff_radius_qc(k) = 0.5_rtype*(mu_c(k)+3._rtype)/lamc(k)
          nc(k) = nc_incld*cld_frac_l(k) !limiters in dsd2 may change nc_incld. Enforcing consistency here.
@@ -1252,7 +1253,7 @@ end function bfb_expm1
   SUBROUTINE p3_main(qc,nc,qr,nr,th_atm,qv,dt,qi,qm,ni,bm,                                                                                                               &
        pres,dz,nc_nuceat_tend,nccn_prescribed,ni_activated,frzimm,frzcnt,frzdep,inv_qc_relvar,it,precip_liq_surf,precip_ice_surf,its,ite,kts,kte,diag_eff_radius_qc,     &
        diag_eff_radius_qi,rho_qi,do_predict_nc, do_prescribed_CCN,p3_autocon_coeff,p3_accret_coeff,p3_qc_autocon_expon,p3_nc_autocon_expon,p3_qc_accret_expon,           &
-       p3_wbf_coeff,p3_max_mean_rain_size,p3_embryonic_rain_size,                                                                                                        &
+       p3_wbf_coeff,p3_mincdnc,p3_max_mean_rain_size,p3_embryonic_rain_size,                                                                                             &
        dpres,exner,qv2qi_depos_tend,precip_total_tend,nevapr,qr_evap_tend,precip_liq_flux,precip_ice_flux,rflx,sflx,cflx,cld_frac_r,cld_frac_l,cld_frac_i,               &
        p3_tend_out,mu_c,lamc,liq_ice_exchange,vap_liq_exchange,                                                                                                          &
        vap_ice_exchange,qv_prev,t_prev,col_location,diag_equiv_reflectivity,diag_ze_rain,diag_ze_ice                                                                     &
@@ -1340,6 +1341,7 @@ end function bfb_expm1
     real(rtype), intent(in)                                     :: p3_nc_autocon_expon      ! autconversion nc exponent
     real(rtype), intent(in)                                     :: p3_qc_accret_expon       ! accretion qc and qr exponent
     real(rtype), intent(in)                                     :: p3_wbf_coeff             ! WBF coefficient
+    real(rtype), intent(in)                                     :: p3_mincdnc               ! impose minimal Nc
     real(rtype), intent(in)                                     :: p3_max_mean_rain_size    ! max mean rain size allowed
     real(rtype), intent(in)                                     :: p3_embryonic_rain_size   ! embryonic rain size from autoconversion
 
@@ -1404,6 +1406,8 @@ end function bfb_expm1
     logical(btype), parameter :: debug_ABORT  = .false.  !.true. will result in forced abort in s/r 'check_values'
 
     real(rtype),dimension(its:ite,kts:kte) :: qc_old, nc_old, qr_old, nr_old, qi_old, ni_old, qv_old, th_atm_old
+    integer :: knc
+    real(rtype) :: mincdnc
 
 #ifdef SCREAM_CONFIG_IS_CMAKE
     integer :: clock_count1, clock_count_rate, clock_count_max, clock_count2, clock_count_diff
@@ -1484,6 +1488,7 @@ end function bfb_expm1
     ni_old = ni   ! Ice  # microphysics tendency, initialize
     qv_old = qv         ! Vapor  microphysics tendency, initialize
     th_atm_old = th_atm         ! Pot. Temp. microphysics tendency, initialize
+    mincdnc=p3_mincdnc
 
 #ifdef SCREAM_CONFIG_IS_CMAKE
     call system_clock(clock_count1, clock_count_rate, clock_count_max)
@@ -1618,6 +1623,12 @@ end function bfb_expm1
        ! Instantenous melting of ice/snow at T = t_snow_melt = 2c    
        call ice_complete_melting(kts,kte,ktop,kbot,kdir,qi(i,:),ni(i,:),qm(i,:),latent_heat_fusion(i,:),exner(i,:),th_atm(i,:), & 
             qr(i,:),nr(i,:),qc(i,:),nc(i,:))
+         do knc=kbot,ktop,kdir
+          if ((mincdnc.gt.0._rtype).and.(qc(i,knc).ge.qsmall)) then
+           nc(i,knc) = max(nc(i,knc),mincdnc*cld_frac_l(i,knc)/rho(i,knc))
+           nc_incld(i,knc) = max(nc_incld(i,knc),mincdnc/rho(i,knc))
+          end if
+         end do
 
        !...................................................
        ! final checks to ensure consistency of mass/number
@@ -1628,7 +1639,8 @@ end function bfb_expm1
             qm(i,:), bm(i,:), latent_heat_vapor(i,:), latent_heat_sublim(i,:),                                                &
             mu_c(i,:), nu(i,:), lamc(i,:), mu_r(i,:), lamr(i,:), vap_liq_exchange(i,:),                                       &
             ze_rain(i,:), ze_ice(i,:), diag_vm_qi(i,:), diag_eff_radius_qi(i,:), diag_diam_qi(i,:), rho_qi(i,:), diag_equiv_reflectivity(i,:), diag_eff_radius_qc(i,:), &
-            diag_ze_rain(i,:),diag_ze_ice(i,:))
+            diag_ze_rain(i,:),diag_ze_ice(i,:),mincdnc)
+
 
        !   if (debug_ON) call check_values(qv,Ti,it,debug_ABORT,800,col_location)
 
@@ -2875,7 +2887,10 @@ subroutine cloud_rain_accretion(rho,inv_rho,qc_incld,nc_incld,qr_incld,inv_qc_re
      elseif (iparam.eq.3) then
         !Khroutdinov and Kogan (2000)
         !print*,'p3_qc_accret_expon = ',p3_qc_accret_expon
-        sbgrd_var_coef = subgrid_variance_scaling(inv_qc_relvar, 1.15_rtype ) !p3_qc_accret_expon
+!        sbgrd_var_coef = subgrid_variance_scaling(inv_qc_relvar, 1.15_rtype )
+!        !p3_qc_accret_expon
+        sbgrd_var_coef = subgrid_variance_scaling(inv_qc_relvar, p3_qc_accret_expon ) !p3_qc_accret_expon
+
         !qc2qr_accret_tend = sbgrd_var_coef*67._rtype*bfb_pow(qc_incld*qr_incld, 1.15_rtype) !p3_qc_accret_expon
 ! +++ E3SMv2 tuning +++        
         !qc2qr_accret_tend = 1.75_rtype*sbgrd_var_coef*67._rtype*bfb_pow(qc_incld*qr_incld, 1.15_rtype) !p3_qc_accret_expon
@@ -2964,7 +2979,9 @@ subroutine cloud_water_autoconversion(rho,qc_incld,nc_incld,inv_qc_relvar,      
       !qc2qr_autoconv_tend = sbgrd_var_coef*1350._rtype*bfb_pow(qc_incld,2.47_rtype)*bfb_pow(nc_incld*1.e-6_rtype*rho,-1.79_rtype)
 
 ! +++ E3SMv2 tunning +++
-      sbgrd_var_coef = subgrid_variance_scaling(inv_qc_relvar, 3.19_rtype)
+!      sbgrd_var_coef = subgrid_variance_scaling(inv_qc_relvar, 3.19_rtype)
+      sbgrd_var_coef = subgrid_variance_scaling(inv_qc_relvar, p3_qc_autocon_expon)
+
       !qc2qr_autoconv_tend = sbgrd_var_coef*30500.0_rtype*bfb_pow(qc_incld,3.19_rtype)*bfb_pow(nc_incld*1.e-6_rtype*rho,-1.40_rtype)
       qc2qr_autoconv_tend = sbgrd_var_coef*p3_autocon_coeff*bfb_pow(qc_incld,p3_qc_autocon_expon)*bfb_pow(nc_incld*1.e-6_rtype*rho,p3_nc_autocon_expon)
       

--- a/components/eam/src/physics/cam/micro_p3_interface.F90
+++ b/components/eam/src/physics/cam/micro_p3_interface.F90
@@ -129,6 +129,7 @@ module micro_p3_interface
       p3_nc_autocon_expon      = huge(1.0_rtype), &
       p3_qc_accret_expon       = huge(1.0_rtype), &
       p3_wbf_coeff             = huge(1.0_rtype), &
+      p3_mincdnc               = huge(1.0_rtype), &
       p3_max_mean_rain_size    = huge(1.0_rtype), &
       p3_embryonic_rain_size   = huge(1.0_rtype)
    
@@ -164,8 +165,7 @@ subroutine micro_p3_readnl(nlfile)
        micro_p3_tableversion, micro_p3_lookup_dir, micro_aerosolactivation, micro_subgrid_cloud, &
        micro_tend_output, p3_autocon_coeff, p3_qc_autocon_expon, p3_nc_autocon_expon, p3_accret_coeff, &
        p3_qc_accret_expon, p3_wbf_coeff, p3_max_mean_rain_size, p3_embryonic_rain_size, &
-       do_prescribed_CCN, do_Cooper_inP3
-
+       do_prescribed_CCN, do_Cooper_inP3, p3_mincdnc
   !-----------------------------------------------------------------------------
 
   if (masterproc) then
@@ -193,6 +193,7 @@ subroutine micro_p3_readnl(nlfile)
      write(iulog,'(A30,1x,8e12.4)') 'p3_nc_autocon_expon',     p3_nc_autocon_expon
      write(iulog,'(A30,1x,8e12.4)') 'p3_qc_accret_expon',      p3_qc_accret_expon
      write(iulog,'(A30,1x,8e12.4)') 'p3_wbf_coeff',            p3_wbf_coeff
+     write(iulog,'(A30,1x,8e12.4)') 'p3_mincdnc',              p3_mincdnc
      write(iulog,'(A30,1x,8e12.4)') 'p3_max_mean_rain_size',   p3_max_mean_rain_size
      write(iulog,'(A30,1x,8e12.4)') 'p3_embryonic_rain_size',  p3_embryonic_rain_size
      write(iulog,'(A30,1x,L)')    'do_prescribed_CCN: ',       do_prescribed_CCN
@@ -213,6 +214,7 @@ subroutine micro_p3_readnl(nlfile)
   call mpibcast(p3_accret_coeff,         1 ,                         mpir8,   0, mpicom)
   call mpibcast(p3_qc_accret_expon,      1 ,                         mpir8,   0, mpicom)
   call mpibcast(p3_wbf_coeff,            1 ,                         mpir8,   0, mpicom)
+  call mpibcast(p3_mincdnc,              1 ,                         mpir8,   0, mpicom)
   call mpibcast(p3_max_mean_rain_size,   1 ,                         mpir8,   0, mpicom)
   call mpibcast(p3_embryonic_rain_size,  1 ,                         mpir8,   0, mpicom)
   call mpibcast(do_prescribed_CCN,       1,                          mpilog,  0, mpicom)
@@ -1324,6 +1326,7 @@ end subroutine micro_p3_readnl
          p3_nc_autocon_expon,         & ! IN  autoconversion nc exponent
          p3_qc_accret_expon,          & ! IN  autoconversion coefficient
          p3_wbf_coeff,                & ! IN  WBF process coefficient
+         p3_mincdnc,                  & ! IN  imposing minimal Nc
          p3_max_mean_rain_size,       & ! IN  max mean rain size
          p3_embryonic_rain_size,      & ! IN  embryonic rain size for autoconversion
          ! AaronDonahue new stuff

--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -2103,6 +2103,7 @@ subroutine tphysbc (ztodt,               &
                              ! after tphysac:clubb_surface and before aerosol dry removal.
                              ! For chemical gases, different versions of EAM 
                              ! might use different process ordering.
+    real(r8):: wuc(pcols,pver)
 
     call phys_getopts( microp_scheme_out      = microp_scheme, &
                        macrop_scheme_out      = macrop_scheme, &
@@ -2362,7 +2363,8 @@ end if
          rliq,       rice, &
          ztodt,   &
          state,   ptend, cam_in%landfrac, pbuf, mu, eu, du, md, ed, dp,   &
-         dsubcld, jt, maxg, ideep, lengath) 
+         dsubcld, jt, maxg, ideep, lengath, &
+         wuc ) 
     call t_stopf('convect_deep_tend')
 
     call physics_update(state, ptend, ztodt, tend)
@@ -2686,7 +2688,7 @@ end if
          call aero_model_wetdep( ztodt, dlf, dlf2, cmfmc2, state,  & ! inputs
                 sh_e_ed_ratio, mu, md, du, eu, ed, dp, dsubcld,    &
                 jt, maxg, ideep, lengath, species_class,           &
-                cam_out, pbuf, ptend )                               ! outputs
+                cam_out, pbuf, ptend, wuc=wuc )                    ! outputs
          call physics_update(state, ptend, ztodt, tend)
 
          ! deep convective aerosol transport

--- a/components/eam/src/physics/cam/zm_conv.F90
+++ b/components/eam/src/physics/cam/zm_conv.F90
@@ -311,7 +311,7 @@ subroutine zm_convr(lchnk   ,ncol    , &
                     t_star  ,q_star, dcape,   &
                     aero    ,qi      ,dif     ,dnlf    ,dnif    , & 
                     dsf     ,dnsf    ,sprd    ,rice    ,frz     , &
-                    mudpcu  ,lambdadpcu, microp_st)
+                    mudpcu  ,lambdadpcu, microp_st, wuc)
 !----------------------------------------------------------------------- 
 ! 
 ! Purpose: 
@@ -478,6 +478,7 @@ subroutine zm_convr(lchnk   ,ncol    , &
    real(r8), intent(out) :: frz(pcols,pver)        ! freezing heating
    real(r8), intent(out) :: rice(pcols)            ! reserved ice (not yet in cldce) for energy integrals
    real(r8), intent(out) :: qi(pcols,pver)         ! cloud ice mixing ratio. 
+   real(r8), intent(inout),optional :: wuc(pcols,pver)
 
 ! move these vars from local storage to output so that convective
 ! transports can be done in outside of conv_cam.
@@ -1655,6 +1656,7 @@ subroutine zm_convr(lchnk   ,ncol    , &
             microp_st%qns (i,k) = 0.5_r8*(microp_st%qns(i,k)+microp_st%qns(i,k+1))
             microp_st%qng (i,k) = 0.5_r8*(microp_st%qng(i,k)+microp_st%qng(i,k+1))
             microp_st%wu(i,k)   = 0.5_r8*(microp_st%wu(i,k)+microp_st%wu(i,k+1))
+            wuc(i,k) = microp_st%wu(i,k)
          end if
 
          if (t(i,k).gt. 273.15_r8 .and. t(i,k-1).le.273.15_r8) then

--- a/components/eam/src/physics/cam/zm_conv_intr.F90
+++ b/components/eam/src/physics/cam/zm_conv_intr.F90
@@ -730,7 +730,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
      ztodt   , &
      jctop   ,jcbot , &
      state   ,ptend_all   ,landfrac,  pbuf, mu, eu, &
-     du, md, ed, dp, dsubcld, jt, maxg, ideep, lengath) 
+     du, md, ed, dp, dsubcld, jt, maxg, ideep, lengath, wuc) 
 
    use cam_history,   only: outfld
    use physics_types, only: physics_state, physics_ptend
@@ -789,6 +789,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    
    ! w holds position of gathered points vs longitude index   
    integer, intent(out)  :: lengath
+   real(r8), intent(inout),optional :: wuc(pcols,pver)
 
    ! Local variables
 
@@ -1102,7 +1103,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
                     lengath ,ql      ,rliq  ,landfrac,  &
                     t_star, q_star, dcape, &  
                     aero(lchnk), qi, dif, dnlf, dnif, dsf, dnsf, sprd, rice, frz, mudpcu, &
-                    lambdadpcu,  microp_st)
+                    lambdadpcu,  microp_st, wuc)
 
    if (zm_microp) then
      dlftot(:,:) = dlf(:,:) + dif(:,:) + dsf(:,:)


### PR DESCRIPTION
Aerosol wet removal improvement: 
1. Use vertical velocity from ZMmp scheme in the deep convection wet removal
2. Detrain the cloud-borne aerosol into stratiform
3. Reorder the stratiform wet removal and the deep convection wet removal
4. Add Nc limit (default 10 per CC) in the P3 scheme
5. Fix the hard-coded qc exponent in the enhancement factors of auto-conversion and accretion