### PR TITLE
Update scropio to 1.4.1 and fix build compilation times on chrysalis

### DIFF
--- a/cime_config/machines/Depends.chrysalis.intel.cmake
+++ b/cime_config/machines/Depends.chrysalis.intel.cmake
@@ -1,0 +1,12 @@
+# Reduce optimization on files with long compile times
+set(O2MODELSRC
+  eam/src/physics/cam/micro_mg_cam.F90      # ~2027 seconds
+  elm/src/data_types/VegetationDataType.F90 # ~ 930 seconds
+)
+if (NOT DEBUG)
+  foreach(ITEM IN LISTS O2MODELSRC)
+    e3sm_remove_flags("${ITEM}" "-O3")
+    e3sm_add_flags("${ITEM}" "-O2")
+  endforeach()
+endif()
+


### PR DESCRIPTION
Closes #49 

This builds on top of #49 by cherry-picking a commit from master to fix compile times on chrysalis. Thanks @oksanaguba for the tip!