### PR TITLE
add cloud-borne aerosols to 2D burden outputs

### DIFF
--- a/components/eam/src/physics/cam/modal_aer_opt.F90
+++ b/components/eam/src/physics/cam/modal_aer_opt.F90
@@ -251,16 +251,30 @@ subroutine modal_aer_opt_init()
    call addfld ('BURDENSOA',horiz_only,  'A','kg/m2'    ,'SOA aerosol burden'         , flag_xyfill=.true.)
    call addfld ('BURDENBC',horiz_only,  'A','kg/m2'     ,'Black carbon aerosol burden', flag_xyfill=.true.)
    call addfld ('BURDENSEASALT',horiz_only,  'A','kg/m2','Seasalt aerosol burden'     , flag_xyfill=.true.)
+   ! ABURDEN... for interstitial and cloud-borne
+   call addfld ('ABURDENDUST',horiz_only,  'A','kg/m2'   ,'Dust aerosol burden'        , flag_xyfill=.true.)
+   call addfld ('ABURDENSO4',horiz_only,  'A','kg/m2'    ,'Sulfate aerosol burden'     , flag_xyfill=.true.)
+   call addfld ('ABURDENPOM',horiz_only,  'A','kg/m2'    ,'POM aerosol burden'         , flag_xyfill=.true.)
+   call addfld ('ABURDENSOA',horiz_only,  'A','kg/m2'    ,'SOA aerosol burden'         , flag_xyfill=.true.)
+   call addfld ('ABURDENBC',horiz_only,  'A','kg/m2'     ,'Black carbon aerosol burden', flag_xyfill=.true.)
+   call addfld ('ABURDENSEASALT',horiz_only,  'A','kg/m2','Seasalt aerosol burden'     , flag_xyfill=.true.)
 #if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
    call addfld ('BURDENMOM',horiz_only,  'A','kg/m2'    ,'Marine organic aerosol burden', flag_xyfill=.true.)
    call addfld ('BURDENNO3',horiz_only,  'A','kg/m2'    ,'Nitrate aerosol burden',        flag_xyfill=.true.)
    call addfld ('BURDENNH4',horiz_only,  'A','kg/m2'    ,'Ammonium aerosol burden',       flag_xyfill=.true.)
+   call addfld ('ABURDENMOM',horiz_only,  'A','kg/m2'    ,'Marine organic aerosol burden', flag_xyfill=.true.)
+   call addfld ('ABURDENNO3',horiz_only,  'A','kg/m2'    ,'Nitrate aerosol burden',        flag_xyfill=.true.)
+   call addfld ('ABURDENNH4',horiz_only,  'A','kg/m2'    ,'Ammonium aerosol burden',       flag_xyfill=.true.)
 #elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
    call addfld ('BURDENMOM',horiz_only,  'A','kg/m2'    ,'Marine organic aerosol burden', flag_xyfill=.true.)
+   call addfld ('ABURDENMOM',horiz_only,  'A','kg/m2'    ,'Marine organic aerosol burden', flag_xyfill=.true.)
 #elif ( defined MODAL_AERO_9MODE )
    call addfld ('BURDENPOLY',horiz_only,  'A','kg/m2'   ,'Marine polysaccharide aerosol burden', flag_xyfill=.true.)
    call addfld ('BURDENPROT',horiz_only,  'A','kg/m2'   ,'Marine protein aerosol burden', flag_xyfill=.true.)
    call addfld ('BURDENLIP',horiz_only,  'A','kg/m2'    ,'Marine lipid aerosol burden'  , flag_xyfill=.true.)
+   call addfld ('ABURDENPOLY',horiz_only,  'A','kg/m2'   ,'Marine polysaccharide aerosol burden', flag_xyfill=.true.)
+   call addfld ('ABURDENPROT',horiz_only,  'A','kg/m2'   ,'Marine protein aerosol burden', flag_xyfill=.true.)
+   call addfld ('ABURDENLIP',horiz_only,  'A','kg/m2'    ,'Marine lipid aerosol burden'  , flag_xyfill=.true.)
 #endif
    call addfld ('SSAVIS',horiz_only,    'A','  ','Aerosol singel-scatter albedo', flag_xyfill=.true.)
 
@@ -327,15 +341,28 @@ subroutine modal_aer_opt_init()
       call add_default ('BURDENSOA'    , 1, ' ')
       call add_default ('BURDENBC'     , 1, ' ')
       call add_default ('BURDENSEASALT', 1, ' ')
+
+      call add_default ('ABURDENDUST'   , 1, ' ')
+      call add_default ('ABURDENSO4'    , 1, ' ')
+      call add_default ('ABURDENPOM'    , 1, ' ')
+      call add_default ('ABURDENSOA'    , 1, ' ')
+      call add_default ('ABURDENBC'     , 1, ' ')
+      call add_default ('ABURDENSEASALT', 1, ' ')
 #if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
       call add_default ('BURDENNO3'    , 1, ' ')
       call add_default ('BURDENNH4'    , 1, ' ')
+      call add_default ('ABURDENNO3'    , 1, ' ')
+      call add_default ('ABURDENNH4'    , 1, ' ')
 #elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
       call add_default ('BURDENMOM'    , 1, ' ')
+      call add_default ('ABURDENMOM'    , 1, ' ')
 #elif ( defined MODAL_AERO_9MODE )
       call add_default ('BURDENPOLY'   , 1, ' ')
       call add_default ('BURDENPROT'   , 1, ' ')
       call add_default ('BURDENLIP'    , 1, ' ')
+      call add_default ('ABURDENPOLY'   , 1, ' ')
+      call add_default ('ABURDENPROT'   , 1, ' ')
+      call add_default ('ABURDENLIP'    , 1, ' ')
 #endif
       end if
       call add_default ('SSAVIS'       , 1, ' ')
@@ -477,6 +504,7 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
    real(r8) :: air_density(pcols,pver) ! (kg/m3)
 
    real(r8),    pointer :: specmmr(:,:)        ! species mass mixing ratio
+   real(r8),    pointer :: aspecmmr(:,:)       ! cloud-borne species mass mixing ratio
    real(r8)             :: specdens            ! species density (kg/m3)
    complex(r8), pointer :: specrefindex(:)     ! species refractive index
    character*32         :: spectype            ! species type
@@ -529,12 +557,17 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
    real(r8) :: burden(pcols)
    real(r8) :: burdendust(pcols), burdenso4(pcols), burdenbc(pcols), &
                burdenpom(pcols), burdensoa(pcols), burdenseasalt(pcols)
+   real(r8) :: aburdendust(pcols), aburdenso4(pcols), aburdenbc(pcols), &
+               aburdenpom(pcols), aburdensoa(pcols), aburdenseasalt(pcols)
 #if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
    real(r8) :: burdenmom(pcols), burdenno3(pcols), burdennh4(pcols)
+   real(r8) :: aburdenmom(pcols), aburdenno3(pcols), aburdennh4(pcols)
 #elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
    real(r8) :: burdenmom(pcols)
+   real(r8) :: aburdenmom(pcols)
 #elif ( defined MODAL_AERO_9MODE )
    real(r8) :: burdenpoly(pcols), burdenprot(pcols), burdenlip(pcols)
+   real(r8) :: aburdenpoly(pcols), aburdenprot(pcols), aburdenlip(pcols)
 #endif
 
    real(r8) :: aodmode(pcols)
@@ -632,20 +665,33 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
    burdensoa(:ncol)      = 0.0_r8
    burdenbc(:ncol)       = 0.0_r8
    burdenseasalt(:ncol)  = 0.0_r8
+   aburdendust(:ncol)     = 0.0_r8
+   aburdenso4(:ncol)      = 0.0_r8
+   aburdenpom(:ncol)      = 0.0_r8
+   aburdensoa(:ncol)      = 0.0_r8
+   aburdenbc(:ncol)       = 0.0_r8
+   aburdenseasalt(:ncol)  = 0.0_r8
 #if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
    burdenmom(:ncol)      = 0.0_r8
    burdenno3(:ncol)      = 0.0_r8
    burdennh4(:ncol)      = 0.0_r8
+   aburdenmom(:ncol)      = 0.0_r8
+   aburdenno3(:ncol)      = 0.0_r8
+   aburdennh4(:ncol)      = 0.0_r8
    momaod(:ncol)         = 0.0_r8
    no3aod(:ncol)         = 0.0_r8
    nh4aod(:ncol)         = 0.0_r8
 #elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
    burdenmom(:ncol)      = 0.0_r8
+   aburdenmom(:ncol)      = 0.0_r8
    momaod(:ncol)         = 0.0_r8
 #elif ( defined MODAL_AERO_9MODE )
    burdenpoly(:ncol)     = 0.0_r8
    burdenprot(:ncol)     = 0.0_r8
    burdenlip(:ncol)      = 0.0_r8
+   aburdenpoly(:ncol)     = 0.0_r8
+   aburdenprot(:ncol)     = 0.0_r8
+   aburdenlip(:ncol)      = 0.0_r8
    polyaod(:ncol)        = 0.0_r8
    protaod(:ncol)        = 0.0_r8
    lipaod(:ncol)         = 0.0_r8
@@ -769,6 +815,7 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
             ! aerosol species loop
             do l = 1, nspec
                call rad_cnst_get_aer_mmr(list_idx, m, l, 'a', state, pbuf, specmmr)
+               call rad_cnst_get_aer_mmr(list_idx, m, l, 'c', state, pbuf, aspecmmr)
                call rad_cnst_get_aer_props(list_idx, m, l, density_aer=specdens, &
                                            refindex_aer_sw=specrefindex, spectype=spectype, &
                                            hygro_aer=hygro_aer)
@@ -793,6 +840,7 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
                   if ((trim(spectype) == 'dust') .or. (trim(spectype) == 'carbonate') .or. (trim(spectype) == 'calcium')) then
                      do i = 1, ncol
                         burdendust(i) = burdendust(i) + specmmr(i,k)*mass(i,k)
+                        aburdendust(i) = aburdendust(i) + specmmr(i,k)*mass(i,k) + aspecmmr(i,k)*mass(i,k)
                         dustvol(i)    = dustvol(i) + vol(i)
                         scatdust(i)   = scatdust(i) + vol(i)*specrefr
                         absdust(i)    = absdust(i) - vol(i)*specrefi
@@ -803,6 +851,7 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
                   if (trim(spectype) == 'dust') then
                      do i = 1, ncol
                         burdendust(i) = burdendust(i) + specmmr(i,k)*mass(i,k)
+                        aburdendust(i) = aburdendust(i) + specmmr(i,k)*mass(i,k) + aspecmmr(i,k)*mass(i,k)
                         dustvol(i)    = vol(i)
                         scatdust(i)   = vol(i)*specrefr
                         absdust(i)    = -vol(i)*specrefi
@@ -813,6 +862,7 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
                   if (trim(spectype) == 'sulfate') then
                      do i = 1, ncol
                         burdenso4(i) = burdenso4(i) + specmmr(i,k)*mass(i,k)
+                        aburdenso4(i) = aburdenso4(i) + specmmr(i,k)*mass(i,k) + aspecmmr(i,k)*mass(i,k)
                         scatso4(i)   = vol(i)*specrefr
                         absso4(i)    = -vol(i)*specrefi
                         hygroso4(i)  = vol(i)*hygro_aer
@@ -822,6 +872,7 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
                   if (trim(spectype) == 'nitrate') then
                      do i = 1, ncol
                         burdenno3(i) = burdenno3(i) + specmmr(i,k)*mass(i,k)
+                        aburdenno3(i) = aburdenno3(i) + specmmr(i,k)*mass(i,k) + aspecmmr(i,k)*mass(i,k)
                         scatno3(i)   = vol(i)*specrefr
                         absno3(i)    = -vol(i)*specrefi
                         hygrono3(i)  = vol(i)*hygro_aer
@@ -830,6 +881,7 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
                   if (trim(spectype) == 'ammonium') then
                      do i = 1, ncol
                         burdennh4(i) = burdennh4(i) + specmmr(i,k)*mass(i,k)
+                        aburdennh4(i) = aburdennh4(i) + specmmr(i,k)*mass(i,k) + aspecmmr(i,k)*mass(i,k)
                         scatnh4(i)   = vol(i)*specrefr
                         absnh4(i)    = -vol(i)*specrefi
                         hygronh4(i)  = vol(i)*hygro_aer
@@ -839,6 +891,7 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
                   if (trim(spectype) == 'black-c') then
                      do i = 1, ncol
                         burdenbc(i) = burdenbc(i) + specmmr(i,k)*mass(i,k)
+                        aburdenbc(i) = aburdenbc(i) + specmmr(i,k)*mass(i,k) + aspecmmr(i,k)*mass(i,k)
                         scatbc(i)   = vol(i)*specrefr
                         absbc(i)    = -vol(i)*specrefi
                         hygrobc(i)  = vol(i)*hygro_aer
@@ -847,6 +900,7 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
                   if (trim(spectype) == 'p-organic') then
                      do i = 1, ncol
                         burdenpom(i) = burdenpom(i) + specmmr(i,k)*mass(i,k)
+                        aburdenpom(i) = aburdenpom(i) + specmmr(i,k)*mass(i,k) + aspecmmr(i,k)*mass(i,k)
                         scatpom(i)   = vol(i)*specrefr
                         abspom(i)    = -vol(i)*specrefi
                         hygropom(i)  = vol(i)*hygro_aer
@@ -855,6 +909,7 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
                   if (trim(spectype) == 's-organic') then
                      do i = 1, ncol
                         burdensoa(i) = burdensoa(i) + specmmr(i,k)*mass(i,k)
+                        aburdensoa(i) = aburdensoa(i) + specmmr(i,k)*mass(i,k) + aspecmmr(i,k)*mass(i,k)
                         scatsoa(i)   = vol(i)*specrefr
                         abssoa(i)    = -vol(i)*specrefi
                         hygrosoa(i)  = vol(i)*hygro_aer
@@ -864,6 +919,7 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
                   if ((trim(spectype) == 'seasalt') .or. (trim(spectype) == 'chloride')) then
                      do i = 1, ncol
                         burdenseasalt(i) = burdenseasalt(i) + specmmr(i,k)*mass(i,k)
+                        aburdenseasalt(i) = aburdenseasalt(i) + specmmr(i,k)*mass(i,k) + aspecmmr(i,k)*mass(i,k)
                         scatseasalt(i)   = scatseasalt(i) + vol(i)*specrefr
                         absseasalt(i)    = absseasalt(i) - vol(i)*specrefi
                         hygroseasalt(i)  = hygroseasalt(i) + vol(i)*hygro_aer
@@ -873,6 +929,7 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
                   if (trim(spectype) == 'seasalt') then
                      do i = 1, ncol
                         burdenseasalt(i) = burdenseasalt(i) + specmmr(i,k)*mass(i,k)
+                        aburdenseasalt(i) = aburdenseasalt(i) + specmmr(i,k)*mass(i,k) + aspecmmr(i,k)*mass(i,k)
                         scatseasalt(i)   = vol(i)*specrefr
                         absseasalt(i)    = -vol(i)*specrefi
                         hygroseasalt(i)  = vol(i)*hygro_aer
@@ -883,6 +940,7 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
                   if (trim(spectype) == 'm-organic') then
                      do i = 1, ncol
                         burdenmom(i) = burdenmom(i) + specmmr(i,k)*mass(i,k)
+                        aburdenmom(i) = aburdenmom(i) + specmmr(i,k)*mass(i,k) + aspecmmr(i,k)*mass(i,k)
                         scatmom(i)   = vol(i)*specrefr
                         absmom(i)    = -vol(i)*specrefi
                         hygromom(i)  = vol(i)*hygro_aer
@@ -892,6 +950,7 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
                   if (trim(spectype) == 'm-poly') then
                      do i = 1, ncol
                         burdenpoly(i) = burdenpoly(i) + specmmr(i,k)*mass(i,k)
+                        aburdenpoly(i) = aburdenpoly(i) + specmmr(i,k)*mass(i,k) + aspecmmr(i,k)*mass(i,k)
                         scatpoly(i)   = vol(i)*specrefr
                         abspoly(i)    = -vol(i)*specrefi
                         hygropoly(i)  = vol(i)*hygro_aer
@@ -900,6 +959,7 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
                   if (trim(spectype) == 'm-prot') then
                      do i = 1, ncol
                         burdenprot(i) = burdenprot(i) + specmmr(i,k)*mass(i,k)
+                        aburdenprot(i) = aburdenprot(i) + specmmr(i,k)*mass(i,k) + aspecmmr(i,k)*mass(i,k)
                         scatprot(i)   = vol(i)*specrefr
                         absprot(i)    = -vol(i)*specrefi
                         hygroprot(i)  = vol(i)*hygro_aer
@@ -908,6 +968,7 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
                   if (trim(spectype) == 'm-lip') then
                      do i = 1, ncol
                         burdenlip(i) = burdenlip(i) + specmmr(i,k)*mass(i,k)
+                        aburdenlip(i) = aburdenlip(i) + specmmr(i,k)*mass(i,k) + aspecmmr(i,k)*mass(i,k)
                         scatlip(i)   = vol(i)*specrefr
                         abslip(i)    = -vol(i)*specrefi
                         hygrolip(i)  = vol(i)*hygro_aer
@@ -1325,17 +1386,30 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
       call outfld('BURDENSOA' ,    burdensoa,     pcols, lchnk)
       call outfld('BURDENBC'  ,    burdenbc,      pcols, lchnk)
       call outfld('BURDENSEASALT', burdenseasalt, pcols, lchnk)
+      call outfld('ABURDENDUST',    aburdendust,    pcols, lchnk)
+      call outfld('ABURDENSO4' ,    aburdenso4,     pcols, lchnk)
+      call outfld('ABURDENPOM' ,    aburdenpom,     pcols, lchnk)
+      call outfld('ABURDENSOA' ,    aburdensoa,     pcols, lchnk)
+      call outfld('ABURDENBC'  ,    aburdenbc,      pcols, lchnk)
+      call outfld('ABURDENSEASALT', aburdenseasalt, pcols, lchnk)
 
 #if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined MOSAIC_SPECIES ) )
       call outfld('BURDENMOM',     burdenmom,     pcols, lchnk)
       call outfld('BURDENNO3',     burdenno3,     pcols, lchnk)
       call outfld('BURDENNH4',     burdennh4,     pcols, lchnk)
+      call outfld('ABURDENMOM',     aburdenmom,     pcols, lchnk)
+      call outfld('ABURDENNO3',     aburdenno3,     pcols, lchnk)
+      call outfld('ABURDENNH4',     aburdennh4,     pcols, lchnk)
 #elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) 
       call outfld('BURDENMOM', burdenmom, pcols, lchnk)
+      call outfld('ABURDENMOM', aburdenmom, pcols, lchnk)
 #elif ( defined MODAL_AERO_9MODE )
       call outfld('BURDENPOLY', burdenpoly, pcols, lchnk)
       call outfld('BURDENPROT', burdenprot, pcols, lchnk)
       call outfld('BURDENLIP', burdenlip, pcols, lchnk)
+      call outfld('ABURDENPOLY', aburdenpoly, pcols, lchnk)
+      call outfld('ABURDENPROT', aburdenprot, pcols, lchnk)
+      call outfld('ABURDENLIP', aburdenlip, pcols, lchnk)
 #endif
 
       call outfld('AODABSBC',      aodabsbc,      pcols, lchnk)


### PR DESCRIPTION
add cloud-borne aerosols to 2D burden outputs 

xref: https://github.com/E3SM-Project/e3sm_diags/issues/681

This PR adds new diagnostic fields to output the total aerosol 2D burdens (both interstitial and cloud-borne). The cloud-borne aerosol burden is expected to be less than 10% of the total burden. See figure below from a two-month free-running simulation showing that these added new terms (`ABURDEN...`) are working as expected vis-a-vis their predecessors (`BURDEN...`).

This came up during the coupled team meeting, internal link: https://acme-climate.atlassian.net/wiki/spaces/CM/pages/3749576957/2023-04-17+Coupled+Model+-+Meeting+notes.

The issue was discussed in https://github.com/E3SM-Project/e3sm_diags/pull/676 and https://github.com/E3SM-Project/e3sm_diags/issues/681. 

<details><summary>Plots showing difference between BURDEN... and ABURDEN... terms</summary>
<p>

![test-aburd](https://user-images.githubusercontent.com/122953255/233147997-f4771327-a5e6-4067-8749-01ba58b5ad6b.png)

</p>
</details> 



[BFB]