### PR TITLE
Revert O3 imp_sol prod/loss diagnostics

### DIFF
--- a/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -1020,15 +1020,15 @@ contains
          + het_rates(i,k,o3_ndx)) *vmr(i,k,o3_ndx)  
 
       ! closure check - non-closure due to non-convergent in implicit solver 
-         p_l_net = chem_prod(i,k,o3_ndx)-chem_loss(i,k,o3_ndx)
-         tmp_tdi = (vmr(i,k,o3_ndx)-vmr_old2(i,k,o3_ndx))/delt
-         tmp_a = (p_l_net - tmp_tdi) * (p_l_net - tmp_tdi)
-         tmp_b = tmp_tdi * tmp_tdi
-         if (sqrt(tmp_a/tmp_b) > 1.e-6) then
-            vmr(i,k,o3_ndx) = vmr_old2(i,k,o3_ndx)
-            chem_prod(i,k,o3_ndx) = 0. 
-            chem_loss(i,k,o3_ndx) = 0.
-         end if
+         !p_l_net = chem_prod(i,k,o3_ndx)-chem_loss(i,k,o3_ndx)
+         !tmp_tdi = (vmr(i,k,o3_ndx)-vmr_old2(i,k,o3_ndx))/delt
+         !tmp_a = (p_l_net - tmp_tdi) * (p_l_net - tmp_tdi)
+         !tmp_b = tmp_tdi * tmp_tdi
+         !if (sqrt(tmp_a/tmp_b) > 1.e-6) then
+         !   vmr(i,k,o3_ndx) = vmr_old2(i,k,o3_ndx)
+         !   chem_prod(i,k,o3_ndx) = 0. 
+         !   chem_loss(i,k,o3_ndx) = 0.
+         !end if
 
       end do column0_loop
       end do level0_loop


### PR DESCRIPTION
This PR reverts the O3 VMR reset for O3 production and loss tendency diagnostics from the implicit solver because such reset leads to incorrect low tropospheric column O3.

Details:
This reset was implemented when the implicit solver printed lots of warnings below about non-convergence:
imp_sol: Time step   1.8000000000000E+03 failed to converge @
(lchnk,lev,col,nstep) =   6479    43     1     0
imp_sol : @ (lchnk,lev,col) =         6479          43           1
failed 1 times

Looking into the implicit solver code in mo_imp_sol.F90, this warning is printed when dt=1800s (the number after "Time step") fails to converge and the solver will halve dt up to cut_limit=5 times.

If the solver cannot converge after cutting dt 5 times, warnings will be printed by the following code:

write(iulog,'('' imp_sol: Failed to converge @ (lchnk,lev,col,nstep,dt,time) = '',4i6,1p,2e21.13)') &
     lchnk,lev,i,nstep,dt,interval_done+dt
do m = 1,clscnt4
   if( .not. converged(m) ) then
      write(iulog,'(1x,a8,1x,1pe10.3)') solsym(clsmap(m,4)), max_delta(m)
   end if
end do

We don't see the warning from this part of code, so it converges with halved dt. Therefore, the reset after implicit solver is incorrect.

[NBFB]