### PR TITLE
Update v3atm testmods with parameter settings from the 4th full smoke test

### DIFF
--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/20tr_v3atm/user_nl_eam
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/20tr_v3atm/user_nl_eam
@@ -15,6 +15,3 @@
  dust_emis_fact         =  11.8D0
  seasalt_emis_scale     =  0.55D0
 
- cosp_lite = .true.
- nhtfrq    = 5
- mfilt     = 1

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/20tr_v3atm_rtmoff/user_nl_eam
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/20tr_v3atm_rtmoff/user_nl_eam
@@ -15,6 +15,3 @@
  dust_emis_fact         =  11.8D0
  seasalt_emis_scale     =  0.55D0
 
- cosp_lite = .true.
- nhtfrq    = 5
- mfilt     = 1


### PR DESCRIPTION
Enable the parameters settings from the 4th full smoke test,
and use the new config to update the baselines for the v3atm tests.
With zmconv_microp = .true. in this config, all the ERS will pass.

Note that it is still needed to fix the ERS failure for the NGD_v3atm branch
when zmconv_microp=.false., which is the current default, 

[NBFB] for all v3atm tests due to updated parameter settings.