### PR TITLE
change if statement so that adding history_verbose won't remove Mass_xx output

### DIFF
--- a/components/eam/src/chemistry/mozart/mo_chm_diags.F90
+++ b/components/eam/src/chemistry/mozart/mo_chm_diags.F90
@@ -770,7 +770,7 @@ contains
     enddo
 
     ! Add sum of mass mixing ratios for each aerosol class
-    if (history_aerosol .and. .not. history_verbose) then
+    if (history_aerosol) then
        call addfld( 'Mass_bc',   (/ 'lev' /), 'A', 'kg/kg ', &
             'sum of bc mass concentration bc_a1+bc_c1+bc_a3+bc_c3+bc_a4+bc_c4')
        call add_default( 'Mass_bc', 1, ' ' )
@@ -989,8 +989,8 @@ contains
     ! Mass_soa = soa_a1 + soa_c1 + soa_a2 + soa_c2 + soa_a3 + soa_c3
 
     !initialize the mass arrays
-    if (history_aerosol .and. .not. history_verbose) then
-       mass_bc(:ncol,:) = 0._r8
+    if (history_aerosol) then
+       mass_bc(:ncol,:)  = 0._r8
        mass_dst(:ncol,:) = 0._r8
        mass_mom(:ncol,:) = 0._r8
        mass_ncl(:ncol,:) = 0._r8
@@ -1172,7 +1172,7 @@ contains
           call outfld( solsym(m), mmr(:ncol,:,m), ncol ,lchnk )
           call outfld( trim(solsym(m))//'_SRF', mmr(:ncol,pver,m), ncol ,lchnk )
 #ifdef MODAL_AERO
-          if (history_aerosol .and. .not. history_verbose) then
+          if (history_aerosol) then
              select case (trim(solsym(m)))
              case ('bc_a1','bc_a3','bc_a4')
                   mass_bc(:ncol,:) = mass_bc(:ncol,:) + mmr(:ncol,:,m)
@@ -1184,7 +1184,11 @@ contains
                   mass_ncl(:ncol,:) = mass_ncl(:ncol,:) + mmr(:ncol,:,m)
              case ('pom_a1','pom_a3','pom_a4')
                   mass_pom(:ncol,:) = mass_pom(:ncol,:) + mmr(:ncol,:,m)
+#if (defined MODAL_AERO_5MODE)
+             case ('so4_a1','so4_a2','so4_a3','so4_a5')
+#else
              case ('so4_a1','so4_a2','so4_a3')
+#endif
                   mass_so4(:ncol,:) = mass_so4(:ncol,:) + mmr(:ncol,:,m)
              case ('soa_a1','soa_a2','soa_a3')
                   mass_soa(:ncol,:) = mass_soa(:ncol,:) + mmr(:ncol,:,m)
@@ -1220,7 +1224,7 @@ contains
 
 #ifdef MODAL_AERO
     ! diagnostics for cloud-borne aerosols, then add to corresponding mass accumulators
-    if (history_aerosol .and. .not. history_verbose) then
+    if (history_aerosol) then
 
 
        do n = 1,pcnst
@@ -1237,7 +1241,11 @@ contains
                      mass_ncl(:ncol,:) = mass_ncl(:ncol,:) + fldcw(:ncol,:)
                 case ('pom_c1','pom_c3','pom_c4')
                      mass_pom(:ncol,:) = mass_pom(:ncol,:) + fldcw(:ncol,:)
+#if (defined MODAL_AERO_5MODE)
+                case ('so4_c1','so4_c2','so4_c3','so4_c5')
+#else
                 case ('so4_c1','so4_c2','so4_c3')
+#endif
                      mass_so4(:ncol,:) = mass_so4(:ncol,:) + fldcw(:ncol,:)
                 case ('soa_c1','soa_c2','soa_c3')
                      mass_soa(:ncol,:) = mass_soa(:ncol,:) + fldcw(:ncol,:)


### PR DESCRIPTION
This PR does two things:

1. change if statement in mo_chm_diags.F90 so that adding history won't remove Mass_xx aerosol field.
2. add MAM5 stratospheric sulfate to Mass_xx field.