### PR TITLE
Bug fix for restart NBFB when ZMmp turned off

### DIFF
--- a/components/eam/src/chemistry/modal_aero/modal_aero_convproc.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_convproc.F90
@@ -23,6 +23,9 @@ module modal_aero_convproc
    use cam_abortutils, only: endrun
    use physconst,    only: spec_class_aerosol, spec_class_gas
    use constituents,  only: pcnst
+!<shanyp 02172023  Pass the zm_microp switch from the ZM scheme
+   use zm_conv,      only: zm_microp ! 
+!shanyp 02172023>
    implicit none
 
    save
@@ -850,7 +853,6 @@ subroutine ma_convproc_dp_intr(                &
                      lun,        itmpveca,                           &
                      dcon_resusp3d=dcon_resusp3d,wuc=wuc )
 !                    ed,         dp,         dsubcld,    jt,         &   
-
 
 
 ! set qbb = "modified q" with convtran tendency applied,
@@ -2065,9 +2067,12 @@ k_loop_main_bb: &
                wup(k) = max( 0.1_r8, min( 4.0_r8, wup(k) ) )
             end if
 ! update the vertical velocity from convective cloud microphysics scheme
-            wup(k) = wuc(icol,k)
-            wup(k) = max( 0.1_r8, min( 15.0_r8, wup(k) ) )
-
+!<shanyp 02172023 Use the wuc only when the zm_microp is turned on. 
+            if(zm_microp) then
+             wup(k) = wuc(icol,k)
+             wup(k) = max( 0.1_r8, min( 15.0_r8, wup(k) ) )
+            end if
+!shanyp 02172023>
 ! compute lagrangian transport time (dt_u) and updraft fractional area (fa_u)
 ! *** these must obey    dt_u(k)*mu_p_eudp(k) = dp_i(k)*fa_u(k)
             dt_u(k) = dz/wup(k)

--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -2104,7 +2104,9 @@ subroutine tphysbc (ztodt,               &
                              ! For chemical gases, different versions of EAM 
                              ! might use different process ordering.
     real(r8):: wuc(pcols,pver)
-
+!<shanyp 02172023
+    wuc(:,:) = 0._r8
+!shanyp 02172023>
     call phys_getopts( microp_scheme_out      = microp_scheme, &
                        macrop_scheme_out      = macrop_scheme, &
                        use_subcol_microp_out  = use_subcol_microp, &


### PR DESCRIPTION
enable the 4th smoke to run with ZMmp turned off