### PR TITLE
P3 threading fixes from p3_PR in E3SM repo for NGD_v3atm

### DIFF
--- a/components/eam/src/physics/cam/micro_p3.F90
+++ b/components/eam/src/physics/cam/micro_p3.F90
@@ -90,6 +90,14 @@ module micro_p3
   real(rtype), protected, dimension(300,10) :: vn_table_vals,vm_table_vals,revap_table_vals
   !$omp threadprivate (vn_table_vals,vm_table_vals,revap_table_vals)
 
+!<shanyp 20221218
+! set lookup tables as threadprivate variables to see if this change can address the threading issue.
+!  !$OMP THREADPRIVATE(ice_table_vals,collect_table_vals,mu_r_table_vals,vn_table_vals,vm_table_vals,revap_table_vals)
+! !$OMP THREADPRIVATE(ice_table_vals) 
+ !,vn_table_vals,vm_table_vals)
+!shanyp 20221218>
+
+
   type realptr
      real(rtype), dimension(:), pointer :: p
   end type realptr
@@ -2624,11 +2632,13 @@ table_val_qi_fallspd,acn,lamc, mu_c,qc_incld,qccol,    &
    real(rtype), intent(out) :: vtrmi1
    real(rtype), intent(out) :: rho_qm_cloud
 
-   real(rtype) :: iTc = 0.0_rtype
-   real(rtype) :: Vt_qc = 0.0_rtype
-   real(rtype) :: D_c  = 0.0_rtype
-   real(rtype) :: V_impact = 0.0_rtype
-   real(rtype) :: Ri = 0.0_rtype
+   real(rtype) :: iTc, Vt_qc,  D_c, V_impact, Ri
+
+   iTc = 0.0_rtype
+   Vt_qc = 0.0_rtype
+   D_c  = 0.0_rtype
+   V_impact = 0.0_rtype
+   Ri = 0.0_rtype
 
    ! if (qi_incld(i,k).ge.qsmall .and. t_atm(i,k).lt.T_zerodegc) then
    !  NOTE:  condition applicable for cloud only; modify when rain is added back

--- a/components/eam/src/physics/cam/micro_p3_interface.F90
+++ b/components/eam/src/physics/cam/micro_p3_interface.F90
@@ -591,8 +591,8 @@ end subroutine micro_p3_readnl
    call addfld('UMR', (/ 'lev' /), 'A',   'm/s', 'Mass-weighted rain  fallspeed'              )
 
    ! Record of inputs/outputs from p3_main
-   call addfld('P3_input',  (/ 'ilev',    'P3_input_dim ' /),    'I', 'N/A', 'Inputs for p3_main subroutine')
-   call addfld('P3_output', (/ 'ilev',    'P3_output_dim' /),    'I', 'N/A', 'Outputs for p3_main subroutine')
+   call addfld('P3_input',  (/ 'ilev         ',    'P3_input_dim ' /),    'I', 'N/A', 'Inputs for p3_main subroutine')
+   call addfld('P3_output', (/ 'ilev         ',    'P3_output_dim' /),    'I', 'N/A', 'Outputs for p3_main subroutine')
    ! Record of microphysics tendencies
    ! warm-phase process rates
    !call addfld('P3_qrcon',  (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for rain condensation   (Not in paper?)')


### PR DESCRIPTION
@yunpengshan2014 identified a fix for the threading issue that was seen in the P3 PR. Also in this PR is padding of the dimension variable names that are required for certain machines.

[NBFB]
