### PR TITLE
Fix threading and pe-layout NBFB issues in UCI-chem codes

### DIFF
--- a/components/eam/src/chemistry/mozart/lin_strat_chem.F90
+++ b/components/eam/src/chemistry/mozart/lin_strat_chem.F90
@@ -369,7 +369,11 @@ end subroutine linoz_readnl
        xsfc(2,:)=   linoz_n2o_clim(:,pver) !  n2o (constant throughout latitude)
        xsfc(3,:)=   linoz_o3lbs(:,pver)*3.e-3_r8  !noylnz
        xsfc(4,:)=   linoz_ch4_clim(:,pver) ! ch4 (constant throughout latitude)
-       ch4max =     maxval(linoz_ch4_clim(1:ncol,pver)) 
+
+! The  local maxval calculation causes NBFB when ncol varies due to threading or pe-layout change
+! Tentatively uses a fixed value
+!      ch4max =     maxval(linoz_ch4_clim(1:ncol,pver)) 
+       ch4max =     1.8e-6_r8
        pw= 2.0_r8 * ch4max + 3.65e-6_r8 
  
 ! OZONE P-L terms !unit vmr/sec
@@ -694,7 +698,7 @@ end subroutine linoz_readnl
     real(r8), intent(in)                           :: delta_t             ! timestep size (secs)
     real(r8), intent(in)                           :: rlats(ncol)         ! column latitudes (radians)
     integer,  intent(in)   , dimension(pcols)      :: ltrop               ! chunk index
-    real(r8), intent(in)   , dimension(ncol ,pver) :: pdeldry             !  dry pressure delta about midpoints (Pa)
+    real(r8), intent(in)   , dimension(pcols,pver) :: pdeldry             !  dry pressure delta about midpoints (Pa)
     logical, optional, intent(in)                  :: tropFlag(pcols,pver)! 3D tropospheric level flag
     !
     ! local

--- a/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -1570,18 +1570,20 @@ contains
        do m = 1,pcnst
           n = map2chm( m )
           if ( n > 0 ) then
-            if ( any( cflx(:ncol,m) /= 0._r8 ) ) then
+           do i=1,ncol
+            if ( cflx(i,m) /= 0._r8  ) then
               if ( .not. any( aer_species == n ) .and. adv_mass(n) /= 0._r8 ) then
                 do k = pver, pver-srf_emit_nlayer+1, -1 ! loop from bottom to top
                   ! kg/m2, tracer mass
-                  wrk(:ncol,k) = adv_mass(n)*vmr(:ncol,k,n)/mbar(:ncol,k) &
-                                    *pdeldry(:ncol,k)*rga
-                  tmp(:ncol) = wrk(:ncol,k) + cflx(:ncol,m)*delt/dble(srf_emit_nlayer)
-                  vmr(:ncol,k,n) = tmp(:ncol)*mbar(:ncol,k)/adv_mass(n)/pdeldry(:ncol,k)/rga
+                  wrk(i,k) = adv_mass(n)*vmr(i,k,n)/mbar(i,k) &
+                                    *pdeldry(i,k)*rga
+                  tmp(i) = wrk(i,k) + cflx(i,m)*delt/dble(srf_emit_nlayer)
+                  vmr(i,k,n) = tmp(i)*mbar(i,k)/adv_mass(n)/pdeldry(i,k)/rga
                 end do
-                cflx(:ncol,m) = 0._r8
+                cflx(i,m) = 0._r8
               endif
             endif
+           end do
           endif
        end do
     endif


### PR DESCRIPTION
. Fixed array shape pdeldry in lin_strat_chem.F90 that would failed debug mode . Replaced ch4max calculation with a global constant. A tentative fix for NBFB
  that would otherwise have
. Fixed codes for surface emission section in mo_gas_phase_chemdr.F90 that
   cause round-off NBFB when threading or pe-layout changes

[NBFB]