### PR TITLE
Fix use of uninitialized/unallocated variables in zm_microp

### DIFF
--- a/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -237,14 +237,14 @@ contains
      inv_ndx_cnst_no3       = get_inv_ndx( 'cnst_NO3' )
      inv_ndx_cnst_oh       = get_inv_ndx( 'cnst_OH' )
      inv_ndx_cnst_ch4      = get_inv_ndx( 'CH4' )
-     write(iulog,*), 'kzm_inv_ndx_no3 ', inv_ndx_cnst_no3
-     write(iulog,*), 'kzm_inv_ndx_oh', inv_ndx_cnst_oh
-     write(iulog,*), 'kzm_inv_ndx_ch4', inv_ndx_cnst_ch4
-     write(iulog,*), 'kzm_oh_ndx', oh_ndx
-     write(iulog,*), 'kzm_no3_ndx', no3_ndx
-     if ((inv_ndx_cnst_oh .gt. 0.0_r8) .and. (inv_ndx_cnst_no3 .gt. 0.0_r8)) then
-        write(iulog,*) 'kzm_prescribed_NO3_OH '
-     endif
+     !write(iulog,*), 'kzm_inv_ndx_no3 ', inv_ndx_cnst_no3
+     !write(iulog,*), 'kzm_inv_ndx_oh', inv_ndx_cnst_oh
+     !write(iulog,*), 'kzm_inv_ndx_ch4', inv_ndx_cnst_ch4
+     !write(iulog,*), 'kzm_oh_ndx', oh_ndx
+     !write(iulog,*), 'kzm_no3_ndx', no3_ndx
+     !if ((inv_ndx_cnst_oh .gt. 0.0_r8) .and. (inv_ndx_cnst_no3 .gt. 0.0_r8)) then
+     !   write(iulog,*) 'kzm_prescribed_NO3_OH '
+     !endif
      !kzm--
      
      if ( chem_name == 'linoz_mam3'.or.chem_name == 'linoz_mam4_resus'.or.chem_name == 'linoz_mam4_resus_mom' &

--- a/components/eam/src/chemistry/utils/prescribed_volcaero.F90
+++ b/components/eam/src/chemistry/utils/prescribed_volcaero.F90
@@ -213,10 +213,10 @@ end subroutine prescribed_volcaero_readnl
     if (trim(adjustl(file_type))== 'VOLC_CMIP6') then
        is_cmip6_volc = .true.
 #if (defined MODAL_AERO_5MODE)
-       write(iulog,*)'kzm_prescribed_volcaero_mam5_flag '
+       if ( masterproc ) write(iulog,*)'kzm_prescribed_volcaero_mam5_flag '
        is_cmip6_volc = .false.
 #else
-      write(iulog,*)'kzm_prescribed_volcaero_flag '
+       if ( masterproc ) write(iulog,*)'kzm_prescribed_volcaero_flag '
 #endif
       
        ispf = 1

--- a/components/eam/src/physics/cam/zm_conv_intr.F90
+++ b/components/eam/src/physics/cam/zm_conv_intr.F90
@@ -974,6 +974,8 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    doslop_moisture = .false.
    doslop_uwind    = .false.
    doslop_vwind    = .false.
+   alphau = 0.0_r8
+   alphav = 0.0_r8
    if( MCSP ) then
         if( MCSP_heat_coeff > 0._r8 ) then
                 doslop_heat = .true.
@@ -1249,8 +1251,8 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
       MCSP_DT(:ncol,:pver) = MCSP_DT(:ncol,:pver)/cpair
       call outfld('MCSP_DT    ',MCSP_DT           ,pcols   ,lchnk   )
       call outfld('MCSP_freq    ',MCSP_freq           ,pcols   ,lchnk   )
-      call outfld('MCSP_DU    ',ptend_loc%u*86400._r8           ,pcols   ,lchnk   )
-      call outfld('MCSP_DV    ',ptend_loc%v*86400._r8           ,pcols   ,lchnk   )
+      if (doslop_uwind) call outfld('MCSP_DU    ',ptend_loc%u*86400._r8           ,pcols   ,lchnk   )
+      if (doslop_vwind) call outfld('MCSP_DV    ',ptend_loc%v*86400._r8           ,pcols   ,lchnk   )
       call outfld('ZM_depth   ',ZM_depth                        ,pcols   ,lchnk   )
       call outfld('MCSP_shear ',MCSP_shear                      ,pcols   ,lchnk   )
 


### PR DESCRIPTION
This has no impact on simulation results. But can cause debug run to crash.

Also remove the testing printout in chemUCI codes.

[BFB]