### PR TITLE
Fix missing exner factor in micro_p3 

### DIFF
--- a/components/eam/src/physics/cam/micro_p3.F90
+++ b/components/eam/src/physics/cam/micro_p3.F90
@@ -4568,7 +4568,7 @@ subroutine ice_complete_melting(kts,kte,ktop,kbot,kdir,qi,ni,qm,latent_heat_fusi
             qr(k) = qr(k) + frac_mlt*del_mass
             nr(k) = nr(k) + frac_mlt*del_num
          endif
-         th_atm(k) = th_atm(k) - frac_mlt*del_mass*latent_heat_fusion(k)/cp
+         th_atm(k) = th_atm(k) - exner(k)*frac_mlt*del_mass*latent_heat_fusion(k)/cp
       endif
    enddo k_loop_mlt
    


### PR DESCRIPTION
The exner factor is needed to account for the ice melting effect on
potential temperature.

[NBFB] for tests using P3