### PR TITLE
Add F1850 and coupled compsets and run scripts

### DIFF
--- a/cime_config/allactive/config_compsets.xml
+++ b/cime_config/allactive/config_compsets.xml
@@ -50,6 +50,16 @@
 </compset>
 
 <compset>
+  <alias>WCYCL1850_chemUCI-Linozv2</alias>
+  <lname>20TRSOI_EAM%CHEMUCI-LINOZV2_ELM%SPBC_MPASSI_MPASO_MOSART_SGLC_SWAV</lname>
+</compset>
+
+<compset>
+  <alias>WCYCL1850_chemUCI-Linozv3</alias>
+  <lname>1850SOI_EAM%CHEMUCI-LINOZV3_ELM%SPBC_MPASSI_MPASO_MOSART_SGLC_SWAV</lname>
+</compset>
+
+<compset>
   <alias>WCYCL1850-1pctCO2</alias>
   <lname>1850SOI_EAM%CMIP6-1pctCO2_ELM%SPBC_MPASSI_MPASO_MOSART_SGLC_SWAV</lname>
 </compset>

--- a/components/eam/bld/namelist_files/use_cases/1850_eam_chemUCI-Linoz.xml
+++ b/components/eam/bld/namelist_files/use_cases/1850_eam_chemUCI-Linoz.xml
@@ -11,7 +11,7 @@
 <!--ncdata dyn="se" hgrid="ne0np4_northamericax4v1" nlev="72" >atm/cam/inic/homme/cami_0001-01-01_northamericax4v1_c190709.nc</ncdata -->
 
 <!-- Solar constant from CMIP6 input4MIPS -->
-<solar_data_file>atm/cam/solar/Solar_1850control_input4MIPS_c20181017.nc</solar_data_file>
+<solar_data_file>atm/cam/solar/Solar_1850control_input4MIPS_c20181106.nc</solar_data_file>
 <solar_data_ymd>18500101</solar_data_ymd>
 <solar_data_type>FIXED</solar_data_type>
 

--- a/components/eam/bld/namelist_files/use_cases/1850_eam_chemUCI-Linoz.xml
+++ b/components/eam/bld/namelist_files/use_cases/1850_eam_chemUCI-Linoz.xml
@@ -66,7 +66,7 @@
 <co_emis_file         >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CO_surface_1850-2014_1.9x2.5_c20210323.nc </co_emis_file>
 <isop_emis_file       >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_ISOP_surface_1850-2014_1.9x2.5_c20210323.nc </isop_emis_file>
 <nox_emis_file        >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_NO_surface_1850-2014_1.9x2.5_c20220425.nc </nox_emis_file>
-<dms_emis_file        >atm/cam/chem/trop_mozart_aero/emis/DMSflux.1850-2100.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160727.nc</dms_emis_file>
+<dms_emis_file        >atm/cam/chem/trop_mozart_aero/emis/DMSflux.1850.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160416.nc </dms_emis_file>
 <so2_emis_file        >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_surf_1850-2014_c180205.nc </so2_emis_file>
 <bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_surf_1850-2014_c180205.nc </bc_a4_emis_file>
 <mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_surf_1850-2014_c180205.nc </mam7_num_a1_emis_file>

--- a/components/eam/bld/namelist_files/use_cases/1850_eam_chemUCI-Linoz.xml
+++ b/components/eam/bld/namelist_files/use_cases/1850_eam_chemUCI-Linoz.xml
@@ -1,0 +1,141 @@
+----- modified based on 1850 version ---- combined with 1850 use_case for V2
+
+<?xml version="1.0"?>
+<namelist_defaults>
+
+<!-- Set default output options for CMIP6 simulations -->
+<cosp_lite>.true.</cosp_lite>
+
+<!-- Atmosphere initial condition -->
+<ncdata dyn="se" hgrid="ne30np4" nlev="72" >atm/cam/inic/homme/NGD_v3atm.ne30pg2.eam.i.0001-01-01-00000.c20230106.nc</ncdata>
+<!--ncdata dyn="se" hgrid="ne0np4_northamericax4v1" nlev="72" >atm/cam/inic/homme/cami_0001-01-01_northamericax4v1_c190709.nc</ncdata -->
+
+<!-- Solar constant from CMIP6 input4MIPS -->
+<solar_data_file>atm/cam/solar/Solar_1850control_input4MIPS_c20181017.nc</solar_data_file>
+<solar_data_ymd>18500101</solar_data_ymd>
+<solar_data_type>FIXED</solar_data_type>
+
+<!-- 2010 GHG values from CMIP6 input4MIPS -->
+<!-- <co2vmr>284.317e-6</co2vmr> The CMIP6 concentration set by CCSM_CO2_PPMV in cime/src/drivers/mct/cime_config/config_component_acme.xml -->
+<ch4vmr>808.249e-9</ch4vmr>
+<n2ovmr>273.0211e-9</n2ovmr>
+<f11vmr>32.1102e-12</f11vmr>
+<f12vmr>0.0</f12vmr>
+
+<!-- Stratospheric aerosols from CMIP6 input4MIPS -->
+<prescribed_volcaero_datapath>atm/cam/volc                                             </prescribed_volcaero_datapath>
+<prescribed_volcaero_file    >CMIP_DOE-ACME_radiation_average_1850-2014_v3_c20171204.nc</prescribed_volcaero_file    >
+<prescribed_volcaero_filetype>VOLC_CMIP6					       </prescribed_volcaero_filetype>
+<prescribed_volcaero_type    >CYCLICAL						       </prescribed_volcaero_type    >
+<prescribed_volcaero_cycle_yr>1                                                        </prescribed_volcaero_cycle_yr>
+
+<!-- For comprehensive history -->
+<history_amwg       >.true.</history_amwg>
+<history_aerosol    >.true.</history_aerosol>
+<history_aero_optics>.true.</history_aero_optics>
+
+<!-- extra output spec -->
++++
+<history_gaschmbudget_2D> .true.</history_gaschmbudget_2D>
+<tropopause_output_all>.true.</tropopause_output_all>
+<tropopause_E90_thrd>76.0e-9</tropopause_E90_thrd>
+
+<!-- External forcing for BAM or MAM.  CMIP6 input4mips data -->
+<ext_frc_type         >CYCLICAL</ext_frc_type>
+<ext_frc_cycle_yr     >1850</ext_frc_cycle_yr>
+<no2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_NO2_aircraft_vertical_1750-2015_1.9x2.5_c20170608.nc </no2_ext_file>
+<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_elev_1850-2014_c180205.nc </so2_ext_file>
+<soag_ext_file        >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_soag_elev_1850-2014_c180205.nc </soag_ext_file>
+<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_elev_1850-2014_c180205.nc </bc_a4_ext_file>
+<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_elev_1850-2014_c180205.nc </mam7_num_a1_ext_file>
+<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_elev_1850-2014_c180205.nc </num_a2_ext_file>
+<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_elev_1850-2014_c180205.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_elev_1850-2014_c180205.nc </pom_a4_ext_file>
+<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_elev_1850-2014_c180205.nc </so4_a1_ext_file>
+<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_elev_1850-2014_c180205.nc </so4_a2_ext_file>
+
+<!-- Surface emissions for MAM4.  CMIP6 input4mips data -->
+<srf_emis_type        >CYCLICAL</srf_emis_type>
+<srf_emis_cycle_yr    >1850</srf_emis_cycle_yr>
+<c2h4_emis_file       >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_C2H4_surface_1850-2014_1.9x2.5_c20210323.nc </c2h4_emis_file>
+<c2h6_emis_file       >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_C2H6_surface_1850-2014_1.9x2.5_c20210323.nc </c2h6_emis_file>
+<c3h8_emis_file       >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_C3H8_surface_1850-2014_1.9x2.5_c20210323.nc </c3h8_emis_file>
+<ch2o_emis_file       >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CH2O_surface_1850-2014_1.9x2.5_c20210323.nc </ch2o_emis_file>
+<ch3cho_emis_file     >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CH3CHO_surface_1850-2014_1.9x2.5_c20210323.nc </ch3cho_emis_file>
+<ch3coch3_emis_file   >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CH3COCH3_surface_1850-2014_1.9x2.5_c20210323.nc </ch3coch3_emis_file>
+<co_emis_file         >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CO_surface_1850-2014_1.9x2.5_c20210323.nc </co_emis_file>
+<isop_emis_file       >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_ISOP_surface_1850-2014_1.9x2.5_c20210323.nc </isop_emis_file>
+<nox_emis_file        >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_NO_surface_1850-2014_1.9x2.5_c20220425.nc </nox_emis_file>
+<dms_emis_file        >atm/cam/chem/trop_mozart_aero/emis/DMSflux.1850-2100.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160727.nc</dms_emis_file>
+<so2_emis_file        >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_surf_1850-2014_c180205.nc </so2_emis_file>
+<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_surf_1850-2014_c180205.nc </bc_a4_emis_file>
+<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_surf_1850-2014_c180205.nc </mam7_num_a1_emis_file>
+<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_surf_1850-2014_c180205.nc </num_a2_emis_file>
+<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_surf_1850-2014_c180205.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_surf_1850-2014_c180205.nc </pom_a4_emis_file>
+<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_surf_1850-2014_c180205.nc </so4_a1_emis_file>
+<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_surf_1850-2014_c180205.nc </so4_a2_emis_file>
+<e90_emis_file        >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions_E90_surface_1750-2015_1.9x2.5_c20210408.nc </e90_emis_file>
+
+<airpl_emis_file></airpl_emis_file>   <!-- need to be empty, but if specifying empty here, the value would be root of input_data_path -->
+
+<!-- <tracer_cnst_filelist>this_field_is_not_used</tracer_cnst_filelist> -->
+<tracer_cnst_type    >CYCLICAL</tracer_cnst_type>
+<tracer_cnst_cycle_yr>1995</tracer_cnst_cycle_yr>
+<tracer_cnst_file    >ch4_oxid_1.9x2.5_L26_1990-1999clim.c090804.nc</tracer_cnst_file>
+<tracer_cnst_filelist>''</tracer_cnst_filelist>
+<tracer_cnst_datapath>atm/cam/chem/methane</tracer_cnst_datapath>
+<tracer_cnst_specifier>'CH4'</tracer_cnst_specifier>
+
+<!-- prescribed methane  -->
+<prescribed_ghg_file      >ch4_oxid_1.9x2.5_L26_1990-1999clim.c090804.nc</prescribed_ghg_file>
+<prescribed_ghg_datapath  >atm/cam/chem/methane</prescribed_ghg_datapath>
+<prescribed_ghg_type      >CYCLICAL</prescribed_ghg_type>
+<prescribed_ghg_cycle_yr  >1995</prescribed_ghg_cycle_yr>
+<prescribed_ghg_filelist  >''</prescribed_ghg_filelist>
+<prescribed_ghg_specifier>'prsd_ch4:CH4'</prescribed_ghg_specifier>
+
+<!-- rad_climate -->
+<rad_climate>
+  'A:Q:H2O', 'N:O2:O2', 'N:CO2:CO2',
+  'A:O3:O3', 'N:N2O:N2O', 'N:CH4:CH4',
+  'N:CFC11:CFC11', 'N:CFC12:CFC12', 'M:mam4_mode1:$INPUTDATA_ROOT/atm/cam/physprops/mam4_mode1_rrtmg_aeronetdust_c141106.nc',
+  'M:mam4_mode2:$INPUTDATA_ROOT/atm/cam/physprops/mam4_mode2_rrtmg_c130628.nc', 'M:mam4_mode3:$INPUTDATA_ROOT/atm/cam/physprops/mam4_mode3_rrtmg_aeronetdust_c141106.nc', 'M:mam4_mode4:$INPUTDATA_ROOT/atm/cam/physprops/mam4_mode4_rrtmg_c130628.nc'
+</rad_climate>
+
+<!-- Marine organic aerosol namelist settings -->
+<mam_mom_mixing_state>3</mam_mom_mixing_state>
+<mam_mom_cycle_yr  >1                                                                                    </mam_mom_cycle_yr  >
+<mam_mom_datapath  >'atm/cam/chem/trop_mam/marine_BGC/'                                                  </mam_mom_datapath  >
+<mam_mom_datatype  >'CYCLICAL'										 </mam_mom_datatype  >
+<mam_mom_filename  >'monthly_macromolecules_0.1deg_bilinear_latlon_year01_merge_date.nc'                 </mam_mom_filename  > <!-- Using the 2000 file, for now -->
+<mam_mom_fixed_tod >0											 </mam_mom_fixed_tod >
+<mam_mom_fixed_ymd >0											 </mam_mom_fixed_ymd >
+<mam_mom_specifier >'chla:CHL1','mpoly:TRUEPOLYC','mprot:TRUEPROTC','mlip:TRUELIPC'			 </mam_mom_specifier >
+
+<!-- Stratospheric ozone (Linoz) updated using CMIP6 input4MIPS GHG concentrations -->
+<chlorine_loading_file      >atm/cam/chem/trop_mozart/ub/Linoz_Chlorine_Loading_CMIP6_0003-2017_c20171114.nc</chlorine_loading_file>
+<chlorine_loading_fixed_ymd >18500101</chlorine_loading_fixed_ymd>
+<chlorine_loading_type      >FIXED</chlorine_loading_type>
+<linoz_data_cycle_yr        >1850</linoz_data_cycle_yr>
+<linoz_data_file            >linv3_1849-2015_2010JPL_cmip6_historical_10deg_58km_c20210625.nc</linoz_data_file>
+<linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
+<linoz_data_type            >CYCLICAL</linoz_data_type>
+
+<!-- Turn off ozone dry deposition, as Linoz O3v2 and ozone are not separated for now. Need to turn on ozone dry deposition when interactive tropospheric chemistry is implemented -->
+<drydep_method       >'xactive_lnd'</drydep_method>
+<drydep_list         >'O3','H2O2','CH2O','CH3OOH','NO','NO2','HNO3','HO2NO2','PAN','CO','CH3COCH3','C2H5OOH','CH3CHO','H2SO4','SO2','NO3','N2O5'</drydep_list>
+<gas_wetdep_method   >'NEU'</gas_wetdep_method>
+<gas_wetdep_list     >'C2H5OOH','CH2O','CH3CHO','CH3OOH','H2O2','H2SO4','HNO3','HO2NO2','SO2'</gas_wetdep_list>
+<fstrat_efold_list>'CH2O', 'CH3O2', 'CH3OOH', 'PAN', 'CO', 'C2H6', 'C3H8', 'C2H4', 'ROHO2', 'CH3COCH3', 'C2H5O2', 'C2H5OOH', 'CH3CHO', 'CH3CO3', 'ISOP', 'ISOPO2', 'MVKMACR', 'MVKO2'</fstrat_efold_list>
+
+<fstrat_list         >''</fstrat_list>
+
+<!-- sim_year used for CLM datasets -->
+<sim_year>1850</sim_year>
+
+<!-- land datasets -->
+<!-- Set in components/clm/bld/namelist_files/use_cases/1850_CMIP6_control.xml -->
+
+
+</namelist_defaults>

--- a/components/eam/chem_proc/inputs/pp_chemUCI_linozv3_mam5_vbs.in
+++ b/components/eam/chem_proc/inputs/pp_chemUCI_linozv3_mam5_vbs.in
@@ -266,21 +266,21 @@ CHEMISTRY
 
 
 * VBS SOAG reactions
-              SOAG0 + OH -> 1.15*SOAG15                                       ; 2e-11
-              SOAG15 + OH -> 1.15*SOAG24                                      ; 2e-11
-              SOAG24 + OH -> 0.46*SOAG33 + 0.5*SOAG35                         ; 2e-11
+[vsoag0_oh]   SOAG0 + OH -> 1.15*SOAG15                                       ; 2e-11
+[vsoag15_oh]  SOAG15 + OH -> 1.15*SOAG24                                      ; 2e-11
+[vsoag24_oh]  SOAG24 + OH -> 0.46*SOAG33 + 0.5*SOAG35                         ; 2e-11
 
-              ISOP + OH ->   0.00272*SOAG32 + 0.00981*SOAG33 + 0.00218*SOAG34       ; 2.54e-11, 410
-              C10H16 + OH -> 0.14986*SOAG32 + 0.05450*SOAG33 + 0.09264*SOAG34     ; 1.2e-11, 444
-              ISOP + O3 -> 0.00327*SOAG33                                         ; 1.05e-14, -2000
-              C10H16 + O3 -> 0.04360*SOAG31 + 0.01035*SOAG32 + 0.09809*SOAG33 + 0.01635*SOAG34     ; 1.e-15, -732
-              ISOP + NO3 -> 0.00027*SOAG32 + 0.04060*SOAG33 + 0.06458*SOAG34      ; 3.03e-12,-446
-              C10H16 + NO3 -> 0.17493*SOAG33 + 0.59019*SOAG34                     ; 1.2e-12, 490
+[visop_oh]    ISOP + OH ->   0.00272*SOAG32 + 0.00981*SOAG33 + 0.00218*SOAG34       ; 2.54e-11, 410
+[vc10h16_oh]  C10H16 + OH -> 0.14986*SOAG32 + 0.05450*SOAG33 + 0.09264*SOAG34     ; 1.2e-11, 444
+[visop_o3]    ISOP + O3 -> 0.00327*SOAG33                                         ; 1.05e-14, -2000
+[vc10h16_o3]  C10H16 + O3 -> 0.04360*SOAG31 + 0.01035*SOAG32 + 0.09809*SOAG33 + 0.01635*SOAG34     ; 1.e-15, -732
+[visop_no3]   ISOP + NO3 -> 0.00027*SOAG32 + 0.04060*SOAG33 + 0.06458*SOAG34      ; 3.03e-12,-446
+[vc10h16_no3] C10H16 + NO3 -> 0.17493*SOAG33 + 0.59019*SOAG34                     ; 1.2e-12, 490
 
-              SOAG35 + OH -> 0.46*SOAG34  + 0.5*SOAG35      ; 2e-11
-              SOAG34 + OH -> 0.46*SOAG33  + 0.5*SOAG35      ; 2e-11
-              SOAG33 + OH -> 0.46*SOAG32  + 0.5*SOAG35      ; 2e-11
-              SOAG32 + OH -> 0.46*SOAG31  + 0.5*SOAG35      ; 2e-11
+[vsoag35_oh]  SOAG35 + OH -> 0.46*SOAG34  + 0.5*SOAG35      ; 2e-11
+[vsoag34_oh]  SOAG34 + OH -> 0.46*SOAG33  + 0.5*SOAG35      ; 2e-11
+[vsoag33_oh]  SOAG33 + OH -> 0.46*SOAG32  + 0.5*SOAG35      ; 2e-11
+[vsoag32_oh]  SOAG32 + OH -> 0.46*SOAG31  + 0.5*SOAG35      ; 2e-11
  End Reactions
 
  Ext Forcing

--- a/components/eam/cime_config/config_component.xml
+++ b/components/eam/cime_config/config_component.xml
@@ -134,6 +134,7 @@
       <value compset="1850(?:SOI)?_EAM.*AV1C-L" >1850_cam5_av1c-04p2</value>
       <value compset="1850(?:SOI)?_EAM.*CMIP6"  >1850_eam_CMIP6</value>
       <value compset="1850(?:SOI)?_EAM.*CMIP6-1pctCO2"  >1850_eam_CMIP6-1pctCO2</value>
+      <value compset="1850(?:SOI)?_EAM.*CHEMUCI.*LINOZ"  >1850_eam_chemUCI-Linoz</value>
       <value compset="1950(?:SOI)?_EAM.*CMIP6"  >1950_eam_CMIP6</value>
       <value compset="1850(?:SOI)?_EAM.*CMIP6.*_BGC%B"  >1850_cam5_CMIP6_bgc</value>
       <value compset="2010S_EAM.*CMIP6"  >2010S_cam5_CMIP6</value>

--- a/components/eam/cime_config/config_compsets.xml
+++ b/components/eam/cime_config/config_compsets.xml
@@ -17,6 +17,16 @@
   </compset>
 
   <compset>
+    <alias>F1850_chemUCI-Linozv2</alias>
+    <lname>1850_EAM%CHEMUCI-LINOZV2_ELM%SPBC_MPASSI%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>F1850_chemUCI-Linozv3</alias>
+    <lname>1850_EAM%CHEMUCI-LINOZV3_ELM%SPBC_MPASSI%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
     <alias>F1850S-AR5-superfast</alias>
     <lname>1850S_EAM%AR5sf_ELM%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
   </compset>

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -2923,7 +2923,6 @@
 		/>
 		<var name="normalMLEvelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^-1"
 			description="Velocity from mixed layer eddies (fox kemper 2011 submesoscale parameterization)"
-			missing_value="FILLVAL" missing_value_mask="edgeMask"
 			packages="submeso"
 		/>
 		<var name="cGMphaseSpeed" type="real" dimensions="nEdges Time" units="m s^-1"

--- a/run.NGD_v3atm.F1850.sh
+++ b/run.NGD_v3atm.F1850.sh
@@ -239,7 +239,7 @@ nhtfrq =   0,-24,-6,-6,-3,-24,0
          'C10H16   -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_MTERP_surface_1850-2014_1.9x2.5_c20230126.nc',
          'SOAG0    -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/emissions-cmip6_e3sm_SOAG0_surf_1850-2014_1.9x2.5_c20230201.nc',
          'NO       -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_NO_surface_1850-2014_1.9x2.5_c20220425.nc',
-         'DMS      -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DMSflux.1850-2100.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160727.nc',
+         'DMS      -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DMSflux.1850.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160416.nc',
          'SO2      -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_surf_1850-2014_c180205.nc',
          'bc_a4    -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_surf_1850-2014_c180205.nc',
          'num_a1   -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_surf_1850-2014_c180205.nc',

--- a/run.NGD_v3atm.F1850.sh
+++ b/run.NGD_v3atm.F1850.sh
@@ -236,7 +236,7 @@ nhtfrq =   0,-24,-6,-6,-3,-24,0
          'CH3COCH3 -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CH3COCH3_surface_1850-2014_1.9x2.5_c20210323.nc',
          'CO       -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CO_surface_1850-2014_1.9x2.5_c20210323.nc',
          'ISOP     -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_ISOP_surface_1850-2014_1.9x2.5_c20210323.nc',
-         'C10H16   -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_MTERP_surface_1850-2014_1.9x2.5_c20220426.nc',
+         'C10H16   -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_MTERP_surface_1850-2014_1.9x2.5_c20230126.nc',
          'SOAG0    -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/emissions-cmip6_e3sm_SOAG0_surf_1850-2014_1.9x2.5_c20230201.nc',
          'NO       -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_NO_surface_1850-2014_1.9x2.5_c20220425.nc',
          'DMS      -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DMSflux.1850-2100.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160727.nc',

--- a/run.NGD_v3atm.F1850.sh
+++ b/run.NGD_v3atm.F1850.sh
@@ -1,0 +1,656 @@
+#!/bin/bash -fe
+
+# E3SM Water Cycle v2 run_e3sm script template.
+#
+# Inspired by v1 run_e3sm script as well as SCREAM group simplified run script.
+#
+# Bash coding style inspired by:
+# http://kfirlavi.herokuapp.com/blog/2012/11/14/defensive-bash-programming
+
+main() {
+
+# For debugging, uncomment libe below
+#set -x
+
+# --- Configuration flags ----
+
+# Machine and project
+readonly MACHINE=chrysalis
+readonly PROJECT="e3sm"
+
+# Simulation
+readonly COMPSET="F1850_chemUCI-Linozv3"
+readonly RESOLUTION="ne30pg2_EC30to60E2r2"
+readonly CASE_NAME="20230223.NGD_v3atm.F1850"  
+
+# Code and compilation
+readonly CHECKOUT="20230223"
+readonly BRANCH="NGD_v3atm_v2.1ocnice_alt" 
+readonly CHERRY=( )
+readonly DEBUG_COMPILE=false
+
+# Run options
+readonly MODEL_START_TYPE="initial"  # 'initial', 'continue', 'branch', 'hybrid'
+readonly START_DATE="0001-01-01"
+
+# Additional options for 'branch' and 'hybrid'
+readonly GET_REFCASE=TRUE
+readonly RUN_REFDIR="/lcrc/group/e3sm/ac.mwu/archive/20220504.v2.LR.bi-grid.amip.chemMZT.chrysalis/archive/rest/1985-01-01-00000"
+readonly RUN_REFCASE="20220504.v2.LR.bi-grid.amip.chemMZT.chrysalis"
+readonly RUN_REFDATE="1985-01-01"
+
+# Set paths
+readonly CODE_ROOT="/home/ac.wlin/E3SM/integration/v3atm-work"
+readonly CASE_ROOT="/lcrc/group/e3sm/${USER}/E3SM_testings/v3atm/${CASE_NAME}"
+readonly MY_INPUT_DATA_PATH="/lcrc/group/e3sm/ac.mwu/inputdata"
+
+# Sub-directories
+readonly CASE_BUILD_DIR=${CASE_ROOT}/build
+readonly CASE_ARCHIVE_DIR=${CASE_ROOT}/archive
+
+# Define type of run
+#  short tests: 'S_2x5_ndays', 'M_1x10_ndays', 'M80_1x10_ndays'
+#  or 'production' for full simulation
+#readonly run='production'
+
+readonly run='production'
+#readonly run='custom-30_1x10_ndays'
+#readonly run='custom-10_2x5_ndays'
+#readonly run='custom-10_1x10_ndays'
+
+if [ "${run}" != "production" ]; then
+
+  # Short test simulations
+  tmp=($(echo $run | tr "_" " "))
+  layout=${tmp[0]}
+  units=${tmp[2]}
+  resubmit=$(( ${tmp[1]%%x*} -1 ))
+  length=${tmp[1]##*x}
+
+  readonly CASE_SCRIPTS_DIR=${CASE_ROOT}/tests/${run}/case_scripts
+  readonly CASE_RUN_DIR=${CASE_ROOT}/tests/${run}/run
+  #readonly PELAYOUT=${layout}
+  readonly PELAYOUT="custom-10"
+  readonly WALLTIME="4:00:00"
+  readonly STOP_OPTION=${units}
+  readonly STOP_N=${length}
+  readonly REST_OPTION=${STOP_OPTION}
+  readonly REST_N=${STOP_N}
+  readonly RESUBMIT=${resubmit}
+  readonly DO_SHORT_TERM_ARCHIVING=false
+
+else
+
+  # Production simulation
+  readonly CASE_SCRIPTS_DIR=${CASE_ROOT}/case_scripts
+  readonly CASE_RUN_DIR=${CASE_ROOT}/run
+  #readonly PELAYOUT="M"
+  readonly PELAYOUT="custom-30"
+  readonly WALLTIME="6:00:00"
+  readonly STOP_OPTION="nmonths"
+  readonly STOP_N="1"
+  readonly REST_OPTION="nmonths"
+  readonly REST_N="5"
+  readonly RESUBMIT="0"
+  readonly DO_SHORT_TERM_ARCHIVING=false
+fi
+
+# Coupler history 
+readonly HIST_OPTION="nyears"
+readonly HIST_N="1"
+
+# Leave empty (unless you understand what it does)
+readonly OLD_EXECUTABLE=""
+
+# --- Toggle flags for what to do ----
+do_fetch_code=false
+do_create_newcase=true
+do_case_setup=true
+do_case_build=true
+do_case_submit=true
+
+# --- Now, do the work ---
+
+# Make directories created by this script world-readable
+umask 022
+
+# Fetch code from Github
+fetch_code
+
+# Create case
+create_newcase
+
+# Custom PE layout
+custom_pelayout
+
+# Setup
+case_setup
+
+# Build
+case_build
+
+# Configure runtime options
+runtime_options
+
+# Copy script into case_script directory for provenance
+copy_script
+
+# Submit
+case_submit
+
+# All done
+echo $'\n----- All done -----\n'
+
+}
+
+# =======================
+# Custom user_nl settings
+# =======================
+
+user_nl() {
+
+cat << EOF >> user_nl_eam
+nhtfrq =   0,-24,-6,-6,-3,-24,0
+ mfilt  = 1,30,120,120,240,30,1
+ avgflag_pertape = 'A','A','I','A','A','A','I'
+ fexcl1 = 'CFAD_SR532_CAL', 'LINOZ_DO3', 'LINOZ_DO3_PSC', 'LINOZ_O3CLIM', 'LINOZ_O3COL', 'LINOZ_SSO3', 'hstobie_linoz'
+ fincl1 = 'extinct_sw_inp','extinct_lw_bnd7','extinct_lw_inp','CLD_CAL', 'TREFMNAV', 'TREFMXAV'
+ fincl2 = 'FLUT','PRECT','U200','V200','U850','V850','Z500','OMEGA500','UBOT','VBOT','TREFHT','TREFHTMN:M','TREFHTMX:X','QREFHT','TS','PS','TMQ','TUQ','TVQ','TOZ', 'FLDS', 'FLNS', 'FSDS', 'FSNS', 'SHFLX', 'LHFLX', 'TGCLDCWP', 'TGCLDIWP', 'TGCLDLWP', 'CLDTOT', 'T250', 'T200', 'T150', 'T100', 'T050', 'T025', 'T010', 'T005', 'T002', 'T001', 'TTOP', 'U250', 'U150', 'U100', 'U050', 'U025', 'U010', 'U005', 'U002', 'U001', 'UTOP', 'FSNT', 'FLNT'
+ fincl3 = 'PSL','T200','T500','U850','V850','UBOT','VBOT','TREFHT', 'Z700', 'TBOT:M'
+ fincl4 = 'FLUT','U200','U850','PRECT','OMEGA500'
+ fincl5 = 'PRECT','PRECC','TUQ','TVQ','QFLX','SHFLX','U90M','V90M'
+ fincl6 = 'CLDTOT_ISCCP','MEANCLDALB_ISCCP','MEANTAU_ISCCP','MEANPTOP_ISCCP','MEANTB_ISCCP','CLDTOT_CAL','CLDTOT_CAL_LIQ','CLDTOT_CAL_ICE','CLDTOT_CAL_UN','CLDHGH_CAL','CLDHGH_CAL_LIQ','CLDHGH_CAL_ICE','CLDHGH_CAL_UN','CLDMED_CAL','CLDMED_CAL_LIQ','CLDMED_CAL_ICE','CLDMED_CAL_UN','CLDLOW_CAL','CLDLOW_CAL_LIQ','CLDLOW_CAL_ICE','CLDLOW_CAL_UN'
+ fincl7 = 'O3', 'PS', 'TROP_P'
+
+ tropopause_e90_thrd    = 80.0e-9
+ history_gaschmbudget_2D = .false.
+ history_gaschmbudget_2D_levels = .false.
+ history_UCIgaschmbudget_2D = .false.
+ history_UCIgaschmbudget_2D_levels = .false.
+ gaschmbudget_2D_L1_s =  1
+ gaschmbudget_2D_L1_e = 26
+ gaschmbudget_2D_L2_s = 27
+ gaschmbudget_2D_L2_e = 38
+ gaschmbudget_2D_L3_s = 39
+ gaschmbudget_2D_L3_e = 58
+ gaschmbudget_2D_L4_s = 59
+ gaschmbudget_2D_L4_e = 72
+! history_aero_optics    = .true.
+! history_aerosol        = .true.
+! history_amwg           = .true.
+! history_budget         = .true.
+! history_verbose        = .true.
+ cosp_lite = .true.
+ zmconv_microp = .true.
+ zmconv_clos_dyn_adj = .true.
+ zmconv_MCSP_heat_coeff = 0.3
+ zmconv_tpert_fix = .true.
+ zmconv_ke = 2.5e-6
+ p3_wbf_coeff = 1.0
+
+ sscav_tuning = .false.
+ 
+ !LWCF tuning
+ nucleate_ice_subgrid   =  1.35
+ p3_mincdnc             =  20.D6
+ dust_emis_fact         =  11.8D0
+ seasalt_emis_scale     =  0.55D0
+
+ tracer_cnst_cycle_yr           = 1995
+ tracer_cnst_datapath           = '\$DIN_LOC_ROOT/atm/cam/chem/methane/'
+ tracer_cnst_file               = 'ch4_oxid_1.9x2.5_L26_1990-1999clim.c090804.nc'
+ tracer_cnst_filelist           = ''
+ tracer_cnst_specifier          = 'CH4','cnst_NO3:NO3', 'cnst_OH:OH'
+ tracer_cnst_type               = 'CYCLICAL'
+
+ linoz_psc_t = 198.0
+
+ ! empty sad_file would have no effect for the 4th full smoke config
+
+ sad_file               = '\$DIN_LOC_ROOT/atm/waccm/sulf/SAD_SULF_1849-2100_1.9x2.5_c090817.nc'
+ sad_type     = 'SERIAL' 
+
+ drydep_list = 'O3','H2O2','CH2O','CH3OOH','NO','NO2','HNO3','HO2NO2','PAN','CO','CH3COCH3','C2H5OOH','CH3CHO','H2SO4','SO2','NO3','N2O5'
+
+ gas_wetdep_list                = 'C2H5OOH','CH2O','CH3CHO','CH3OOH','H2O2','H2SO4','HNO3','HO2NO2','SO2','SOAG0','SOAG15','SOAG24','SOAG35','SOAG34','SOAG33','SOAG32','SOAG31'
+ gas_wetdep_method              = 'NEU'
+ 
+ ext_frc_cycle_yr               = 1850
+ ext_frc_specifier              = 'NO2    -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_NO2_aircraft_vertical_1750-2015_1.9x2.5_c20170608.nc',
+         'SO2    -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_elev_1850-2014_c180205.nc',
+         'SOAG0  -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/emissions-cmip6_e3sm_SOAG0_elev_1850-2014_1.9x2.5_c20230201.nc',
+         'bc_a4  -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_elev_1850-2014_c180205.nc',
+         'num_a1 -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_elev_1850-2014_c180205.nc',
+         'num_a2 -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_elev_1850-2014_c180205.nc',
+         'num_a4 -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_elev_1850-2014_c180205.nc',
+         'pom_a4 -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_elev_1850-2014_c180205.nc',
+         'so4_a1 -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_elev_1850-2014_c180205.nc',
+         'so4_a2 -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_elev_1850-2014_c180205.nc'
+ ext_frc_type           = 'CYCLICAL'
+ srf_emis_cycle_yr              = 1850
+ srf_emis_specifier             = 'C2H4     -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_C2H4_surface_1850-2014_1.9x2.5_c20210323.nc',
+         'C2H6     -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_C2H6_surface_1850-2014_1.9x2.5_c20210323.nc',
+         'C3H8     -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_C3H8_surface_1850-2014_1.9x2.5_c20210323.nc',
+         'CH2O     -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CH2O_surface_1850-2014_1.9x2.5_c20210323.nc',
+         'CH3CHO   -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CH3CHO_surface_1850-2014_1.9x2.5_c20210323.nc',
+         'CH3COCH3 -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CH3COCH3_surface_1850-2014_1.9x2.5_c20210323.nc',
+         'CO       -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CO_surface_1850-2014_1.9x2.5_c20210323.nc',
+         'ISOP     -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_ISOP_surface_1850-2014_1.9x2.5_c20210323.nc',
+         'C10H16   -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_MTERP_surface_1850-2014_1.9x2.5_c20220426.nc',
+         'SOAG0    -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/emissions-cmip6_e3sm_SOAG0_surf_1850-2014_1.9x2.5_c20230201.nc',
+         'NO       -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_NO_surface_1850-2014_1.9x2.5_c20220425.nc',
+         'DMS      -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DMSflux.1850-2100.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160727.nc',
+         'SO2      -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_surf_1850-2014_c180205.nc',
+         'bc_a4    -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_surf_1850-2014_c180205.nc',
+         'num_a1   -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_surf_1850-2014_c180205.nc',
+         'num_a2   -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_surf_1850-2014_c180205.nc',
+         'num_a4   -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_surf_1850-2014_c180205.nc',
+         'pom_a4   -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_surf_1850-2014_c180205.nc',
+         'so4_a1   -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_surf_1850-2014_c180205.nc',
+         'so4_a2   -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_surf_1850-2014_c180205.nc'
+         'E90      -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions_E90_surface_1750-2015_1.9x2.5_c20210408.nc'
+ srf_emis_type          = 'CYCLICAL'
+
+ mode_defs = 'mam5_mode1:accum:=', 'A:num_a1:N:num_c1:num_mr:+',
+         'A:so4_a1:N:so4_c1:sulfate:\$DIN_LOC_ROOT/atm/cam/physprops/sulfate_rrtmg_c080918.nc:+',
+         'A:pom_a1:N:pom_c1:p-organic:\$DIN_LOC_ROOT/atm/cam/physprops/ocpho_rrtmg_c130709.nc:+',
+         'A:soa_a1:N:soa_c1:s-organic:\$DIN_LOC_ROOT/atm/cam/physprops/ocphi_rrtmg_c100508.nc:+',
+         'A:bc_a1:N:bc_c1:black-c:\$DIN_LOC_ROOT/atm/cam/physprops/bcpho_rrtmg_c100508.nc:+',
+         'A:dst_a1:N:dst_c1:dust:\$DIN_LOC_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_c141106.nc:+',
+         'A:ncl_a1:N:ncl_c1:seasalt:\$DIN_LOC_ROOT/atm/cam/physprops/ssam_rrtmg_c100508.nc:+',
+         'A:mom_a1:N:mom_c1:m-organic:\$DIN_LOC_ROOT/atm/cam/physprops/poly_rrtmg_c130816.nc:',
+         'mam5_mode2:aitken:=', 'A:num_a2:N:num_c2:num_mr:+',
+         'A:so4_a2:N:so4_c2:sulfate:\$DIN_LOC_ROOT/atm/cam/physprops/sulfate_rrtmg_c080918.nc:+',
+         'A:soa_a2:N:soa_c2:s-organic:\$DIN_LOC_ROOT/atm/cam/physprops/ocphi_rrtmg_c100508.nc:+',
+         'A:ncl_a2:N:ncl_c2:seasalt:\$DIN_LOC_ROOT/atm/cam/physprops/ssam_rrtmg_c100508.nc:+',
+         'A:mom_a2:N:mom_c2:m-organic:\$DIN_LOC_ROOT/atm/cam/physprops/poly_rrtmg_c130816.nc:',
+         'mam5_mode3:coarse:=', 'A:num_a3:N:num_c3:num_mr:+',
+         'A:dst_a3:N:dst_c3:dust:\$DIN_LOC_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_c141106.nc:+',
+         'A:ncl_a3:N:ncl_c3:seasalt:\$DIN_LOC_ROOT/atm/cam/physprops/ssam_rrtmg_c100508.nc:+',
+         'A:so4_a3:N:so4_c3:sulfate:\$DIN_LOC_ROOT/atm/cam/physprops/sulfate_rrtmg_c080918.nc:+',
+         'A:bc_a3:N:bc_c3:black-c:\$DIN_LOC_ROOT/atm/cam/physprops/bcpho_rrtmg_c100508.nc:+',
+         'A:pom_a3:N:pom_c3:p-organic:\$DIN_LOC_ROOT/atm/cam/physprops/ocpho_rrtmg_c130709.nc:+',
+         'A:soa_a3:N:soa_c3:s-organic:\$DIN_LOC_ROOT/atm/cam/physprops/ocphi_rrtmg_c100508.nc:+',
+         'A:mom_a3:N:mom_c3:m-organic:\$DIN_LOC_ROOT/atm/cam/physprops/poly_rrtmg_c130816.nc:',
+         'mam5_mode4:primary_carbon:=', 'A:num_a4:N:num_c4:num_mr:+',
+         'A:pom_a4:N:pom_c4:p-organic:\$DIN_LOC_ROOT/atm/cam/physprops/ocpho_rrtmg_c130709.nc:+',
+         'A:bc_a4:N:bc_c4:black-c:\$DIN_LOC_ROOT/atm/cam/physprops/bcpho_rrtmg_c100508.nc:+',
+         'A:mom_a4:N:mom_c4:m-organic:\$DIN_LOC_ROOT/atm/cam/physprops/poly_rrtmg_c130816.nc',
+         'mam5_mode5:strat_coarse:=', 'A:num_a5:N:num_c5:num_mr:+',
+         'A:so4_a5:N:so4_c5:sulfate:\$DIN_LOC_ROOT/atm/cam/physprops/sulfate_rrtmg_c080918.nc'
+
+ rad_climate            = 'A:H2OLNZ:H2O', 'N:O2:O2', 'N:CO2:CO2',
+         'A:O3:O3', 'A:N2OLNZ:N2O', 'A:CH4LNZ:CH4',
+         'N:CFC11:CFC11', 'N:CFC12:CFC12', 
+         'M:mam5_mode1:\$DIN_LOC_ROOT/atm/cam/physprops/mam4_mode1_rrtmg_aeronetdust_c141106.nc',
+         'M:mam5_mode2:\$DIN_LOC_ROOT/atm/cam/physprops/mam4_mode2_rrtmg_c130628.nc', 
+         'M:mam5_mode3:\$DIN_LOC_ROOT/atm/cam/physprops/mam4_mode3_rrtmg_aeronetdust_c141106.nc',
+         'M:mam5_mode4:\$DIN_LOC_ROOT/atm/cam/physprops/mam4_mode4_rrtmg_c130628.nc',
+         'M:mam5_mode5:\$DIN_LOC_ROOT/atm/cam/physprops/mam4_mode3_rrtmg_aeronetdust_sig1.2_dgnl.40_c150219_ke.nc'
+! rad_diag_1 = 'A:H2OLNZ:H2O','N:O2:O2','N:CO2:CO2','A:O3:O3','A:N2OLNZ:N2O','A:CH4LNZ:CH4','N:CFC11:CFC11','N:CFC12:CFC12'
+
+
+ cflx_cpl_opt = 2
+
+ soil_erod_file         = '\$DIN_LOC_ROOT/atm/cam/dst/dst_1.9x2.5_c090203.nc'
+
+EOF
+
+cat << EOF >> user_nl_elm
+ hist_dov2xy = .true.,.true.
+ hist_fincl2 = 'H2OSNO', 'FSNO', 'QRUNOFF', 'QSNOMELT', 'FSNO_EFF', 'SNORDSL', 'SNOW', 'FSDS', 'FSR', 'FLDS', 'FIRE', 'FIRA'
+ hist_mfilt = 1,365
+ hist_nhtfrq = 0,-24
+ hist_avgflag_pertape = 'A','A'
+ check_finidat_year_consistency = .false.
+ check_dynpft_consistency = .false.
+ fsurdat = '\${DIN_LOC_ROOT}/lnd/clm2/surfdata_map/surfdata_ne30pg2_simyr1850_c210402.nc'
+
+ !comment out finidat if running hybrid type
+
+ finidat = '\${DIN_LOC_ROOT}/lnd/clm2/initdata/NGD_v3atm.ne30pg2_EC30to60E2r2.elm.r.0001-01-01-00000.c20230106.nc'
+ flanduse_timeseries = '\${DIN_LOC_ROOT}/lnd/clm2/surfdata_map/landuse.timeseries_ne30np4.pg2_hist_simyr1850-2015_c210113.nc'
+EOF
+
+}
+
+# =====================================
+# Customize MPAS stream files if needed
+# =====================================
+
+patch_mpas_streams() {
+
+echo
+
+}
+
+# =====================================================
+# Custom PE layout: custom-N where N is number of nodes
+# =====================================================
+
+custom_pelayout() {
+
+if [[ ${PELAYOUT} == custom-* ]];
+then
+    echo $'\n CUSTOMIZE PROCESSOR CONFIGURATION:'
+
+    # Number of cores per node (machine specific)
+    if [ "${MACHINE}" == "chrysalis" ]; then
+        ncore=64
+    elif [ "${MACHINE}" == "compy" ]; then
+        ncore=40
+    else
+        echo 'ERROR: MACHINE = '${MACHINE}' is not supported for custom PE layout.' 
+        exit 400
+    fi
+
+    # Extract number of nodes
+    tmp=($(echo ${PELAYOUT} | tr "-" " "))
+    nnodes=${tmp[1]}
+
+    # Customize
+    pushd ${CASE_SCRIPTS_DIR}
+    ./xmlchange NTASKS=$(( $nnodes * $ncore ))
+    ./xmlchange NTHRDS=1
+    ./xmlchange MAX_MPITASKS_PER_NODE=$ncore
+    ./xmlchange MAX_TASKS_PER_NODE=$ncore
+    popd
+
+fi
+
+}
+
+######################################################
+### Most users won't need to change anything below ###
+######################################################
+
+#-----------------------------------------------------
+fetch_code() {
+
+    if [ "${do_fetch_code,,}" != "true" ]; then
+        echo $'\n----- Skipping fetch_code -----\n'
+        return
+    fi
+
+    echo $'\n----- Starting fetch_code -----\n'
+    local path=${CODE_ROOT}
+    local repo=e3sm
+
+    echo "Cloning $repo repository branch $BRANCH under $path"
+    if [ -d "${path}" ]; then
+        echo "ERROR: Directory already exists. Not overwriting"
+        exit 20
+    fi
+    mkdir -p ${path}
+    pushd ${path}
+
+    # This will put repository, with all code
+    git clone git@github.com:E3SM-Project/${repo}.git .
+    
+    # Setup git hooks
+    rm -rf .git/hooks
+    git clone git@github.com:E3SM-Project/E3SM-Hooks.git .git/hooks
+    git config commit.template .git/hooks/commit.template
+
+    # Bring in all submodule components
+    git submodule update --init --recursive
+
+    # Check out desired branch
+    git checkout ${BRANCH}
+
+    # Custom addition
+    if [ "${CHERRY}" != "" ]; then
+        echo ----- WARNING: adding git cherry-pick -----
+        for commit in "${CHERRY[@]}"
+        do
+            echo ${commit}
+            git cherry-pick ${commit}
+        done
+        echo -------------------------------------------
+    fi
+
+    # Bring in all submodule components
+    git submodule update --init --recursive
+
+    popd
+}
+
+#-----------------------------------------------------
+create_newcase() {
+
+    if [ "${do_create_newcase,,}" != "true" ]; then
+        echo $'\n----- Skipping create_newcase -----\n'
+        return
+    fi
+
+    echo $'\n----- Starting create_newcase -----\n'
+
+    if [[ ${PELAYOUT} == custom-* ]];
+    then
+        layout="M" # temporary placeholder for create_newcase
+    else
+        layout=${PELAYOUT}
+
+    fi
+    ${CODE_ROOT}/cime/scripts/create_newcase \
+        --case ${CASE_NAME} \
+        --output-root ${CASE_ROOT} \
+        --script-root ${CASE_SCRIPTS_DIR} \
+        --handle-preexisting-dirs u \
+        --compset ${COMPSET} \
+        --res ${RESOLUTION} \
+        --machine ${MACHINE} \
+        --project ${PROJECT} \
+        --walltime ${WALLTIME} \
+        --pecount ${layout}
+
+    if [ $? != 0 ]; then
+      echo $'\nNote: if create_newcase failed because sub-directory already exists:'
+      echo $'  * delete old case_script sub-directory'
+      echo $'  * or set do_newcase=false\n'
+      exit 35
+    fi
+
+}
+
+#-----------------------------------------------------
+case_setup() {
+
+    if [ "${do_case_setup,,}" != "true" ]; then
+        echo $'\n----- Skipping case_setup -----\n'
+        return
+    fi
+
+    echo $'\n----- Starting case_setup -----\n'
+    pushd ${CASE_SCRIPTS_DIR}
+
+    # Source Mods copy .F90 files to src.*
+    # cp ${HOME}/source_files/E3SMv2_UCI-MZT-MSC_20220629/mo_gas_phase_chemdr.F90   ${CASE_SCRIPTS_DIR}/SourceMods/src.eam/mo_gas_phase_chemdr.F90
+
+    # Setup some CIME directories
+    ./xmlchange EXEROOT=${CASE_BUILD_DIR}
+    ./xmlchange RUNDIR=${CASE_RUN_DIR}
+
+    # Short term archiving
+    ./xmlchange DOUT_S=${DO_SHORT_TERM_ARCHIVING^^}
+    ./xmlchange DOUT_S_ROOT=${CASE_ARCHIVE_DIR}
+
+    # Build with COSP, except for a data atmosphere (datm)
+    if [ `./xmlquery --value COMP_ATM` == "datm"  ]; then 
+      echo $'\nThe specified configuration uses a data atmosphere, so cannot activate COSP simulator\n'
+    else
+      echo $'\nConfiguring E3SM to use the COSP simulator\n'
+      ./xmlchange --id CAM_CONFIG_OPTS --append --val='-cosp'
+    fi
+
+    # Extracts input_data_dir in case it is needed for user edits to the namelist later
+    local input_data_dir=`./xmlquery DIN_LOC_ROOT --value`
+
+    # MW changing chemistry mechanism
+    local usr_mech_infile="$CODE_ROOT/components/eam/chem_proc/inputs/pp_chemUCI_linozv3_mam5_vbs.in"
+    echo 'Changing chemistry to :'${usr_mech_infile} for the 4th full smoke config to be consistent with chem package reset below
+    ./xmlchange --id CAM_CONFIG_OPTS --append --val='-chem superfast_mam5_resus_mom_vbs_mosaic -vbs -usr_mech_infile '${usr_mech_infile}
+
+    # Custom user_nl
+    user_nl
+
+    # Finally, run CIME case.setup
+    ./case.setup --reset
+
+    popd
+}
+
+#-----------------------------------------------------
+case_build() {
+
+    pushd ${CASE_SCRIPTS_DIR}
+
+    # do_case_build = false
+    if [ "${do_case_build,,}" != "true" ]; then
+
+        echo $'\n----- case_build -----\n'
+
+        if [ "${OLD_EXECUTABLE}" == "" ]; then
+            # Ues previously built executable, make sure it exists
+            if [ -x ${CASE_BUILD_DIR}/e3sm.exe ]; then
+                echo 'Skipping build because $do_case_build = '${do_case_build}
+            else
+                echo 'ERROR: $do_case_build = '${do_case_build}' but no executable exists for this case.'
+                exit 297
+            fi
+        else
+            # If absolute pathname exists and is executable, reuse pre-exiting executable
+            if [ -x ${OLD_EXECUTABLE} ]; then
+                echo 'Using $OLD_EXECUTABLE = '${OLD_EXECUTABLE}
+                cp -fp ${OLD_EXECUTABLE} ${CASE_BUILD_DIR}/
+            else
+                echo 'ERROR: $OLD_EXECUTABLE = '$OLD_EXECUTABLE' does not exist or is not an executable file.'
+                exit 297
+            fi
+        fi
+        echo 'WARNING: Setting BUILD_COMPLETE = TRUE.  This is a little risky, but trusting the user.'
+        ./xmlchange BUILD_COMPLETE=TRUE
+
+    # do_case_build = true
+    else
+
+        echo $'\n----- Starting case_build -----\n'
+
+        # Turn on debug compilation option if requested
+        if [ "${DEBUG_COMPILE^^}" == "TRUE" ]; then
+            ./xmlchange DEBUG=${DEBUG_COMPILE^^}
+        fi
+
+        # Run CIME case.build
+        ./case.build
+
+    fi
+
+    # Some user_nl settings won't be updated to *_in files under the run directory
+    # Call preview_namelists to make sure *_in and user_nl files are consistent.
+    echo $'\n----- Preview namelists -----\n'
+    ./preview_namelists
+
+    popd
+}
+
+#-----------------------------------------------------
+runtime_options() {
+
+    echo $'\n----- Starting runtime_options -----\n'
+    pushd ${CASE_SCRIPTS_DIR}
+
+    # Set simulation start date
+    ./xmlchange RUN_STARTDATE=${START_DATE}
+
+    # Segment length
+    ./xmlchange STOP_OPTION=${STOP_OPTION,,},STOP_N=${STOP_N}
+
+    # Restart frequency
+    ./xmlchange REST_OPTION=${REST_OPTION,,},REST_N=${REST_N}
+
+    # Coupler history
+    ./xmlchange HIST_OPTION=${HIST_OPTION,,},HIST_N=${HIST_N}
+
+    # Coupler budgets (always on)
+    ./xmlchange BUDGETS=TRUE
+
+    # Set resubmissions
+    if (( RESUBMIT > 0 )); then
+        ./xmlchange RESUBMIT=${RESUBMIT}
+    fi
+
+    # Run type
+    # Start from default of user-specified initial conditions
+    if [ "${MODEL_START_TYPE,,}" == "initial" ]; then
+        ./xmlchange RUN_TYPE="startup"
+        ./xmlchange CONTINUE_RUN="FALSE"
+
+    # Continue existing run
+    elif [ "${MODEL_START_TYPE,,}" == "continue" ]; then
+        ./xmlchange CONTINUE_RUN="TRUE"
+
+    elif [ "${MODEL_START_TYPE,,}" == "branch" ] || [ "${MODEL_START_TYPE,,}" == "hybrid" ]; then
+        ./xmlchange RUN_TYPE=${MODEL_START_TYPE,,}
+        ./xmlchange GET_REFCASE=${GET_REFCASE}
+        ./xmlchange RUN_REFDIR=${RUN_REFDIR}
+        ./xmlchange RUN_REFCASE=${RUN_REFCASE}
+        ./xmlchange RUN_REFDATE=${RUN_REFDATE}
+        echo 'Warning: $MODEL_START_TYPE = '${MODEL_START_TYPE} 
+        echo '$RUN_REFDIR = '${RUN_REFDIR}
+        echo '$RUN_REFCASE = '${RUN_REFCASE}
+        echo '$RUN_REFDATE = '${START_DATE}
+    else
+        echo 'ERROR: $MODEL_START_TYPE = '${MODEL_START_TYPE}' is unrecognized. Exiting.'
+        exit 380
+    fi
+
+    # Patch mpas streams files
+    patch_mpas_streams
+
+    popd
+}
+
+#-----------------------------------------------------
+case_submit() {
+
+    if [ "${do_case_submit,,}" != "true" ]; then
+        echo $'\n----- Skipping case_submit -----\n'
+        return
+    fi
+
+    echo $'\n----- Starting case_submit -----\n'
+    pushd ${CASE_SCRIPTS_DIR}
+    
+    # Run CIME case.submit
+    ./case.submit
+
+    popd
+}
+
+#-----------------------------------------------------
+copy_script() {
+
+    echo $'\n----- Saving run script for provenance -----\n'
+
+    local script_provenance_dir=${CASE_SCRIPTS_DIR}/run_script_provenance
+    mkdir -p ${script_provenance_dir}
+    local this_script_name=`basename $0`
+    local script_provenance_name=${this_script_name}.`date +%Y%m%d-%H%M%S`
+    cp -vp ${this_script_name} ${script_provenance_dir}/${script_provenance_name}
+
+}
+
+#-----------------------------------------------------
+# Silent versions of popd and pushd
+pushd() {
+    command pushd "$@" > /dev/null
+}
+popd() {
+    command popd "$@" > /dev/null
+}
+
+# Now, actually run the script
+#-----------------------------------------------------
+main
+

--- a/run.NGD_v3atm.F1850.sh
+++ b/run.NGD_v3atm.F1850.sh
@@ -309,7 +309,10 @@ cat << EOF >> user_nl_elm
  !comment out finidat if running hybrid type
 
  finidat = '\${DIN_LOC_ROOT}/lnd/clm2/initdata/NGD_v3atm.ne30pg2_EC30to60E2r2.elm.r.0001-01-01-00000.c20230106.nc'
- flanduse_timeseries = '\${DIN_LOC_ROOT}/lnd/clm2/surfdata_map/landuse.timeseries_ne30np4.pg2_hist_simyr1850-2015_c210113.nc'
+
+ ! If using the above finidat for 1850, also set the following, esp. the 2nd one
+  check_finidat_fsurdat_consistency = .false.
+  check_finidat_pct_consistency   = .false.
 EOF
 
 }

--- a/run.NGD_v3atm.F2010.sh
+++ b/run.NGD_v3atm.F2010.sh
@@ -307,7 +307,9 @@ cat << EOF >> user_nl_elm
  !comment out finidat if running hybrid type
 
  finidat = '\${DIN_LOC_ROOT}/lnd/clm2/initdata/NGD_v3atm.ne30pg2_EC30to60E2r2.elm.r.0001-01-01-00000.c20230106.nc'
- flanduse_timeseries = '\${DIN_LOC_ROOT}/lnd/clm2/surfdata_map/landuse.timeseries_ne30np4.pg2_hist_simyr1850-2015_c210113.nc'
+ ! If using the above finidat for 1850, also set the following, esp. the 2nd one
+  check_finidat_fsurdat_consistency = .false.
+  check_finidat_pct_consistency   = .false.
 EOF
 
 }

--- a/run.NGD_v3atm.F20TR.sh
+++ b/run.NGD_v3atm.F20TR.sh
@@ -197,7 +197,7 @@ nhtfrq =   0,-24,-6,-6,-3,-24,0
  seasalt_emis_scale     =  0.55D0
 
  tracer_cnst_cycle_yr           = 1995
- tracer_cnst_datapath           = '/lcrc/group/e3sm/data/inputdata/atm/cam/chem/methane/'
+ tracer_cnst_datapath           = '\$DIN_LOC_ROOT/atm/cam/chem/methane/'
  tracer_cnst_file               = 'ch4_oxid_1.9x2.5_L26_1990-1999clim.c090804.nc'
  tracer_cnst_filelist           = ''
  tracer_cnst_specifier          = 'CH4','cnst_NO3:NO3', 'cnst_OH:OH'
@@ -205,7 +205,7 @@ nhtfrq =   0,-24,-6,-6,-3,-24,0
 
  linoz_psc_t = 198.0
 
- sad_file               = '/lcrc/group/e3sm/data/inputdata/atm/waccm/sulf/SAD_SULF_1849-2100_1.9x2.5_c090817.nc'
+ sad_file               = '\$DIN_LOC_ROOT/atm/waccm/sulf/SAD_SULF_1849-2100_1.9x2.5_c090817.nc'
  sad_type     = 'SERIAL' 
 
  drydep_list = 'O3','H2O2','CH2O','CH3OOH','NO','NO2','HNO3','HO2NO2','PAN','CO','CH3COCH3','C2H5OOH','CH3CHO','H2SO4','SO2','NO3','N2O5'
@@ -213,85 +213,83 @@ nhtfrq =   0,-24,-6,-6,-3,-24,0
  gas_wetdep_list                = 'C2H5OOH','CH2O','CH3CHO','CH3OOH','H2O2','H2SO4','HNO3','HO2NO2','SO2','SOAG0','SOAG15','SOAG24','SOAG35','SOAG34','SOAG33','SOAG32','SOAG31'
  gas_wetdep_method              = 'NEU'
  
- ext_frc_specifier              = 'NO2    -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_NO2_aircraft_vertical_1750-2015_1.9x2.5_c20170608.nc',
-         'SO2    -> /lcrc/group/e3sm/ac.mwu/inputdata/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_elev_1850-2014_c180205_kzm_1850_2014_volcano.nc', 
-         'SOAG0  -> /lcrc/group/e3sm/ac.mwu/inputdata/cam/chem/emis/test/SOC_ELEV_CEDS_1985_2014_QZRNGDAMIP_F4.nc',
-         'bc_a4  -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_elev_1850-2014_c180205.nc',
-         'num_a1 -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_elev_1850-2014_c180205.nc',
-         'num_a2 -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_elev_1850-2014_c180205.nc',
-         'num_a4 -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_elev_1850-2014_c180205.nc',
-         'pom_a4 -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_elev_1850-2014_c180205.nc',
-         'so4_a1 -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_elev_1850-2014_c180205.nc',
-         'so4_a2 -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_elev_1850-2014_c180205.nc' 
+ ext_frc_specifier              = 'NO2    -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_NO2_aircraft_vertical_1750-2015_1.9x2.5_c20170608.nc',
+         'SO2    -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_elev_1850-2014_c180205_kzm_1850_2014_volcano.nc', 
+         'SOAG0  -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/emissions-cmip6_e3sm_SOAG0_elev_1850-2014_1.9x2.5_c20230201.nc',
+         'bc_a4  -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_elev_1850-2014_c180205.nc',
+         'num_a1 -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_elev_1850-2014_c180205.nc',
+         'num_a2 -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_elev_1850-2014_c180205.nc',
+         'num_a4 -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_elev_1850-2014_c180205.nc',
+         'pom_a4 -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_elev_1850-2014_c180205.nc',
+         'so4_a1 -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_elev_1850-2014_c180205.nc',
+         'so4_a2 -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_elev_1850-2014_c180205.nc' 
  ext_frc_type           = 'INTERP_MISSING_MONTHS'
- srf_emis_specifier             = 'C2H4     -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_C2H4_surface_1850-2014_1.9x2.5_c20210323.nc', 
-         'C2H6     -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_C2H6_surface_1850-2014_1.9x2.5_c20210323.nc', 
-         'C3H8     -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_C3H8_surface_1850-2014_1.9x2.5_c20210323.nc',
-         'CH2O     -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CH2O_surface_1850-2014_1.9x2.5_c20210323.nc',
-         'CH3CHO   -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CH3CHO_surface_1850-2014_1.9x2.5_c20210323.nc',
-         'CH3COCH3 -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CH3COCH3_surface_1850-2014_1.9x2.5_c20210323.nc',
-         'CO       -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CO_surface_1850-2014_1.9x2.5_c20210323.nc',       
-         'ISOP     -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_ISOP_surface_1850-2014_1.9x2.5_c20210323.nc',
-         'C10H16   -> /lcrc/group/e3sm/ac.mwu/inputdata/cam/chem/emis/CMIP6_emissions_1750_2015_2deg_FINAL/emissions-cmip6_e3sm_MTERP_surface_1850-2014_1.9x2.5_c20220426.nc',         
-         'SOAG0    -> /lcrc/group/e3sm/ac.mwu/inputdata/cam/chem/emis/test/SOC_CEDS_1985_2014_QZRNGDAMIP_F4.nc',
-         'NO       -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_NO_surface_1850-2014_1.9x2.5_c20220425.nc',    
-         'DMS      -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/DMSflux.1850-2100.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160727.nc',
-         'SO2      -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_surf_1850-2014_c180205.nc',
-         'bc_a4    -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_surf_1850-2014_c180205.nc',
-         'num_a1   -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_surf_1850-2014_c180205.nc',
-         'num_a2   -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_surf_1850-2014_c180205.nc',
-         'num_a4   -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_surf_1850-2014_c180205.nc',
-         'pom_a4   -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_surf_1850-2014_c180205.nc',
-         'so4_a1   -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_surf_1850-2014_c180205.nc',
-         'so4_a2   -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_surf_1850-2014_c180205.nc',
-         'E90      -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions_E90_surface_1750-2015_1.9x2.5_c20210408.nc'
+ srf_emis_specifier             = 'C2H4     -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_C2H4_surface_1850-2014_1.9x2.5_c20210323.nc', 
+         'C2H6     -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_C2H6_surface_1850-2014_1.9x2.5_c20210323.nc', 
+         'C3H8     -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_C3H8_surface_1850-2014_1.9x2.5_c20210323.nc',
+         'CH2O     -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CH2O_surface_1850-2014_1.9x2.5_c20210323.nc',
+         'CH3CHO   -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CH3CHO_surface_1850-2014_1.9x2.5_c20210323.nc',
+         'CH3COCH3 -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CH3COCH3_surface_1850-2014_1.9x2.5_c20210323.nc',
+         'CO       -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CO_surface_1850-2014_1.9x2.5_c20210323.nc',       
+         'ISOP     -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_ISOP_surface_1850-2014_1.9x2.5_c20210323.nc',
+         'C10H16   -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_MTERP_surface_1850-2014_1.9x2.5_c20230126.nc',         
+         'SOAG0    -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/emissions-cmip6_e3sm_SOAG0_surf_1850-2014_1.9x2.5_c20230201.nc',
+         'NO       -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_NO_surface_1850-2014_1.9x2.5_c20220425.nc',    
+         'DMS      -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DMSflux.1850-2100.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160727.nc',
+         'SO2      -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_surf_1850-2014_c180205.nc',
+         'bc_a4    -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_surf_1850-2014_c180205.nc',
+         'num_a1   -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_surf_1850-2014_c180205.nc',
+         'num_a2   -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_surf_1850-2014_c180205.nc',
+         'num_a4   -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_surf_1850-2014_c180205.nc',
+         'pom_a4   -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_surf_1850-2014_c180205.nc',
+         'so4_a1   -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_surf_1850-2014_c180205.nc',
+         'so4_a2   -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_surf_1850-2014_c180205.nc',
+         'E90      -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions_E90_surface_1750-2015_1.9x2.5_c20210408.nc'
  srf_emis_type          = 'INTERP_MISSING_MONTHS'
 
  mode_defs = 'mam5_mode1:accum:=', 'A:num_a1:N:num_c1:num_mr:+',
-         'A:so4_a1:N:so4_c1:sulfate:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/sulfate_rrtmg_c080918.nc:+',
-         'A:pom_a1:N:pom_c1:p-organic:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/ocpho_rrtmg_c130709.nc:+',
-         'A:soa_a1:N:soa_c1:s-organic:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/ocphi_rrtmg_c100508.nc:+',
-         'A:bc_a1:N:bc_c1:black-c:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/bcpho_rrtmg_c100508.nc:+',
-         'A:dst_a1:N:dst_c1:dust:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/dust_aeronet_rrtmg_c141106.nc:+',
-         'A:ncl_a1:N:ncl_c1:seasalt:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/ssam_rrtmg_c100508.nc:+',
-         'A:mom_a1:N:mom_c1:m-organic:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/poly_rrtmg_c130816.nc:',
+         'A:so4_a1:N:so4_c1:sulfate:\$DIN_LOC_ROOT/atm/cam/physprops/sulfate_rrtmg_c080918.nc:+',
+         'A:pom_a1:N:pom_c1:p-organic:\$DIN_LOC_ROOT/atm/cam/physprops/ocpho_rrtmg_c130709.nc:+',
+         'A:soa_a1:N:soa_c1:s-organic:\$DIN_LOC_ROOT/atm/cam/physprops/ocphi_rrtmg_c100508.nc:+',
+         'A:bc_a1:N:bc_c1:black-c:\$DIN_LOC_ROOT/atm/cam/physprops/bcpho_rrtmg_c100508.nc:+',
+         'A:dst_a1:N:dst_c1:dust:\$DIN_LOC_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_c141106.nc:+',
+         'A:ncl_a1:N:ncl_c1:seasalt:\$DIN_LOC_ROOT/atm/cam/physprops/ssam_rrtmg_c100508.nc:+',
+         'A:mom_a1:N:mom_c1:m-organic:\$DIN_LOC_ROOT/atm/cam/physprops/poly_rrtmg_c130816.nc:',
          'mam5_mode2:aitken:=', 'A:num_a2:N:num_c2:num_mr:+',
-         'A:so4_a2:N:so4_c2:sulfate:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/sulfate_rrtmg_c080918.nc:+',
-         'A:soa_a2:N:soa_c2:s-organic:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/ocphi_rrtmg_c100508.nc:+',
-         'A:ncl_a2:N:ncl_c2:seasalt:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/ssam_rrtmg_c100508.nc:+',
-         'A:mom_a2:N:mom_c2:m-organic:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/poly_rrtmg_c130816.nc:',
+         'A:so4_a2:N:so4_c2:sulfate:\$DIN_LOC_ROOT/atm/cam/physprops/sulfate_rrtmg_c080918.nc:+',
+         'A:soa_a2:N:soa_c2:s-organic:\$DIN_LOC_ROOT/atm/cam/physprops/ocphi_rrtmg_c100508.nc:+',
+         'A:ncl_a2:N:ncl_c2:seasalt:\$DIN_LOC_ROOT/atm/cam/physprops/ssam_rrtmg_c100508.nc:+',
+         'A:mom_a2:N:mom_c2:m-organic:\$DIN_LOC_ROOT/atm/cam/physprops/poly_rrtmg_c130816.nc:',
          'mam5_mode3:coarse:=', 'A:num_a3:N:num_c3:num_mr:+',
-         'A:dst_a3:N:dst_c3:dust:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/dust_aeronet_rrtmg_c141106.nc:+',
-         'A:ncl_a3:N:ncl_c3:seasalt:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/ssam_rrtmg_c100508.nc:+',
-         'A:so4_a3:N:so4_c3:sulfate:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/sulfate_rrtmg_c080918.nc:+',
-         'A:bc_a3:N:bc_c3:black-c:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/bcpho_rrtmg_c100508.nc:+',
-         'A:pom_a3:N:pom_c3:p-organic:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/ocpho_rrtmg_c130709.nc:+',
-         'A:soa_a3:N:soa_c3:s-organic:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/ocphi_rrtmg_c100508.nc:+',
-         'A:mom_a3:N:mom_c3:m-organic:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/poly_rrtmg_c130816.nc:',
+         'A:dst_a3:N:dst_c3:dust:\$DIN_LOC_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_c141106.nc:+',
+         'A:ncl_a3:N:ncl_c3:seasalt:\$DIN_LOC_ROOT/atm/cam/physprops/ssam_rrtmg_c100508.nc:+',
+         'A:so4_a3:N:so4_c3:sulfate:\$DIN_LOC_ROOT/atm/cam/physprops/sulfate_rrtmg_c080918.nc:+',
+         'A:bc_a3:N:bc_c3:black-c:\$DIN_LOC_ROOT/atm/cam/physprops/bcpho_rrtmg_c100508.nc:+',
+         'A:pom_a3:N:pom_c3:p-organic:\$DIN_LOC_ROOT/atm/cam/physprops/ocpho_rrtmg_c130709.nc:+',
+         'A:soa_a3:N:soa_c3:s-organic:\$DIN_LOC_ROOT/atm/cam/physprops/ocphi_rrtmg_c100508.nc:+',
+         'A:mom_a3:N:mom_c3:m-organic:\$DIN_LOC_ROOT/atm/cam/physprops/poly_rrtmg_c130816.nc:',
          'mam5_mode4:primary_carbon:=', 'A:num_a4:N:num_c4:num_mr:+',
-         'A:pom_a4:N:pom_c4:p-organic:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/ocpho_rrtmg_c130709.nc:+',
-         'A:bc_a4:N:bc_c4:black-c:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/bcpho_rrtmg_c100508.nc:+',
-         'A:mom_a4:N:mom_c4:m-organic:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/poly_rrtmg_c130816.nc',
+         'A:pom_a4:N:pom_c4:p-organic:\$DIN_LOC_ROOT/atm/cam/physprops/ocpho_rrtmg_c130709.nc:+',
+         'A:bc_a4:N:bc_c4:black-c:\$DIN_LOC_ROOT/atm/cam/physprops/bcpho_rrtmg_c100508.nc:+',
+         'A:mom_a4:N:mom_c4:m-organic:\$DIN_LOC_ROOT/atm/cam/physprops/poly_rrtmg_c130816.nc',
          'mam5_mode5:strat_coarse:=', 'A:num_a5:N:num_c5:num_mr:+',
-         'A:so4_a5:N:so4_c5:sulfate:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/sulfate_rrtmg_c080918.nc'
+         'A:so4_a5:N:so4_c5:sulfate:\$DIN_LOC_ROOT/atm/cam/physprops/sulfate_rrtmg_c080918.nc'
 
  rad_climate            = 'A:H2OLNZ:H2O', 'N:O2:O2', 'N:CO2:CO2',
          'A:O3:O3', 'A:N2OLNZ:N2O', 'A:CH4LNZ:CH4',
          'N:CFC11:CFC11', 'N:CFC12:CFC12', 
-         'M:mam5_mode1:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/mam4_mode1_rrtmg_aeronetdust_c141106.nc',
-         'M:mam5_mode2:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/mam4_mode2_rrtmg_c130628.nc', 
-         'M:mam5_mode3:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/mam4_mode3_rrtmg_aeronetdust_c141106.nc',
-         'M:mam5_mode4:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/mam4_mode4_rrtmg_c130628.nc',
-         'M:mam5_mode5:/lcrc/group/e3sm/ac.mwu/inputdata/cam/physprops/mam4_mode3_rrtmg_aeronetdust_sig1.2_dgnl.40_c150219_ke.nc'
+         'M:mam5_mode1:\$DIN_LOC_ROOT/atm/cam/physprops/mam4_mode1_rrtmg_aeronetdust_c141106.nc',
+         'M:mam5_mode2:\$DIN_LOC_ROOT/atm/cam/physprops/mam4_mode2_rrtmg_c130628.nc', 
+         'M:mam5_mode3:\$DIN_LOC_ROOT/atm/cam/physprops/mam4_mode3_rrtmg_aeronetdust_c141106.nc',
+         'M:mam5_mode4:\$DIN_LOC_ROOT/atm/cam/physprops/mam4_mode4_rrtmg_c130628.nc',
+         'M:mam5_mode5:\$DIN_LOC_ROOT/atm/cam/physprops/mam4_mode3_rrtmg_aeronetdust_sig1.2_dgnl.40_c150219_ke.nc'
 ! rad_diag_1 = 'A:H2OLNZ:H2O','N:O2:O2','N:CO2:CO2','A:O3:O3','A:N2OLNZ:N2O','A:CH4LNZ:CH4','N:CFC11:CFC11','N:CFC12:CFC12'
 
 
  cflx_cpl_opt = 2
 
- soil_erod_file         = '/lcrc/group/e3sm/data/inputdata/atm/cam/dst/dst_1.9x2.5_c090203.nc'
+ soil_erod_file         = '\$DIN_LOC_ROOT/atm/cam/dst/dst_1.9x2.5_c090203.nc'
 
- megan_factors_file = '/lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart/emis/megan21_emis_factors_c20130304.nc'
- megan_specifier = 'C10H16 = myrcene + sabinene + limonene + carene_3 + ocimene_t_b + pinene_b + pinene_a + 2met_styrene + cymene_p + cymene_o + phellandrene_a + thujene_a + terpinene_a + terpinene_g + terpinolene + phellandrene_b + camphene + bornene + fenchene_a + ocimene_al + ocimene_c_b'
 
 EOF
 
@@ -303,8 +301,8 @@ cat << EOF >> user_nl_elm
  hist_avgflag_pertape = 'A','A'
  check_finidat_year_consistency = .false.
  check_dynpft_consistency = .false.
- fsurdat = '${input_data_dir}/lnd/clm2/surfdata_map/surfdata_ne30pg2_simyr1850_c210402.nc'
- flanduse_timeseries = '${input_data_dir}/lnd/clm2/surfdata_map/landuse.timeseries_ne30np4.pg2_hist_simyr1850-2015_c210113.nc'
+ fsurdat = '\$DIN_LOC_ROOT/lnd/clm2/surfdata_map/surfdata_ne30pg2_simyr1850_c210402.nc'
+ flanduse_timeseries = '\$DIN_LOC_ROOT/lnd/clm2/surfdata_map/landuse.timeseries_ne30np4.pg2_hist_simyr1850-2015_c210113.nc'
 EOF
 
 }

--- a/run.NGD_v3atm.F20TR.sh
+++ b/run.NGD_v3atm.F20TR.sh
@@ -1,0 +1,658 @@
+#!/bin/bash -fe
+
+# E3SM Water Cycle v2 run_e3sm script template.
+#
+# Inspired by v1 run_e3sm script as well as SCREAM group simplified run script.
+#
+# Bash coding style inspired by:
+# http://kfirlavi.herokuapp.com/blog/2012/11/14/defensive-bash-programming
+
+main() {
+
+# For debugging, uncomment libe below
+#set -x
+
+# --- Configuration flags ----
+
+# Machine and project
+readonly MACHINE=chrysalis
+readonly PROJECT="e3sm"
+
+# Simulation
+readonly COMPSET="F20TR_chemUCI-Linozv3"
+readonly RESOLUTION="ne30pg2_EC30to60E2r2"
+readonly CASE_NAME="20230221.NGD_v3atm.F20TR"
+
+# Code and compilation
+readonly CHECKOUT="20230223"
+readonly BRANCH="NGD_v3atm_v2.1ocnice_alt" 
+readonly CHERRY=( )
+readonly DEBUG_COMPILE=false
+
+# Run options
+readonly MODEL_START_TYPE="hybrid"  # 'initial', 'continue', 'branch', 'hybrid'
+readonly START_DATE="1985-01-01"
+
+# Additional options for 'branch' and 'hybrid'
+readonly GET_REFCASE=TRUE
+readonly RUN_REFDIR="/lcrc/group/e3sm/ac.mwu/archive/20220504.v2.LR.bi-grid.amip.chemMZT.chrysalis/archive/rest/1985-01-01-00000"
+readonly RUN_REFCASE="20220504.v2.LR.bi-grid.amip.chemMZT.chrysalis"
+readonly RUN_REFDATE="1985-01-01"
+
+# Set paths
+readonly CODE_ROOT="/home/ac.wlin/E3SM/integration/v3atm-work"
+readonly CASE_ROOT="/lcrc/group/e3sm/${USER}/E3SM_testings/v3atm/${CASE_NAME}"
+readonly MY_INPUT_DATA_PATH="/lcrc/group/e3sm/ac.mwu/inputdata"
+
+# Sub-directories
+readonly CASE_BUILD_DIR=${CASE_ROOT}/build
+readonly CASE_ARCHIVE_DIR=${CASE_ROOT}/archive
+
+# Define type of run
+#  short tests: 'S_2x5_ndays', 'M_1x10_ndays', 'M80_1x10_ndays'
+#  or 'production' for full simulation
+#readonly run='production'
+
+readonly run='production'
+#readonly run='custom-30_1x10_ndays'
+#readonly run='custom-10_2x5_ndays'
+#readonly run='custom-10_1x10_ndays'
+
+if [ "${run}" != "production" ]; then
+
+  # Short test simulations
+  tmp=($(echo $run | tr "_" " "))
+  layout=${tmp[0]}
+  units=${tmp[2]}
+  resubmit=$(( ${tmp[1]%%x*} -1 ))
+  length=${tmp[1]##*x}
+
+  readonly CASE_SCRIPTS_DIR=${CASE_ROOT}/tests/${run}/case_scripts
+  readonly CASE_RUN_DIR=${CASE_ROOT}/tests/${run}/run
+  #readonly PELAYOUT=${layout}
+  readonly PELAYOUT="custom-30"
+  readonly WALLTIME="6:00:00"
+  readonly STOP_OPTION=${units}
+  readonly STOP_N=${length}
+  readonly REST_OPTION=${STOP_OPTION}
+  readonly REST_N=${STOP_N}
+  readonly RESUBMIT=${resubmit}
+  readonly DO_SHORT_TERM_ARCHIVING=false
+
+else
+
+  # Production simulation
+  readonly CASE_SCRIPTS_DIR=${CASE_ROOT}/case_scripts
+  readonly CASE_RUN_DIR=${CASE_ROOT}/run
+  #readonly PELAYOUT="M"
+  readonly PELAYOUT="custom-30"
+  readonly WALLTIME="34:00:00"
+  readonly STOP_OPTION="nyears"
+  readonly STOP_N="15"
+  readonly REST_OPTION="nyears"
+  readonly REST_N="5"
+  readonly RESUBMIT="0"
+  readonly DO_SHORT_TERM_ARCHIVING=false
+fi
+
+# Coupler history 
+readonly HIST_OPTION="nyears"
+readonly HIST_N="1"
+
+# Leave empty (unless you understand what it does)
+readonly OLD_EXECUTABLE=""
+
+# --- Toggle flags for what to do ----
+do_fetch_code=false
+do_create_newcase=true
+do_case_setup=true
+do_case_build=true
+do_case_submit=true
+
+# --- Now, do the work ---
+
+# Make directories created by this script world-readable
+umask 022
+
+# Fetch code from Github
+fetch_code
+
+# Create case
+create_newcase
+
+# Custom PE layout
+custom_pelayout
+
+# Setup
+case_setup
+
+# Build
+case_build
+
+# Configure runtime options
+runtime_options
+
+# Copy script into case_script directory for provenance
+copy_script
+
+# Submit
+case_submit
+
+# All done
+echo $'\n----- All done -----\n'
+
+}
+
+# =======================
+# Custom user_nl settings
+# =======================
+
+user_nl() {
+
+cat << EOF >> user_nl_eam
+nhtfrq =   0,-24,-6,-6,-3,-24,0
+ mfilt  = 1,30,120,120,240,30,1
+ avgflag_pertape = 'A','A','I','A','A','A','I'
+ fexcl1 = 'CFAD_SR532_CAL', 'LINOZ_DO3', 'LINOZ_DO3_PSC', 'LINOZ_O3CLIM', 'LINOZ_O3COL', 'LINOZ_SSO3', 'hstobie_linoz'
+ fincl1 = 'extinct_sw_inp','extinct_lw_bnd7','extinct_lw_inp','CLD_CAL', 'TREFMNAV', 'TREFMXAV'
+ fincl2 = 'FLUT','PRECT','U200','V200','U850','V850','Z500','OMEGA500','UBOT','VBOT','TREFHT','TREFHTMN:M','TREFHTMX:X','QREFHT','TS','PS','TMQ','TUQ','TVQ','TOZ', 'FLDS', 'FLNS', 'FSDS', 'FSNS', 'SHFLX', 'LHFLX', 'TGCLDCWP', 'TGCLDIWP', 'TGCLDLWP', 'CLDTOT', 'T250', 'T200', 'T150', 'T100', 'T050', 'T025', 'T010', 'T005', 'T002', 'T001', 'TTOP', 'U250', 'U150', 'U100', 'U050', 'U025', 'U010', 'U005', 'U002', 'U001', 'UTOP', 'FSNT', 'FLNT'
+ fincl3 = 'PSL','T200','T500','U850','V850','UBOT','VBOT','TREFHT', 'Z700', 'TBOT:M'
+ fincl4 = 'FLUT','U200','U850','PRECT','OMEGA500'
+ fincl5 = 'PRECT','PRECC','TUQ','TVQ','QFLX','SHFLX','U90M','V90M'
+ fincl6 = 'CLDTOT_ISCCP','MEANCLDALB_ISCCP','MEANTAU_ISCCP','MEANPTOP_ISCCP','MEANTB_ISCCP','CLDTOT_CAL','CLDTOT_CAL_LIQ','CLDTOT_CAL_ICE','CLDTOT_CAL_UN','CLDHGH_CAL','CLDHGH_CAL_LIQ','CLDHGH_CAL_ICE','CLDHGH_CAL_UN','CLDMED_CAL','CLDMED_CAL_LIQ','CLDMED_CAL_ICE','CLDMED_CAL_UN','CLDLOW_CAL','CLDLOW_CAL_LIQ','CLDLOW_CAL_ICE','CLDLOW_CAL_UN'
+ fincl7 = 'O3', 'PS', 'TROP_P'
+
+ tropopause_e90_thrd    = 80.0e-9
+ history_gaschmbudget_2D = .false.
+ history_gaschmbudget_2D_levels = .false.
+ history_UCIgaschmbudget_2D = .false.
+ history_UCIgaschmbudget_2D_levels = .false.
+ gaschmbudget_2D_L1_s =  1
+ gaschmbudget_2D_L1_e = 26
+ gaschmbudget_2D_L2_s = 27
+ gaschmbudget_2D_L2_e = 38
+ gaschmbudget_2D_L3_s = 39
+ gaschmbudget_2D_L3_e = 58
+ gaschmbudget_2D_L4_s = 59
+ gaschmbudget_2D_L4_e = 72
+! history_aero_optics    = .true.
+! history_aerosol        = .true.
+! history_amwg           = .true.
+! history_budget         = .true.
+! history_verbose        = .true.
+ cosp_lite = .true.
+ zmconv_microp = .true.
+ zmconv_clos_dyn_adj = .true.
+ zmconv_MCSP_heat_coeff = 0.3
+ zmconv_tpert_fix = .true.
+ zmconv_ke = 2.5e-6
+ p3_wbf_coeff = 1.0
+
+ sscav_tuning = .false.
+ 
+ !LWCF tuning
+ nucleate_ice_subgrid   =  1.35
+ p3_mincdnc             =  20.D6
+ dust_emis_fact         =  11.8D0
+ seasalt_emis_scale     =  0.55D0
+
+ tracer_cnst_cycle_yr           = 1995
+ tracer_cnst_datapath           = '/lcrc/group/e3sm/data/inputdata/atm/cam/chem/methane/'
+ tracer_cnst_file               = 'ch4_oxid_1.9x2.5_L26_1990-1999clim.c090804.nc'
+ tracer_cnst_filelist           = ''
+ tracer_cnst_specifier          = 'CH4','cnst_NO3:NO3', 'cnst_OH:OH'
+ tracer_cnst_type               = 'CYCLICAL'
+
+ linoz_psc_t = 198.0
+
+ sad_file               = '/lcrc/group/e3sm/data/inputdata/atm/waccm/sulf/SAD_SULF_1849-2100_1.9x2.5_c090817.nc'
+ sad_type     = 'SERIAL' 
+
+ drydep_list = 'O3','H2O2','CH2O','CH3OOH','NO','NO2','HNO3','HO2NO2','PAN','CO','CH3COCH3','C2H5OOH','CH3CHO','H2SO4','SO2','NO3','N2O5'
+
+ gas_wetdep_list                = 'C2H5OOH','CH2O','CH3CHO','CH3OOH','H2O2','H2SO4','HNO3','HO2NO2','SO2','SOAG0','SOAG15','SOAG24','SOAG35','SOAG34','SOAG33','SOAG32','SOAG31'
+ gas_wetdep_method              = 'NEU'
+ 
+ ext_frc_specifier              = 'NO2    -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_NO2_aircraft_vertical_1750-2015_1.9x2.5_c20170608.nc',
+         'SO2    -> /lcrc/group/e3sm/ac.mwu/inputdata/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_elev_1850-2014_c180205_kzm_1850_2014_volcano.nc', 
+         'SOAG0  -> /lcrc/group/e3sm/ac.mwu/inputdata/cam/chem/emis/test/SOC_ELEV_CEDS_1985_2014_QZRNGDAMIP_F4.nc',
+         'bc_a4  -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_elev_1850-2014_c180205.nc',
+         'num_a1 -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_elev_1850-2014_c180205.nc',
+         'num_a2 -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_elev_1850-2014_c180205.nc',
+         'num_a4 -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_elev_1850-2014_c180205.nc',
+         'pom_a4 -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_elev_1850-2014_c180205.nc',
+         'so4_a1 -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_elev_1850-2014_c180205.nc',
+         'so4_a2 -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_elev_1850-2014_c180205.nc' 
+ ext_frc_type           = 'INTERP_MISSING_MONTHS'
+ srf_emis_specifier             = 'C2H4     -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_C2H4_surface_1850-2014_1.9x2.5_c20210323.nc', 
+         'C2H6     -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_C2H6_surface_1850-2014_1.9x2.5_c20210323.nc', 
+         'C3H8     -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_C3H8_surface_1850-2014_1.9x2.5_c20210323.nc',
+         'CH2O     -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CH2O_surface_1850-2014_1.9x2.5_c20210323.nc',
+         'CH3CHO   -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CH3CHO_surface_1850-2014_1.9x2.5_c20210323.nc',
+         'CH3COCH3 -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CH3COCH3_surface_1850-2014_1.9x2.5_c20210323.nc',
+         'CO       -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CO_surface_1850-2014_1.9x2.5_c20210323.nc',       
+         'ISOP     -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_ISOP_surface_1850-2014_1.9x2.5_c20210323.nc',
+         'C10H16   -> /lcrc/group/e3sm/ac.mwu/inputdata/cam/chem/emis/CMIP6_emissions_1750_2015_2deg_FINAL/emissions-cmip6_e3sm_MTERP_surface_1850-2014_1.9x2.5_c20220426.nc',         
+         'SOAG0    -> /lcrc/group/e3sm/ac.mwu/inputdata/cam/chem/emis/test/SOC_CEDS_1985_2014_QZRNGDAMIP_F4.nc',
+         'NO       -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_NO_surface_1850-2014_1.9x2.5_c20220425.nc',    
+         'DMS      -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/DMSflux.1850-2100.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160727.nc',
+         'SO2      -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_surf_1850-2014_c180205.nc',
+         'bc_a4    -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_surf_1850-2014_c180205.nc',
+         'num_a1   -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_surf_1850-2014_c180205.nc',
+         'num_a2   -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_surf_1850-2014_c180205.nc',
+         'num_a4   -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_surf_1850-2014_c180205.nc',
+         'pom_a4   -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_surf_1850-2014_c180205.nc',
+         'so4_a1   -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_surf_1850-2014_c180205.nc',
+         'so4_a2   -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_surf_1850-2014_c180205.nc',
+         'E90      -> /lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions_E90_surface_1750-2015_1.9x2.5_c20210408.nc'
+ srf_emis_type          = 'INTERP_MISSING_MONTHS'
+
+ mode_defs = 'mam5_mode1:accum:=', 'A:num_a1:N:num_c1:num_mr:+',
+         'A:so4_a1:N:so4_c1:sulfate:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/sulfate_rrtmg_c080918.nc:+',
+         'A:pom_a1:N:pom_c1:p-organic:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/ocpho_rrtmg_c130709.nc:+',
+         'A:soa_a1:N:soa_c1:s-organic:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/ocphi_rrtmg_c100508.nc:+',
+         'A:bc_a1:N:bc_c1:black-c:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/bcpho_rrtmg_c100508.nc:+',
+         'A:dst_a1:N:dst_c1:dust:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/dust_aeronet_rrtmg_c141106.nc:+',
+         'A:ncl_a1:N:ncl_c1:seasalt:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/ssam_rrtmg_c100508.nc:+',
+         'A:mom_a1:N:mom_c1:m-organic:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/poly_rrtmg_c130816.nc:',
+         'mam5_mode2:aitken:=', 'A:num_a2:N:num_c2:num_mr:+',
+         'A:so4_a2:N:so4_c2:sulfate:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/sulfate_rrtmg_c080918.nc:+',
+         'A:soa_a2:N:soa_c2:s-organic:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/ocphi_rrtmg_c100508.nc:+',
+         'A:ncl_a2:N:ncl_c2:seasalt:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/ssam_rrtmg_c100508.nc:+',
+         'A:mom_a2:N:mom_c2:m-organic:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/poly_rrtmg_c130816.nc:',
+         'mam5_mode3:coarse:=', 'A:num_a3:N:num_c3:num_mr:+',
+         'A:dst_a3:N:dst_c3:dust:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/dust_aeronet_rrtmg_c141106.nc:+',
+         'A:ncl_a3:N:ncl_c3:seasalt:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/ssam_rrtmg_c100508.nc:+',
+         'A:so4_a3:N:so4_c3:sulfate:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/sulfate_rrtmg_c080918.nc:+',
+         'A:bc_a3:N:bc_c3:black-c:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/bcpho_rrtmg_c100508.nc:+',
+         'A:pom_a3:N:pom_c3:p-organic:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/ocpho_rrtmg_c130709.nc:+',
+         'A:soa_a3:N:soa_c3:s-organic:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/ocphi_rrtmg_c100508.nc:+',
+         'A:mom_a3:N:mom_c3:m-organic:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/poly_rrtmg_c130816.nc:',
+         'mam5_mode4:primary_carbon:=', 'A:num_a4:N:num_c4:num_mr:+',
+         'A:pom_a4:N:pom_c4:p-organic:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/ocpho_rrtmg_c130709.nc:+',
+         'A:bc_a4:N:bc_c4:black-c:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/bcpho_rrtmg_c100508.nc:+',
+         'A:mom_a4:N:mom_c4:m-organic:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/poly_rrtmg_c130816.nc',
+         'mam5_mode5:strat_coarse:=', 'A:num_a5:N:num_c5:num_mr:+',
+         'A:so4_a5:N:so4_c5:sulfate:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/sulfate_rrtmg_c080918.nc'
+
+ rad_climate            = 'A:H2OLNZ:H2O', 'N:O2:O2', 'N:CO2:CO2',
+         'A:O3:O3', 'A:N2OLNZ:N2O', 'A:CH4LNZ:CH4',
+         'N:CFC11:CFC11', 'N:CFC12:CFC12', 
+         'M:mam5_mode1:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/mam4_mode1_rrtmg_aeronetdust_c141106.nc',
+         'M:mam5_mode2:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/mam4_mode2_rrtmg_c130628.nc', 
+         'M:mam5_mode3:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/mam4_mode3_rrtmg_aeronetdust_c141106.nc',
+         'M:mam5_mode4:/lcrc/group/e3sm/data/inputdata/atm/cam/physprops/mam4_mode4_rrtmg_c130628.nc',
+         'M:mam5_mode5:/lcrc/group/e3sm/ac.mwu/inputdata/cam/physprops/mam4_mode3_rrtmg_aeronetdust_sig1.2_dgnl.40_c150219_ke.nc'
+! rad_diag_1 = 'A:H2OLNZ:H2O','N:O2:O2','N:CO2:CO2','A:O3:O3','A:N2OLNZ:N2O','A:CH4LNZ:CH4','N:CFC11:CFC11','N:CFC12:CFC12'
+
+
+ cflx_cpl_opt = 2
+
+ soil_erod_file         = '/lcrc/group/e3sm/data/inputdata/atm/cam/dst/dst_1.9x2.5_c090203.nc'
+
+ megan_factors_file = '/lcrc/group/e3sm/data/inputdata/atm/cam/chem/trop_mozart/emis/megan21_emis_factors_c20130304.nc'
+ megan_specifier = 'C10H16 = myrcene + sabinene + limonene + carene_3 + ocimene_t_b + pinene_b + pinene_a + 2met_styrene + cymene_p + cymene_o + phellandrene_a + thujene_a + terpinene_a + terpinene_g + terpinolene + phellandrene_b + camphene + bornene + fenchene_a + ocimene_al + ocimene_c_b'
+
+EOF
+
+cat << EOF >> user_nl_elm
+ hist_dov2xy = .true.,.true.
+ hist_fincl2 = 'H2OSNO', 'FSNO', 'QRUNOFF', 'QSNOMELT', 'FSNO_EFF', 'SNORDSL', 'SNOW', 'FSDS', 'FSR', 'FLDS', 'FIRE', 'FIRA'
+ hist_mfilt = 1,365
+ hist_nhtfrq = 0,-24
+ hist_avgflag_pertape = 'A','A'
+ check_finidat_year_consistency = .false.
+ check_dynpft_consistency = .false.
+ fsurdat = '${input_data_dir}/lnd/clm2/surfdata_map/surfdata_ne30pg2_simyr1850_c210402.nc'
+ flanduse_timeseries = '${input_data_dir}/lnd/clm2/surfdata_map/landuse.timeseries_ne30np4.pg2_hist_simyr1850-2015_c210113.nc'
+EOF
+
+}
+
+# =====================================
+# Customize MPAS stream files if needed
+# =====================================
+
+patch_mpas_streams() {
+
+echo
+
+}
+
+# =====================================================
+# Custom PE layout: custom-N where N is number of nodes
+# =====================================================
+
+custom_pelayout() {
+
+if [[ ${PELAYOUT} == custom-* ]];
+then
+    echo $'\n CUSTOMIZE PROCESSOR CONFIGURATION:'
+
+    # Number of cores per node (machine specific)
+    if [ "${MACHINE}" == "chrysalis" ]; then
+        ncore=64
+    elif [ "${MACHINE}" == "compy" ]; then
+        ncore=40
+    else
+        echo 'ERROR: MACHINE = '${MACHINE}' is not supported for custom PE layout.' 
+        exit 400
+    fi
+
+    # Extract number of nodes
+    tmp=($(echo ${PELAYOUT} | tr "-" " "))
+    nnodes=${tmp[1]}
+
+    # Customize
+    pushd ${CASE_SCRIPTS_DIR}
+    ./xmlchange NTASKS=$(( $nnodes * $ncore ))
+    ./xmlchange NTHRDS=1
+    ./xmlchange MAX_MPITASKS_PER_NODE=$ncore
+    ./xmlchange MAX_TASKS_PER_NODE=$ncore
+    popd
+
+fi
+
+}
+
+######################################################
+### Most users won't need to change anything below ###
+######################################################
+
+#-----------------------------------------------------
+fetch_code() {
+
+    if [ "${do_fetch_code,,}" != "true" ]; then
+        echo $'\n----- Skipping fetch_code -----\n'
+        return
+    fi
+
+    echo $'\n----- Starting fetch_code -----\n'
+    local path=${CODE_ROOT}
+    local repo=e3sm
+
+    echo "Cloning $repo repository branch $BRANCH under $path"
+    if [ -d "${path}" ]; then
+        echo "ERROR: Directory already exists. Not overwriting"
+        exit 20
+    fi
+    mkdir -p ${path}
+    pushd ${path}
+
+    # This will put repository, with all code
+    git clone git@github.com:E3SM-Project/${repo}.git .
+    
+    # Setup git hooks
+    rm -rf .git/hooks
+    git clone git@github.com:E3SM-Project/E3SM-Hooks.git .git/hooks
+    git config commit.template .git/hooks/commit.template
+
+    # Bring in all submodule components
+    git submodule update --init --recursive
+
+    # Check out desired branch
+    git checkout ${BRANCH}
+
+    # Custom addition
+    if [ "${CHERRY}" != "" ]; then
+        echo ----- WARNING: adding git cherry-pick -----
+        for commit in "${CHERRY[@]}"
+        do
+            echo ${commit}
+            git cherry-pick ${commit}
+        done
+        echo -------------------------------------------
+    fi
+
+    # Bring in all submodule components
+    git submodule update --init --recursive
+
+    popd
+}
+
+#-----------------------------------------------------
+create_newcase() {
+
+    if [ "${do_create_newcase,,}" != "true" ]; then
+        echo $'\n----- Skipping create_newcase -----\n'
+        return
+    fi
+
+    echo $'\n----- Starting create_newcase -----\n'
+
+    if [[ ${PELAYOUT} == custom-* ]];
+    then
+        layout="M" # temporary placeholder for create_newcase
+    else
+        layout=${PELAYOUT}
+
+    fi
+    ${CODE_ROOT}/cime/scripts/create_newcase \
+        --case ${CASE_NAME} \
+        --output-root ${CASE_ROOT} \
+        --script-root ${CASE_SCRIPTS_DIR} \
+        --handle-preexisting-dirs u \
+        --compset ${COMPSET} \
+        --res ${RESOLUTION} \
+        --machine ${MACHINE} \
+        --project ${PROJECT} \
+        --walltime ${WALLTIME} \
+        --pecount ${layout}
+
+    if [ $? != 0 ]; then
+      echo $'\nNote: if create_newcase failed because sub-directory already exists:'
+      echo $'  * delete old case_script sub-directory'
+      echo $'  * or set do_newcase=false\n'
+      exit 35
+    fi
+
+}
+
+#-----------------------------------------------------
+case_setup() {
+
+    if [ "${do_case_setup,,}" != "true" ]; then
+        echo $'\n----- Skipping case_setup -----\n'
+        return
+    fi
+
+    echo $'\n----- Starting case_setup -----\n'
+    pushd ${CASE_SCRIPTS_DIR}
+
+    # Source Mods copy .F90 files to src.*
+    # cp ${HOME}/source_files/E3SMv2_UCI-MZT-MSC_20220629/mo_gas_phase_chemdr.F90   ${CASE_SCRIPTS_DIR}/SourceMods/src.eam/mo_gas_phase_chemdr.F90
+
+    # Setup some CIME directories
+    ./xmlchange EXEROOT=${CASE_BUILD_DIR}
+    ./xmlchange RUNDIR=${CASE_RUN_DIR}
+
+    # Short term archiving
+    ./xmlchange DOUT_S=${DO_SHORT_TERM_ARCHIVING^^}
+    ./xmlchange DOUT_S_ROOT=${CASE_ARCHIVE_DIR}
+
+    # Build with COSP, except for a data atmosphere (datm)
+    if [ `./xmlquery --value COMP_ATM` == "datm"  ]; then 
+      echo $'\nThe specified configuration uses a data atmosphere, so cannot activate COSP simulator\n'
+    else
+      echo $'\nConfiguring E3SM to use the COSP simulator\n'
+      ./xmlchange --id CAM_CONFIG_OPTS --append --val='-cosp'
+    fi
+
+    # Extracts input_data_dir in case it is needed for user edits to the namelist later
+    local input_data_dir=`./xmlquery DIN_LOC_ROOT --value`
+
+    # MW changing chemistry mechanism, not ready to use the former, which is only after PR #43
+    # local usr_mech_infile="$CODE_ROOT/components/eam/chem_proc/inputs/pp_chemUCI_linozv3_mam5_vbs.in"
+    # local usr_mech_infile="/lcrc/group/e3sm/ac.mwu/archive/20221205.amip.NGD_v3atm.chem-mam5-vbs.chrysalis/case_scripts/Buildconf/eamconf/chem_mech.in"
+    local usr_mech_infile="$CODE_ROOT/components/eam/chem_proc/inputs/pp_chemUCI_linozv3_mam5_vbs.in"
+        echo 'MW Changing chemistry to :'${usr_mech_infile} 
+    ./xmlchange --id CAM_CONFIG_OPTS --append --val='-chem superfast_mam5_resus_mom_vbs_mosaic -vbs -usr_mech_infile '${usr_mech_infile}
+
+    # Custom user_nl
+    user_nl
+
+    # for custom-30, it seems several comp's rootpe not at 0, thus using 49 nodes
+
+    ./pelayout
+    ./xmlchange ROOTPE=0
+
+    # Finally, run CIME case.setup
+    ./case.setup --reset
+
+    popd
+}
+
+#-----------------------------------------------------
+case_build() {
+
+    pushd ${CASE_SCRIPTS_DIR}
+
+    # do_case_build = false
+    if [ "${do_case_build,,}" != "true" ]; then
+
+        echo $'\n----- case_build -----\n'
+
+        if [ "${OLD_EXECUTABLE}" == "" ]; then
+            # Ues previously built executable, make sure it exists
+            if [ -x ${CASE_BUILD_DIR}/e3sm.exe ]; then
+                echo 'Skipping build because $do_case_build = '${do_case_build}
+            else
+                echo 'ERROR: $do_case_build = '${do_case_build}' but no executable exists for this case.'
+                exit 297
+            fi
+        else
+            # If absolute pathname exists and is executable, reuse pre-exiting executable
+            if [ -x ${OLD_EXECUTABLE} ]; then
+                echo 'Using $OLD_EXECUTABLE = '${OLD_EXECUTABLE}
+                cp -fp ${OLD_EXECUTABLE} ${CASE_BUILD_DIR}/
+            else
+                echo 'ERROR: $OLD_EXECUTABLE = '$OLD_EXECUTABLE' does not exist or is not an executable file.'
+                exit 297
+            fi
+        fi
+        echo 'WARNING: Setting BUILD_COMPLETE = TRUE.  This is a little risky, but trusting the user.'
+        ./xmlchange BUILD_COMPLETE=TRUE
+
+    # do_case_build = true
+    else
+
+        echo $'\n----- Starting case_build -----\n'
+
+        # Turn on debug compilation option if requested
+        if [ "${DEBUG_COMPILE^^}" == "TRUE" ]; then
+            ./xmlchange DEBUG=${DEBUG_COMPILE^^}
+        fi
+
+        # Run CIME case.build
+        ./case.build
+
+    fi
+
+    # Some user_nl settings won't be updated to *_in files under the run directory
+    # Call preview_namelists to make sure *_in and user_nl files are consistent.
+    echo $'\n----- Preview namelists -----\n'
+    ./preview_namelists
+
+    popd
+}
+
+#-----------------------------------------------------
+runtime_options() {
+
+    echo $'\n----- Starting runtime_options -----\n'
+    pushd ${CASE_SCRIPTS_DIR}
+
+    # Set simulation start date
+    ./xmlchange RUN_STARTDATE=${START_DATE}
+
+    # Segment length
+    ./xmlchange STOP_OPTION=${STOP_OPTION,,},STOP_N=${STOP_N}
+
+    # Restart frequency
+    ./xmlchange REST_OPTION=${REST_OPTION,,},REST_N=${REST_N}
+
+    # Coupler history
+    ./xmlchange HIST_OPTION=${HIST_OPTION,,},HIST_N=${HIST_N}
+
+    # Coupler budgets (always on)
+    ./xmlchange BUDGETS=TRUE
+
+    # Set resubmissions
+    if (( RESUBMIT > 0 )); then
+        ./xmlchange RESUBMIT=${RESUBMIT}
+    fi
+
+    # Run type
+    # Start from default of user-specified initial conditions
+    if [ "${MODEL_START_TYPE,,}" == "initial" ]; then
+        ./xmlchange RUN_TYPE="startup"
+        ./xmlchange CONTINUE_RUN="FALSE"
+
+    # Continue existing run
+    elif [ "${MODEL_START_TYPE,,}" == "continue" ]; then
+        ./xmlchange CONTINUE_RUN="TRUE"
+
+    elif [ "${MODEL_START_TYPE,,}" == "branch" ] || [ "${MODEL_START_TYPE,,}" == "hybrid" ]; then
+        ./xmlchange RUN_TYPE=${MODEL_START_TYPE,,}
+        ./xmlchange GET_REFCASE=${GET_REFCASE}
+        ./xmlchange RUN_REFDIR=${RUN_REFDIR}
+        ./xmlchange RUN_REFCASE=${RUN_REFCASE}
+        ./xmlchange RUN_REFDATE=${RUN_REFDATE}
+        echo 'Warning: $MODEL_START_TYPE = '${MODEL_START_TYPE} 
+        echo '$RUN_REFDIR = '${RUN_REFDIR}
+        echo '$RUN_REFCASE = '${RUN_REFCASE}
+        echo '$RUN_REFDATE = '${START_DATE}
+    else
+        echo 'ERROR: $MODEL_START_TYPE = '${MODEL_START_TYPE}' is unrecognized. Exiting.'
+        exit 380
+    fi
+
+    # Patch mpas streams files
+    patch_mpas_streams
+
+    popd
+}
+
+#-----------------------------------------------------
+case_submit() {
+
+    if [ "${do_case_submit,,}" != "true" ]; then
+        echo $'\n----- Skipping case_submit -----\n'
+        return
+    fi
+
+    echo $'\n----- Starting case_submit -----\n'
+    pushd ${CASE_SCRIPTS_DIR}
+    
+    # Run CIME case.submit
+    ./case.submit
+
+    popd
+}
+
+#-----------------------------------------------------
+copy_script() {
+
+    echo $'\n----- Saving run script for provenance -----\n'
+
+    local script_provenance_dir=${CASE_SCRIPTS_DIR}/run_script_provenance
+    mkdir -p ${script_provenance_dir}
+    local this_script_name=`basename $0`
+    local script_provenance_name=${this_script_name}.`date +%Y%m%d-%H%M%S`
+    cp -vp ${this_script_name} ${script_provenance_dir}/${script_provenance_name}
+
+}
+
+#-----------------------------------------------------
+# Silent versions of popd and pushd
+pushd() {
+    command pushd "$@" > /dev/null
+}
+popd() {
+    command popd "$@" > /dev/null
+}
+
+# Now, actually run the script
+#-----------------------------------------------------
+main
+

--- a/run.NGD_v3atm.piControl.sh
+++ b/run.NGD_v3atm.piControl.sh
@@ -307,9 +307,11 @@ cat << EOF >> user_nl_elm
  fsurdat = '\${DIN_LOC_ROOT}/lnd/clm2/surfdata_map/surfdata_ne30pg2_simyr1850_c210402.nc'
 
  !comment out finidat if running hybrid type
-
  finidat = '\${DIN_LOC_ROOT}/lnd/clm2/initdata/NGD_v3atm.ne30pg2_EC30to60E2r2.elm.r.0001-01-01-00000.c20230106.nc'
- flanduse_timeseries = '\${DIN_LOC_ROOT}/lnd/clm2/surfdata_map/landuse.timeseries_ne30np4.pg2_hist_simyr1850-2015_c210113.nc'
+
+ ! If using the above finidat for 1850, also set the following, esp. the 2nd one
+  check_finidat_fsurdat_consistency = .false.
+  check_finidat_pct_consistency   = .false.
 EOF
 
 }

--- a/run.NGD_v3atm.piControl.sh
+++ b/run.NGD_v3atm.piControl.sh
@@ -239,7 +239,7 @@ nhtfrq =   0,-24,-6,-6,-3,-24,0
          'C10H16   -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_MTERP_surface_1850-2014_1.9x2.5_c20230126.nc',
          'SOAG0    -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/emissions-cmip6_e3sm_SOAG0_surf_1850-2014_1.9x2.5_c20230201.nc',
          'NO       -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_NO_surface_1850-2014_1.9x2.5_c20220425.nc',
-         'DMS      -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DMSflux.1850-2100.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160727.nc',
+         'DMS      -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DMSflux.1850.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160416.nc',
          'SO2      -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_surf_1850-2014_c180205.nc',
          'bc_a4    -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_surf_1850-2014_c180205.nc',
          'num_a1   -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_surf_1850-2014_c180205.nc',

--- a/run.NGD_v3atm.piControl.sh
+++ b/run.NGD_v3atm.piControl.sh
@@ -236,7 +236,7 @@ nhtfrq =   0,-24,-6,-6,-3,-24,0
          'CH3COCH3 -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CH3COCH3_surface_1850-2014_1.9x2.5_c20210323.nc',
          'CO       -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CO_surface_1850-2014_1.9x2.5_c20210323.nc',
          'ISOP     -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_ISOP_surface_1850-2014_1.9x2.5_c20210323.nc',
-         'C10H16   -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_MTERP_surface_1850-2014_1.9x2.5_c20220426.nc',
+         'C10H16   -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_MTERP_surface_1850-2014_1.9x2.5_c20230126.nc',
          'SOAG0    -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/emissions-cmip6_e3sm_SOAG0_surf_1850-2014_1.9x2.5_c20230201.nc',
          'NO       -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_NO_surface_1850-2014_1.9x2.5_c20220425.nc',
          'DMS      -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DMSflux.1850-2100.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160727.nc',

--- a/run.NGD_v3atm.piControl.sh
+++ b/run.NGD_v3atm.piControl.sh
@@ -1,0 +1,656 @@
+#!/bin/bash -fe
+
+# E3SM Water Cycle v2 run_e3sm script template.
+#
+# Inspired by v1 run_e3sm script as well as SCREAM group simplified run script.
+#
+# Bash coding style inspired by:
+# http://kfirlavi.herokuapp.com/blog/2012/11/14/defensive-bash-programming
+
+main() {
+
+# For debugging, uncomment libe below
+#set -x
+
+# --- Configuration flags ----
+
+# Machine and project
+readonly MACHINE=chrysalis
+readonly PROJECT="e3sm"
+
+# Simulation
+readonly COMPSET="WCYCL1850_chemUCI-Linozv3"
+readonly RESOLUTION="ne30pg2_EC30to60E2r2"
+readonly CASE_NAME="20230223.NGD_v3atm.piControl"  
+
+# Code and compilation
+readonly CHECKOUT="20230223"
+readonly BRANCH="NGD_v3atm_v2.1ocnice_alt" 
+readonly CHERRY=( )
+readonly DEBUG_COMPILE=false
+
+# Run options
+readonly MODEL_START_TYPE="initial"  # 'initial', 'continue', 'branch', 'hybrid'
+readonly START_DATE="0001-01-01"
+
+# Additional options for 'branch' and 'hybrid'
+readonly GET_REFCASE=TRUE
+readonly RUN_REFDIR="/lcrc/group/e3sm/ac.mwu/archive/20220504.v2.LR.bi-grid.amip.chemMZT.chrysalis/archive/rest/1985-01-01-00000"
+readonly RUN_REFCASE="20220504.v2.LR.bi-grid.amip.chemMZT.chrysalis"
+readonly RUN_REFDATE="1985-01-01"
+
+# Set paths
+readonly CODE_ROOT="/home/ac.wlin/E3SM/integration/v3atm-work"
+readonly CASE_ROOT="/lcrc/group/e3sm/${USER}/E3SM_testings/v3atm/${CASE_NAME}"
+readonly MY_INPUT_DATA_PATH="/lcrc/group/e3sm/ac.mwu/inputdata"
+
+# Sub-directories
+readonly CASE_BUILD_DIR=${CASE_ROOT}/build
+readonly CASE_ARCHIVE_DIR=${CASE_ROOT}/archive
+
+# Define type of run
+#  short tests: 'S_2x5_ndays', 'M_1x10_ndays', 'M80_1x10_ndays'
+#  or 'production' for full simulation
+#readonly run='production'
+
+readonly run='production'
+#readonly run='custom-30_1x10_ndays'
+#readonly run='custom-10_2x5_ndays'
+#readonly run='custom-10_1x10_ndays'
+
+if [ "${run}" != "production" ]; then
+
+  # Short test simulations
+  tmp=($(echo $run | tr "_" " "))
+  layout=${tmp[0]}
+  units=${tmp[2]}
+  resubmit=$(( ${tmp[1]%%x*} -1 ))
+  length=${tmp[1]##*x}
+
+  readonly CASE_SCRIPTS_DIR=${CASE_ROOT}/tests/${run}/case_scripts
+  readonly CASE_RUN_DIR=${CASE_ROOT}/tests/${run}/run
+  #readonly PELAYOUT=${layout}
+  readonly PELAYOUT="custom-10"
+  readonly WALLTIME="4:00:00"
+  readonly STOP_OPTION=${units}
+  readonly STOP_N=${length}
+  readonly REST_OPTION=${STOP_OPTION}
+  readonly REST_N=${STOP_N}
+  readonly RESUBMIT=${resubmit}
+  readonly DO_SHORT_TERM_ARCHIVING=false
+
+else
+
+  # Production simulation
+  readonly CASE_SCRIPTS_DIR=${CASE_ROOT}/case_scripts
+  readonly CASE_RUN_DIR=${CASE_ROOT}/run
+  #readonly PELAYOUT="M"
+  readonly PELAYOUT="L"
+  readonly WALLTIME="6:00:00"
+  readonly STOP_OPTION="nmonths"
+  readonly STOP_N="1"
+  readonly REST_OPTION="nmonths"
+  readonly REST_N="5"
+  readonly RESUBMIT="0"
+  readonly DO_SHORT_TERM_ARCHIVING=false
+fi
+
+# Coupler history 
+readonly HIST_OPTION="nyears"
+readonly HIST_N="1"
+
+# Leave empty (unless you understand what it does)
+readonly OLD_EXECUTABLE=""
+
+# --- Toggle flags for what to do ----
+do_fetch_code=false
+do_create_newcase=true
+do_case_setup=true
+do_case_build=true
+do_case_submit=true
+
+# --- Now, do the work ---
+
+# Make directories created by this script world-readable
+umask 022
+
+# Fetch code from Github
+fetch_code
+
+# Create case
+create_newcase
+
+# Custom PE layout
+custom_pelayout
+
+# Setup
+case_setup
+
+# Build
+case_build
+
+# Configure runtime options
+runtime_options
+
+# Copy script into case_script directory for provenance
+copy_script
+
+# Submit
+case_submit
+
+# All done
+echo $'\n----- All done -----\n'
+
+}
+
+# =======================
+# Custom user_nl settings
+# =======================
+
+user_nl() {
+
+cat << EOF >> user_nl_eam
+nhtfrq =   0,-24,-6,-6,-3,-24,0
+ mfilt  = 1,30,120,120,240,30,1
+ avgflag_pertape = 'A','A','I','A','A','A','I'
+ fexcl1 = 'CFAD_SR532_CAL', 'LINOZ_DO3', 'LINOZ_DO3_PSC', 'LINOZ_O3CLIM', 'LINOZ_O3COL', 'LINOZ_SSO3', 'hstobie_linoz'
+ fincl1 = 'extinct_sw_inp','extinct_lw_bnd7','extinct_lw_inp','CLD_CAL', 'TREFMNAV', 'TREFMXAV'
+ fincl2 = 'FLUT','PRECT','U200','V200','U850','V850','Z500','OMEGA500','UBOT','VBOT','TREFHT','TREFHTMN:M','TREFHTMX:X','QREFHT','TS','PS','TMQ','TUQ','TVQ','TOZ', 'FLDS', 'FLNS', 'FSDS', 'FSNS', 'SHFLX', 'LHFLX', 'TGCLDCWP', 'TGCLDIWP', 'TGCLDLWP', 'CLDTOT', 'T250', 'T200', 'T150', 'T100', 'T050', 'T025', 'T010', 'T005', 'T002', 'T001', 'TTOP', 'U250', 'U150', 'U100', 'U050', 'U025', 'U010', 'U005', 'U002', 'U001', 'UTOP', 'FSNT', 'FLNT'
+ fincl3 = 'PSL','T200','T500','U850','V850','UBOT','VBOT','TREFHT', 'Z700', 'TBOT:M'
+ fincl4 = 'FLUT','U200','U850','PRECT','OMEGA500'
+ fincl5 = 'PRECT','PRECC','TUQ','TVQ','QFLX','SHFLX','U90M','V90M'
+ fincl6 = 'CLDTOT_ISCCP','MEANCLDALB_ISCCP','MEANTAU_ISCCP','MEANPTOP_ISCCP','MEANTB_ISCCP','CLDTOT_CAL','CLDTOT_CAL_LIQ','CLDTOT_CAL_ICE','CLDTOT_CAL_UN','CLDHGH_CAL','CLDHGH_CAL_LIQ','CLDHGH_CAL_ICE','CLDHGH_CAL_UN','CLDMED_CAL','CLDMED_CAL_LIQ','CLDMED_CAL_ICE','CLDMED_CAL_UN','CLDLOW_CAL','CLDLOW_CAL_LIQ','CLDLOW_CAL_ICE','CLDLOW_CAL_UN'
+ fincl7 = 'O3', 'PS', 'TROP_P'
+
+ tropopause_e90_thrd    = 80.0e-9
+ history_gaschmbudget_2D = .false.
+ history_gaschmbudget_2D_levels = .false.
+ history_UCIgaschmbudget_2D = .false.
+ history_UCIgaschmbudget_2D_levels = .false.
+ gaschmbudget_2D_L1_s =  1
+ gaschmbudget_2D_L1_e = 26
+ gaschmbudget_2D_L2_s = 27
+ gaschmbudget_2D_L2_e = 38
+ gaschmbudget_2D_L3_s = 39
+ gaschmbudget_2D_L3_e = 58
+ gaschmbudget_2D_L4_s = 59
+ gaschmbudget_2D_L4_e = 72
+! history_aero_optics    = .true.
+! history_aerosol        = .true.
+! history_amwg           = .true.
+! history_budget         = .true.
+! history_verbose        = .true.
+ cosp_lite = .true.
+ zmconv_microp = .true.
+ zmconv_clos_dyn_adj = .true.
+ zmconv_MCSP_heat_coeff = 0.3
+ zmconv_tpert_fix = .true.
+ zmconv_ke = 2.5e-6
+ p3_wbf_coeff = 1.0
+
+ sscav_tuning = .false.
+ 
+ !LWCF tuning
+ nucleate_ice_subgrid   =  1.35
+ p3_mincdnc             =  20.D6
+ dust_emis_fact         =  11.8D0
+ seasalt_emis_scale     =  0.55D0
+
+ tracer_cnst_cycle_yr           = 1995
+ tracer_cnst_datapath           = '\$DIN_LOC_ROOT/atm/cam/chem/methane/'
+ tracer_cnst_file               = 'ch4_oxid_1.9x2.5_L26_1990-1999clim.c090804.nc'
+ tracer_cnst_filelist           = ''
+ tracer_cnst_specifier          = 'CH4','cnst_NO3:NO3', 'cnst_OH:OH'
+ tracer_cnst_type               = 'CYCLICAL'
+
+ linoz_psc_t = 198.0
+
+ ! empty sad_file would have no effect for the 4th full smoke config
+
+ sad_file               = '\$DIN_LOC_ROOT/atm/waccm/sulf/SAD_SULF_1849-2100_1.9x2.5_c090817.nc'
+ sad_type     = 'SERIAL' 
+
+ drydep_list = 'O3','H2O2','CH2O','CH3OOH','NO','NO2','HNO3','HO2NO2','PAN','CO','CH3COCH3','C2H5OOH','CH3CHO','H2SO4','SO2','NO3','N2O5'
+
+ gas_wetdep_list                = 'C2H5OOH','CH2O','CH3CHO','CH3OOH','H2O2','H2SO4','HNO3','HO2NO2','SO2','SOAG0','SOAG15','SOAG24','SOAG35','SOAG34','SOAG33','SOAG32','SOAG31'
+ gas_wetdep_method              = 'NEU'
+ 
+ ext_frc_cycle_yr               = 1850
+ ext_frc_specifier              = 'NO2    -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_NO2_aircraft_vertical_1750-2015_1.9x2.5_c20170608.nc',
+         'SO2    -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_elev_1850-2014_c180205.nc',
+         'SOAG0  -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/emissions-cmip6_e3sm_SOAG0_elev_1850-2014_1.9x2.5_c20230201.nc',
+         'bc_a4  -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_elev_1850-2014_c180205.nc',
+         'num_a1 -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_elev_1850-2014_c180205.nc',
+         'num_a2 -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_elev_1850-2014_c180205.nc',
+         'num_a4 -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_elev_1850-2014_c180205.nc',
+         'pom_a4 -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_elev_1850-2014_c180205.nc',
+         'so4_a1 -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_elev_1850-2014_c180205.nc',
+         'so4_a2 -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_elev_1850-2014_c180205.nc'
+ ext_frc_type           = 'CYCLICAL'
+ srf_emis_cycle_yr              = 1850
+ srf_emis_specifier             = 'C2H4     -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_C2H4_surface_1850-2014_1.9x2.5_c20210323.nc',
+         'C2H6     -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_C2H6_surface_1850-2014_1.9x2.5_c20210323.nc',
+         'C3H8     -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_C3H8_surface_1850-2014_1.9x2.5_c20210323.nc',
+         'CH2O     -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CH2O_surface_1850-2014_1.9x2.5_c20210323.nc',
+         'CH3CHO   -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CH3CHO_surface_1850-2014_1.9x2.5_c20210323.nc',
+         'CH3COCH3 -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CH3COCH3_surface_1850-2014_1.9x2.5_c20210323.nc',
+         'CO       -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CO_surface_1850-2014_1.9x2.5_c20210323.nc',
+         'ISOP     -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_ISOP_surface_1850-2014_1.9x2.5_c20210323.nc',
+         'C10H16   -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_MTERP_surface_1850-2014_1.9x2.5_c20220426.nc',
+         'SOAG0    -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/emissions-cmip6_e3sm_SOAG0_surf_1850-2014_1.9x2.5_c20230201.nc',
+         'NO       -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_NO_surface_1850-2014_1.9x2.5_c20220425.nc',
+         'DMS      -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DMSflux.1850-2100.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160727.nc',
+         'SO2      -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_surf_1850-2014_c180205.nc',
+         'bc_a4    -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_surf_1850-2014_c180205.nc',
+         'num_a1   -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_surf_1850-2014_c180205.nc',
+         'num_a2   -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_surf_1850-2014_c180205.nc',
+         'num_a4   -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_surf_1850-2014_c180205.nc',
+         'pom_a4   -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_surf_1850-2014_c180205.nc',
+         'so4_a1   -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_surf_1850-2014_c180205.nc',
+         'so4_a2   -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_surf_1850-2014_c180205.nc'
+         'E90      -> \$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions_E90_surface_1750-2015_1.9x2.5_c20210408.nc'
+ srf_emis_type          = 'CYCLICAL'
+
+ mode_defs = 'mam5_mode1:accum:=', 'A:num_a1:N:num_c1:num_mr:+',
+         'A:so4_a1:N:so4_c1:sulfate:\$DIN_LOC_ROOT/atm/cam/physprops/sulfate_rrtmg_c080918.nc:+',
+         'A:pom_a1:N:pom_c1:p-organic:\$DIN_LOC_ROOT/atm/cam/physprops/ocpho_rrtmg_c130709.nc:+',
+         'A:soa_a1:N:soa_c1:s-organic:\$DIN_LOC_ROOT/atm/cam/physprops/ocphi_rrtmg_c100508.nc:+',
+         'A:bc_a1:N:bc_c1:black-c:\$DIN_LOC_ROOT/atm/cam/physprops/bcpho_rrtmg_c100508.nc:+',
+         'A:dst_a1:N:dst_c1:dust:\$DIN_LOC_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_c141106.nc:+',
+         'A:ncl_a1:N:ncl_c1:seasalt:\$DIN_LOC_ROOT/atm/cam/physprops/ssam_rrtmg_c100508.nc:+',
+         'A:mom_a1:N:mom_c1:m-organic:\$DIN_LOC_ROOT/atm/cam/physprops/poly_rrtmg_c130816.nc:',
+         'mam5_mode2:aitken:=', 'A:num_a2:N:num_c2:num_mr:+',
+         'A:so4_a2:N:so4_c2:sulfate:\$DIN_LOC_ROOT/atm/cam/physprops/sulfate_rrtmg_c080918.nc:+',
+         'A:soa_a2:N:soa_c2:s-organic:\$DIN_LOC_ROOT/atm/cam/physprops/ocphi_rrtmg_c100508.nc:+',
+         'A:ncl_a2:N:ncl_c2:seasalt:\$DIN_LOC_ROOT/atm/cam/physprops/ssam_rrtmg_c100508.nc:+',
+         'A:mom_a2:N:mom_c2:m-organic:\$DIN_LOC_ROOT/atm/cam/physprops/poly_rrtmg_c130816.nc:',
+         'mam5_mode3:coarse:=', 'A:num_a3:N:num_c3:num_mr:+',
+         'A:dst_a3:N:dst_c3:dust:\$DIN_LOC_ROOT/atm/cam/physprops/dust_aeronet_rrtmg_c141106.nc:+',
+         'A:ncl_a3:N:ncl_c3:seasalt:\$DIN_LOC_ROOT/atm/cam/physprops/ssam_rrtmg_c100508.nc:+',
+         'A:so4_a3:N:so4_c3:sulfate:\$DIN_LOC_ROOT/atm/cam/physprops/sulfate_rrtmg_c080918.nc:+',
+         'A:bc_a3:N:bc_c3:black-c:\$DIN_LOC_ROOT/atm/cam/physprops/bcpho_rrtmg_c100508.nc:+',
+         'A:pom_a3:N:pom_c3:p-organic:\$DIN_LOC_ROOT/atm/cam/physprops/ocpho_rrtmg_c130709.nc:+',
+         'A:soa_a3:N:soa_c3:s-organic:\$DIN_LOC_ROOT/atm/cam/physprops/ocphi_rrtmg_c100508.nc:+',
+         'A:mom_a3:N:mom_c3:m-organic:\$DIN_LOC_ROOT/atm/cam/physprops/poly_rrtmg_c130816.nc:',
+         'mam5_mode4:primary_carbon:=', 'A:num_a4:N:num_c4:num_mr:+',
+         'A:pom_a4:N:pom_c4:p-organic:\$DIN_LOC_ROOT/atm/cam/physprops/ocpho_rrtmg_c130709.nc:+',
+         'A:bc_a4:N:bc_c4:black-c:\$DIN_LOC_ROOT/atm/cam/physprops/bcpho_rrtmg_c100508.nc:+',
+         'A:mom_a4:N:mom_c4:m-organic:\$DIN_LOC_ROOT/atm/cam/physprops/poly_rrtmg_c130816.nc',
+         'mam5_mode5:strat_coarse:=', 'A:num_a5:N:num_c5:num_mr:+',
+         'A:so4_a5:N:so4_c5:sulfate:\$DIN_LOC_ROOT/atm/cam/physprops/sulfate_rrtmg_c080918.nc'
+
+ rad_climate            = 'A:H2OLNZ:H2O', 'N:O2:O2', 'N:CO2:CO2',
+         'A:O3:O3', 'A:N2OLNZ:N2O', 'A:CH4LNZ:CH4',
+         'N:CFC11:CFC11', 'N:CFC12:CFC12', 
+         'M:mam5_mode1:\$DIN_LOC_ROOT/atm/cam/physprops/mam4_mode1_rrtmg_aeronetdust_c141106.nc',
+         'M:mam5_mode2:\$DIN_LOC_ROOT/atm/cam/physprops/mam4_mode2_rrtmg_c130628.nc', 
+         'M:mam5_mode3:\$DIN_LOC_ROOT/atm/cam/physprops/mam4_mode3_rrtmg_aeronetdust_c141106.nc',
+         'M:mam5_mode4:\$DIN_LOC_ROOT/atm/cam/physprops/mam4_mode4_rrtmg_c130628.nc',
+         'M:mam5_mode5:\$DIN_LOC_ROOT/atm/cam/physprops/mam4_mode3_rrtmg_aeronetdust_sig1.2_dgnl.40_c150219_ke.nc'
+! rad_diag_1 = 'A:H2OLNZ:H2O','N:O2:O2','N:CO2:CO2','A:O3:O3','A:N2OLNZ:N2O','A:CH4LNZ:CH4','N:CFC11:CFC11','N:CFC12:CFC12'
+
+
+ cflx_cpl_opt = 2
+
+ soil_erod_file         = '\$DIN_LOC_ROOT/atm/cam/dst/dst_1.9x2.5_c090203.nc'
+
+EOF
+
+cat << EOF >> user_nl_elm
+ hist_dov2xy = .true.,.true.
+ hist_fincl2 = 'H2OSNO', 'FSNO', 'QRUNOFF', 'QSNOMELT', 'FSNO_EFF', 'SNORDSL', 'SNOW', 'FSDS', 'FSR', 'FLDS', 'FIRE', 'FIRA'
+ hist_mfilt = 1,365
+ hist_nhtfrq = 0,-24
+ hist_avgflag_pertape = 'A','A'
+ check_finidat_year_consistency = .false.
+ check_dynpft_consistency = .false.
+ fsurdat = '\${DIN_LOC_ROOT}/lnd/clm2/surfdata_map/surfdata_ne30pg2_simyr1850_c210402.nc'
+
+ !comment out finidat if running hybrid type
+
+ finidat = '\${DIN_LOC_ROOT}/lnd/clm2/initdata/NGD_v3atm.ne30pg2_EC30to60E2r2.elm.r.0001-01-01-00000.c20230106.nc'
+ flanduse_timeseries = '\${DIN_LOC_ROOT}/lnd/clm2/surfdata_map/landuse.timeseries_ne30np4.pg2_hist_simyr1850-2015_c210113.nc'
+EOF
+
+}
+
+# =====================================
+# Customize MPAS stream files if needed
+# =====================================
+
+patch_mpas_streams() {
+
+echo
+
+}
+
+# =====================================================
+# Custom PE layout: custom-N where N is number of nodes
+# =====================================================
+
+custom_pelayout() {
+
+if [[ ${PELAYOUT} == custom-* ]];
+then
+    echo $'\n CUSTOMIZE PROCESSOR CONFIGURATION:'
+
+    # Number of cores per node (machine specific)
+    if [ "${MACHINE}" == "chrysalis" ]; then
+        ncore=64
+    elif [ "${MACHINE}" == "compy" ]; then
+        ncore=40
+    else
+        echo 'ERROR: MACHINE = '${MACHINE}' is not supported for custom PE layout.' 
+        exit 400
+    fi
+
+    # Extract number of nodes
+    tmp=($(echo ${PELAYOUT} | tr "-" " "))
+    nnodes=${tmp[1]}
+
+    # Customize
+    pushd ${CASE_SCRIPTS_DIR}
+    ./xmlchange NTASKS=$(( $nnodes * $ncore ))
+    ./xmlchange NTHRDS=1
+    ./xmlchange MAX_MPITASKS_PER_NODE=$ncore
+    ./xmlchange MAX_TASKS_PER_NODE=$ncore
+    popd
+
+fi
+
+}
+
+######################################################
+### Most users won't need to change anything below ###
+######################################################
+
+#-----------------------------------------------------
+fetch_code() {
+
+    if [ "${do_fetch_code,,}" != "true" ]; then
+        echo $'\n----- Skipping fetch_code -----\n'
+        return
+    fi
+
+    echo $'\n----- Starting fetch_code -----\n'
+    local path=${CODE_ROOT}
+    local repo=e3sm
+
+    echo "Cloning $repo repository branch $BRANCH under $path"
+    if [ -d "${path}" ]; then
+        echo "ERROR: Directory already exists. Not overwriting"
+        exit 20
+    fi
+    mkdir -p ${path}
+    pushd ${path}
+
+    # This will put repository, with all code
+    git clone git@github.com:E3SM-Project/${repo}.git .
+    
+    # Setup git hooks
+    rm -rf .git/hooks
+    git clone git@github.com:E3SM-Project/E3SM-Hooks.git .git/hooks
+    git config commit.template .git/hooks/commit.template
+
+    # Bring in all submodule components
+    git submodule update --init --recursive
+
+    # Check out desired branch
+    git checkout ${BRANCH}
+
+    # Custom addition
+    if [ "${CHERRY}" != "" ]; then
+        echo ----- WARNING: adding git cherry-pick -----
+        for commit in "${CHERRY[@]}"
+        do
+            echo ${commit}
+            git cherry-pick ${commit}
+        done
+        echo -------------------------------------------
+    fi
+
+    # Bring in all submodule components
+    git submodule update --init --recursive
+
+    popd
+}
+
+#-----------------------------------------------------
+create_newcase() {
+
+    if [ "${do_create_newcase,,}" != "true" ]; then
+        echo $'\n----- Skipping create_newcase -----\n'
+        return
+    fi
+
+    echo $'\n----- Starting create_newcase -----\n'
+
+    if [[ ${PELAYOUT} == custom-* ]];
+    then
+        layout="M" # temporary placeholder for create_newcase
+    else
+        layout=${PELAYOUT}
+
+    fi
+    ${CODE_ROOT}/cime/scripts/create_newcase \
+        --case ${CASE_NAME} \
+        --output-root ${CASE_ROOT} \
+        --script-root ${CASE_SCRIPTS_DIR} \
+        --handle-preexisting-dirs u \
+        --compset ${COMPSET} \
+        --res ${RESOLUTION} \
+        --machine ${MACHINE} \
+        --project ${PROJECT} \
+        --walltime ${WALLTIME} \
+        --pecount ${layout}
+
+    if [ $? != 0 ]; then
+      echo $'\nNote: if create_newcase failed because sub-directory already exists:'
+      echo $'  * delete old case_script sub-directory'
+      echo $'  * or set do_newcase=false\n'
+      exit 35
+    fi
+
+}
+
+#-----------------------------------------------------
+case_setup() {
+
+    if [ "${do_case_setup,,}" != "true" ]; then
+        echo $'\n----- Skipping case_setup -----\n'
+        return
+    fi
+
+    echo $'\n----- Starting case_setup -----\n'
+    pushd ${CASE_SCRIPTS_DIR}
+
+    # Source Mods copy .F90 files to src.*
+    # cp ${HOME}/source_files/E3SMv2_UCI-MZT-MSC_20220629/mo_gas_phase_chemdr.F90   ${CASE_SCRIPTS_DIR}/SourceMods/src.eam/mo_gas_phase_chemdr.F90
+
+    # Setup some CIME directories
+    ./xmlchange EXEROOT=${CASE_BUILD_DIR}
+    ./xmlchange RUNDIR=${CASE_RUN_DIR}
+
+    # Short term archiving
+    ./xmlchange DOUT_S=${DO_SHORT_TERM_ARCHIVING^^}
+    ./xmlchange DOUT_S_ROOT=${CASE_ARCHIVE_DIR}
+
+    # Build with COSP, except for a data atmosphere (datm)
+    if [ `./xmlquery --value COMP_ATM` == "datm"  ]; then 
+      echo $'\nThe specified configuration uses a data atmosphere, so cannot activate COSP simulator\n'
+    else
+      echo $'\nConfiguring E3SM to use the COSP simulator\n'
+      ./xmlchange --id CAM_CONFIG_OPTS --append --val='-cosp'
+    fi
+
+    # Extracts input_data_dir in case it is needed for user edits to the namelist later
+    local input_data_dir=`./xmlquery DIN_LOC_ROOT --value`
+
+    # MW changing chemistry mechanism
+    local usr_mech_infile="$CODE_ROOT/components/eam/chem_proc/inputs/pp_chemUCI_linozv3_mam5_vbs.in"
+    echo 'Changing chemistry to :'${usr_mech_infile} for the 4th full smoke config to be consistent with chem package reset below
+    ./xmlchange --id CAM_CONFIG_OPTS --append --val='-chem superfast_mam5_resus_mom_vbs_mosaic -vbs -usr_mech_infile '${usr_mech_infile}
+
+    # Custom user_nl
+    user_nl
+
+    # Finally, run CIME case.setup
+    ./case.setup --reset
+
+    popd
+}
+
+#-----------------------------------------------------
+case_build() {
+
+    pushd ${CASE_SCRIPTS_DIR}
+
+    # do_case_build = false
+    if [ "${do_case_build,,}" != "true" ]; then
+
+        echo $'\n----- case_build -----\n'
+
+        if [ "${OLD_EXECUTABLE}" == "" ]; then
+            # Ues previously built executable, make sure it exists
+            if [ -x ${CASE_BUILD_DIR}/e3sm.exe ]; then
+                echo 'Skipping build because $do_case_build = '${do_case_build}
+            else
+                echo 'ERROR: $do_case_build = '${do_case_build}' but no executable exists for this case.'
+                exit 297
+            fi
+        else
+            # If absolute pathname exists and is executable, reuse pre-exiting executable
+            if [ -x ${OLD_EXECUTABLE} ]; then
+                echo 'Using $OLD_EXECUTABLE = '${OLD_EXECUTABLE}
+                cp -fp ${OLD_EXECUTABLE} ${CASE_BUILD_DIR}/
+            else
+                echo 'ERROR: $OLD_EXECUTABLE = '$OLD_EXECUTABLE' does not exist or is not an executable file.'
+                exit 297
+            fi
+        fi
+        echo 'WARNING: Setting BUILD_COMPLETE = TRUE.  This is a little risky, but trusting the user.'
+        ./xmlchange BUILD_COMPLETE=TRUE
+
+    # do_case_build = true
+    else
+
+        echo $'\n----- Starting case_build -----\n'
+
+        # Turn on debug compilation option if requested
+        if [ "${DEBUG_COMPILE^^}" == "TRUE" ]; then
+            ./xmlchange DEBUG=${DEBUG_COMPILE^^}
+        fi
+
+        # Run CIME case.build
+        ./case.build
+
+    fi
+
+    # Some user_nl settings won't be updated to *_in files under the run directory
+    # Call preview_namelists to make sure *_in and user_nl files are consistent.
+    echo $'\n----- Preview namelists -----\n'
+    ./preview_namelists
+
+    popd
+}
+
+#-----------------------------------------------------
+runtime_options() {
+
+    echo $'\n----- Starting runtime_options -----\n'
+    pushd ${CASE_SCRIPTS_DIR}
+
+    # Set simulation start date
+    ./xmlchange RUN_STARTDATE=${START_DATE}
+
+    # Segment length
+    ./xmlchange STOP_OPTION=${STOP_OPTION,,},STOP_N=${STOP_N}
+
+    # Restart frequency
+    ./xmlchange REST_OPTION=${REST_OPTION,,},REST_N=${REST_N}
+
+    # Coupler history
+    ./xmlchange HIST_OPTION=${HIST_OPTION,,},HIST_N=${HIST_N}
+
+    # Coupler budgets (always on)
+    ./xmlchange BUDGETS=TRUE
+
+    # Set resubmissions
+    if (( RESUBMIT > 0 )); then
+        ./xmlchange RESUBMIT=${RESUBMIT}
+    fi
+
+    # Run type
+    # Start from default of user-specified initial conditions
+    if [ "${MODEL_START_TYPE,,}" == "initial" ]; then
+        ./xmlchange RUN_TYPE="startup"
+        ./xmlchange CONTINUE_RUN="FALSE"
+
+    # Continue existing run
+    elif [ "${MODEL_START_TYPE,,}" == "continue" ]; then
+        ./xmlchange CONTINUE_RUN="TRUE"
+
+    elif [ "${MODEL_START_TYPE,,}" == "branch" ] || [ "${MODEL_START_TYPE,,}" == "hybrid" ]; then
+        ./xmlchange RUN_TYPE=${MODEL_START_TYPE,,}
+        ./xmlchange GET_REFCASE=${GET_REFCASE}
+        ./xmlchange RUN_REFDIR=${RUN_REFDIR}
+        ./xmlchange RUN_REFCASE=${RUN_REFCASE}
+        ./xmlchange RUN_REFDATE=${RUN_REFDATE}
+        echo 'Warning: $MODEL_START_TYPE = '${MODEL_START_TYPE} 
+        echo '$RUN_REFDIR = '${RUN_REFDIR}
+        echo '$RUN_REFCASE = '${RUN_REFCASE}
+        echo '$RUN_REFDATE = '${START_DATE}
+    else
+        echo 'ERROR: $MODEL_START_TYPE = '${MODEL_START_TYPE}' is unrecognized. Exiting.'
+        exit 380
+    fi
+
+    # Patch mpas streams files
+    patch_mpas_streams
+
+    popd
+}
+
+#-----------------------------------------------------
+case_submit() {
+
+    if [ "${do_case_submit,,}" != "true" ]; then
+        echo $'\n----- Skipping case_submit -----\n'
+        return
+    fi
+
+    echo $'\n----- Starting case_submit -----\n'
+    pushd ${CASE_SCRIPTS_DIR}
+    
+    # Run CIME case.submit
+    ./case.submit
+
+    popd
+}
+
+#-----------------------------------------------------
+copy_script() {
+
+    echo $'\n----- Saving run script for provenance -----\n'
+
+    local script_provenance_dir=${CASE_SCRIPTS_DIR}/run_script_provenance
+    mkdir -p ${script_provenance_dir}
+    local this_script_name=`basename $0`
+    local script_provenance_name=${this_script_name}.`date +%Y%m%d-%H%M%S`
+    cp -vp ${this_script_name} ${script_provenance_dir}/${script_provenance_name}
+
+}
+
+#-----------------------------------------------------
+# Silent versions of popd and pushd
+pushd() {
+    command pushd "$@" > /dev/null
+}
+popd() {
+    command popd "$@" > /dev/null
+}
+
+# Now, actually run the script
+#-----------------------------------------------------
+main
+

--- a/run.NGD_v3atm.piControl.sh
+++ b/run.NGD_v3atm.piControl.sh
@@ -30,14 +30,14 @@ readonly CHERRY=( )
 readonly DEBUG_COMPILE=false
 
 # Run options
-readonly MODEL_START_TYPE="initial"  # 'initial', 'continue', 'branch', 'hybrid'
+readonly MODEL_START_TYPE="hybrid"  # 'initial', 'continue', 'branch', 'hybrid'
 readonly START_DATE="0001-01-01"
 
 # Additional options for 'branch' and 'hybrid'
 readonly GET_REFCASE=TRUE
-readonly RUN_REFDIR="/lcrc/group/e3sm/ac.mwu/archive/20220504.v2.LR.bi-grid.amip.chemMZT.chrysalis/archive/rest/1985-01-01-00000"
-readonly RUN_REFCASE="20220504.v2.LR.bi-grid.amip.chemMZT.chrysalis"
-readonly RUN_REFDATE="1985-01-01"
+readonly RUN_REFDIR="/lcrc/group/e3sm/ac.golaz/E3SMv2_1/v2_1.LR.piControl/init"
+readonly RUN_REFCASE="20221012.submeso.piControl.ne30pg2_EC30to60E2r2.chrysalis"
+readonly RUN_REFDATE="0301-01-01"
 
 # Set paths
 readonly CODE_ROOT="/home/ac.wlin/E3SM/integration/v3atm-work"


### PR DESCRIPTION
This is to support v3atm fourth full smoke configuration for 1850 condition.

The compsets added include F1850-chemUCI-Linozv3 and WCYCL1850-chemUCI-Linozv3 (piControl) 
as the base compsets to create cases. The full configurations equivalent to the fourth full smoke test 
continue to use run script to realize for now.

Run scripts for F1850 and piControl are added, along with an updated run script for F20TR

The template F1850 and piControl run script set to create cases with startup run type. If there is suitable reference case available, may change to create a hybrid case. Special attention to atm initial condition as a reference case may not contain the tracer species introduced in v3atm.

[BFB] for existing tests. 
