### PR TITLE
Energy leak fixes in ZM

### DIFF
--- a/components/eam/src/physics/cam/zm_conv.F90
+++ b/components/eam/src/physics/cam/zm_conv.F90
@@ -4017,16 +4017,8 @@ subroutine cldprp(lchnk   , &
             evp(i,k) = -ed(i,k)*q(i,k) + (md(i,k)*qd(i,k)-md(i,k+1)*qd(i,k+1))/dz(i,k)
             evp(i,k) = max(evp(i,k),0._r8)
             mdt = min(md(i,k+1),-small)
-            if (zm_microp) then
-              evp(i,k) = min(evp(i,k),rprd(i,k))
-              if (rprd(i,k)> 0._r8) then
-                sd(i,k+1) = (((rl+latice*sprd(i,k)/rprd(i,k))/cp*evp(i,k) -ed(i,k)*s(i,k))*dz(i,k) + md(i,k)*sd(i,k))/mdt
-              else
-                sd(i,k+1) = ((rl/cp*evp(i,k)-ed(i,k)*s(i,k))*dz(i,k) + md(i,k)*sd(i,k))/mdt
-              end if
-            else
-              sd(i,k+1) = ((rl/cp*evp(i,k)-ed(i,k)*s(i,k))*dz(i,k) + md(i,k)*sd(i,k))/mdt
-            end if
+            if (zm_microp)   evp(i,k) = min(evp(i,k),rprd(i,k))
+            sd(i,k+1) = ((rl/cp*evp(i,k)-ed(i,k)*s(i,k))*dz(i,k) + md(i,k)*sd(i,k))/mdt
             totevp(i) = totevp(i) - dz(i,k)*ed(i,k)*q(i,k)
          end if
       end do
@@ -4066,7 +4058,6 @@ subroutine cldprp(lchnk   , &
 ! cmeg is the cloud water condensed - rain water evaporated
 ! rprd is the cloud water converted to rain - (rain evaporated)
          cmeg(i,k) = cu(i,k) - evp(i,k)
-         if (rprd(i,k)> 0._r8) sprd(i,k) = sprd(i,k)-evp(i,k)*sprd(i,k)/rprd(i,k)
          rprd(i,k) = rprd(i,k)-evp(i,k)
       end do
    end do

--- a/components/eam/src/physics/cam/zm_conv.F90
+++ b/components/eam/src/physics/cam/zm_conv.F90
@@ -4058,6 +4058,12 @@ subroutine cldprp(lchnk   , &
 ! cmeg is the cloud water condensed - rain water evaporated
 ! rprd is the cloud water converted to rain - (rain evaporated)
          cmeg(i,k) = cu(i,k) - evp(i,k)
+         if (zm_microp) then
+           if (rprd(i,k)> 0._r8)  then
+              frz1(i,k) = frz1(i,k)- evp(i,k)*sprd(i,k)/rprd(i,k)
+              sprd(i,k) = sprd(i,k)- evp(i,k)*sprd(i,k)/rprd(i,k)
+           end if
+         end if
          rprd(i,k) = rprd(i,k)-evp(i,k)
       end do
    end do

--- a/components/eam/src/physics/cam/zm_microphysics.F90
+++ b/components/eam/src/physics/cam/zm_microphysics.F90
@@ -2983,21 +2983,22 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                  nr(i,k-1) = max(nr(i,k-1),0._r8)
               end if
 
-              rprd(i,k-1)= (qnitend(i,k) + qrtend(i,k)+ qgtend(i,k) )*arcf(i,k) + dsfm(i,k-1)
-              sprd(i,k-1)= (qnitend(i,k)+qgtend(i,k)) *arcf(i,k) -fhmrm(i,k-1) + dsfm(i,k-1)
-              if (rprd(i,k-1).lt.0._r8) then
+              ! snow detrainment adjustment
+              dum = min((qnitend(i,k)+qrtend(i,k)+qgtend(i,k))*arcf(i,k),(qnitend(i,k)+qgtend(i,k))*arcf(i,k)-fhmrm(i,k-1))
+              if ( dum+dsfm(i,k-1).lt.0._r8) then
                  if (dsfm(i,k-1).ne.0._r8) then
-                    dsfn(i,k-1) = dsfn(i,k-1)*(dsfm(i,k-1)-rprd(i,k-1))/dsfm(i,k-1)
-                    dsfm(i,k-1) = -(qnitend(i,k) + qrtend(i,k)+ qgtend(i,k) )*arcf(i,k)
+                    dsfn(i,k-1) = dsfn(i,k-1)*(-dum*omsm)/dsfm(i,k-1)
+                    dsfm(i,k-1) = -dum*omsm
                     qnide(i,k)  = -dsfm(i,k-1)/du(i,k-1)
                     nsde(i,k)   = -dsfn(i,k-1)/du(i,k-1)
                     qni(i,k-1) = qni(i,k-1) + dz(i,k)*du(i,k-1)*(qni(i,k-1)-qnide(i,k))/mu(i,k-1)
                     ns(i,k-1)  =  ns(i,k-1) + dz(i,k)*du(i,k-1)*(ns(i,k-1)-nsde(i,k))/mu(i,k-1)
                     ns(i,k-1) = max(ns(i,k-1),0._r8)
                  end if
-                 rprd(i,k-1) = 0._r8
-                 sprd(i,k-1) = 0._r8
               end if
+
+              rprd(i,k-1)= (qnitend(i,k) + qrtend(i,k)+ qgtend(i,k) )*arcf(i,k) + dsfm(i,k-1)
+              sprd(i,k-1)= (qnitend(i,k)+qgtend(i,k)) *arcf(i,k) -fhmrm(i,k-1) + dsfm(i,k-1)
 
 
               ! cloud water


### PR DESCRIPTION
This fix by Xiaoliang Song plugs two energy leaks. The description, as provided by Xiaoliang:  
```
1) flxsnow(i,k+1) = max(flxsnow(i,k+1), 0._r8) in the subroutine zm_conv_evap () 
This code is part of v2 and the current master. It may result in mass and energy leak when flxsnow <0.
In ZM microphysics, the overly strong snow detrainment may result in negative flxsnow. I have implemented 
an adjustment of snow detrainment in the microphysics code to fix this issue.

2) In the downdraft, the energy change related to ice-phase precipitation evaporation is not fully considered. 
Since the current convective microphysics scheme is designed for convective updraft, the representation of 
microphysical processes in downdraft is very crude. I have removed two line of code related to the change of 
sprd to maintain energy conservation. Since the total precipitation and evaporation is determined by rprd and evp,
this change should not have a noticeable impact on the simulation. 
```


