### PR TITLE
modified the ngd_v3atm to fit for linoz simulation

### DIFF
--- a/components/eam/bld/namelist_files/use_cases/SSP370_eam_CMIP6.xml
+++ b/components/eam/bld/namelist_files/use_cases/SSP370_eam_CMIP6.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0"?>
+<namelist_defaults>
+
+<!-- Set default output options for CMIP6 simulations -->
+<cosp_lite>.true.</cosp_lite>
+
+<!-- Solar constant from CMIP6 input4MIPS -->
+<solar_data_file>atm/cam/solar/Solar_1850-2299_input4MIPS_c20181106.nc</solar_data_file>
+<solar_data_type>SERIAL</solar_data_type>
+
+<!-- GHG values from CMIP6 input4MIPS -->
+<bndtvghg>atm/cam/ggas/GHG_CMIP_SSP370-1-2-1_Annual_Global_2015-2500_c20210509.nc</bndtvghg>
+<scenario_ghg>RAMPED</scenario_ghg>
+
+<!-- Stratospheric aerosols from CMIP6 input4MIPS -->
+<prescribed_volcaero_datapath>atm/cam/volc                                             </prescribed_volcaero_datapath>
+<prescribed_volcaero_file    >CMIP_DOE-ACME_radiation_average_1850-2014_v3_c20171204.nc</prescribed_volcaero_file    >
+<prescribed_volcaero_filetype>VOLC_CMIP6					       </prescribed_volcaero_filetype>
+<prescribed_volcaero_type    >CYCLICAL						       </prescribed_volcaero_type    >
+<prescribed_volcaero_cycle_yr>1                                                        </prescribed_volcaero_cycle_yr>
+
+<!-- For comprehensive history -->
+<history_amwg>.true.</history_amwg>
+<history_aerosol>.true.</history_aerosol>
+<history_aero_optics>.true.</history_aero_optics>
+
+<!-- External forcing for BAM or MAM.  CMIP6 input4mips data -->
+<ext_frc_type>INTERP_MISSING_MONTHS</ext_frc_type>
+<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP370_ne30/cmip6_ssp370_mam4_so2_elev_2015-2100_c210216.nc </so2_ext_file>
+<soag_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP370_ne30/cmip6_ssp370_mam4_soag_elev_2015-2100_c210216.nc </soag_ext_file>
+<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP370_ne30/cmip6_ssp370_mam4_bc_a4_elev_2015-2100_c210216.nc </bc_a4_ext_file>
+<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP370_ne30/cmip6_ssp370_mam4_num_a1_elev_2015-2100_c210216.nc </mam7_num_a1_ext_file>
+<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP370_ne30/cmip6_ssp370_mam4_num_a2_elev_2015-2100_c210216.nc </num_a2_ext_file>
+<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP370_ne30/cmip6_ssp370_mam4_num_a4_elev_2015-2100_c210216.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP370_ne30/cmip6_ssp370_mam4_pom_a4_elev_2015-2100_c210216.nc </pom_a4_ext_file>
+<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP370_ne30/cmip6_ssp370_mam4_so4_a1_elev_2015-2100_c210216.nc </so4_a1_ext_file>
+<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP370_ne30/cmip6_ssp370_mam4_so4_a2_elev_2015-2100_c210216.nc </so4_a2_ext_file>
+
+<!-- Surface emissions for MAM4.  CMIP6 input4mips data -->
+<srf_emis_type>INTERP_MISSING_MONTHS</srf_emis_type>
+<dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.1850-2100.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160727.nc</dms_emis_file>
+<so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP370_ne30/cmip6_ssp370_mam4_so2_surf_2015-2100_c210216.nc </so2_emis_file>
+<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP370_ne30/cmip6_ssp370_mam4_bc_a4_surf_2015-2100_c210216.nc </bc_a4_emis_file>
+<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP370_ne30/cmip6_ssp370_mam4_num_a1_surf_2015-2100_c210216.nc </mam7_num_a1_emis_file>
+<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP370_ne30/cmip6_ssp370_mam4_num_a2_surf_2015-2100_c210216.nc </num_a2_emis_file>
+<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP370_ne30/cmip6_ssp370_mam4_num_a4_surf_2015-2100_c210216.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP370_ne30/cmip6_ssp370_mam4_pom_a4_surf_2015-2100_c210216.nc </pom_a4_emis_file>
+<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP370_ne30/cmip6_ssp370_mam4_so4_a1_surf_2015-2100_c210216.nc </so4_a1_emis_file>
+<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP370_ne30/cmip6_ssp370_mam4_so4_a2_surf_2015-2100_c210216.nc </so4_a2_emis_file>
+
+<!-- Prescribed oxidants for aerosol chemistry.   Ozone is from CMIP6 input4MIPS file -->
+<tracer_cnst_type    >INTERP_MISSING_MONTHS</tracer_cnst_type>
+<tracer_cnst_datapath>atm/cam/chem/trop_mozart_aero/oxid</tracer_cnst_datapath>
+<tracer_cnst_file    >oxid_SSP370_1.9x2.5_L70_2015-2100_c20211006.nc</tracer_cnst_file>
+<tracer_cnst_filelist>''</tracer_cnst_filelist>
+
+<!-- <tracer_cnst_filelist>this_field_is_not_used</tracer_cnst_filelist> -->
+
+<!-- Marine organic aerosol namelist settings -->
+<mam_mom_mixing_state>3</mam_mom_mixing_state>
+<mam_mom_cycle_yr  >1                                                                                    </mam_mom_cycle_yr  >
+<mam_mom_datapath  >'atm/cam/chem/trop_mam/marine_BGC/'                                                  </mam_mom_datapath  >
+<mam_mom_datatype  >'CYCLICAL'										 </mam_mom_datatype  >
+<mam_mom_filename  >'monthly_macromolecules_0.1deg_bilinear_latlon_year01_merge_date.nc'                 </mam_mom_filename  > <!-- Using the 2000 file, for now -->
+<mam_mom_fixed_tod >0											 </mam_mom_fixed_tod >
+<mam_mom_fixed_ymd >0											 </mam_mom_fixed_ymd >
+<mam_mom_specifier >'chla:CHL1','mpoly:TRUEPOLYC','mprot:TRUEPROTC','mlip:TRUELIPC'			 </mam_mom_specifier >
+
+<!-- Stratospheric ozone (Linoz) updated using CMIP6 input4MIPS GHG concentrations -->
+<chlorine_loading_file      >atm/cam/chem/trop_mozart/ub/Linoz_Chlorine_Loading_CMIP6_Hist_SSP370_0003-2503_c20210202.nc</chlorine_loading_file>
+<chlorine_loading_type      >SERIAL</chlorine_loading_type>
+<linoz_data_file            >linoz_1850-2500_CMIP6_Hist_SSP370_10deg_58km_c20210202.nc</linoz_data_file>
+<linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
+<linoz_data_type            >INTERP_MISSING_MONTHS</linoz_data_type>
+
+<!-- Turn off ozone dry deposition, as Linoz O3v2 and ozone are not separated for now. Need to turn on ozone dry deposition when interactive tropospheric chemistry is implemented -->
+<drydep_list            >'H2O2', 'H2SO4', 'SO2'</drydep_list>
+
+<!-- sim_year used for CLM datasets and SSTs forcings -->
+<sim_year>2015-2100</sim_year>
+
+</namelist_defaults>

--- a/components/eam/bld/namelist_files/use_cases/SSP370_eam_chemUCI-Linoz.xml
+++ b/components/eam/bld/namelist_files/use_cases/SSP370_eam_chemUCI-Linoz.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0"?>
+<namelist_defaults>
+
+<!-- Set default output options for CMIP6 simulations -->
+<cosp_lite>.true.</cosp_lite>
+
+<!-- Solar constant from CMIP6 input4MIPS -->
+<solar_data_file>atm/cam/solar/Solar_1850-2299_input4MIPS_c20181106.nc</solar_data_file>
+<solar_data_type>SERIAL</solar_data_type>
+
+<!-- GHG values from CMIP6 input4MIPS -->
+<bndtvghg>atm/cam/ggas/GHG_CMIP_SSP370-1-2-1_Annual_Global_2015-2500_c20210509.nc</bndtvghg>
+<scenario_ghg>RAMPED</scenario_ghg>
+
+<!-- Stratospheric aerosols from CMIP6 input4MIPS -->
+<prescribed_volcaero_datapath>atm/cam/volc                                             </prescribed_volcaero_datapath>
+<prescribed_volcaero_file    >CMIP_DOE-ACME_radiation_average_1850-2014_v3_c20171204.nc</prescribed_volcaero_file    >
+<prescribed_volcaero_filetype>VOLC_CMIP6					       </prescribed_volcaero_filetype>
+<prescribed_volcaero_type    >CYCLICAL						       </prescribed_volcaero_type    >
+<prescribed_volcaero_cycle_yr>1                                                        </prescribed_volcaero_cycle_yr>
+
+<!-- For comprehensive history -->
+<history_amwg>.true.</history_amwg>
+<history_aerosol>.true.</history_aerosol>
+<history_aero_optics>.true.</history_aero_optics>
+
+<!-- External forcing for BAM or MAM.  CMIP6 input4mips data -->
+<ext_frc_type>INTERP_MISSING_MONTHS</ext_frc_type>
+<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP370_ne30/cmip6_ssp370_mam4_so2_elev_2015-2100_c210216.nc </so2_ext_file>
+<soag_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP370_ne30/cmip6_ssp370_mam4_soag_elev_2015-2100_c210216.nc </soag_ext_file>
+<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP370_ne30/cmip6_ssp370_mam4_bc_a4_elev_2015-2100_c210216.nc </bc_a4_ext_file>
+<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP370_ne30/cmip6_ssp370_mam4_num_a1_elev_2015-2100_c210216.nc </mam7_num_a1_ext_file>
+<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP370_ne30/cmip6_ssp370_mam4_num_a2_elev_2015-2100_c210216.nc </num_a2_ext_file>
+<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP370_ne30/cmip6_ssp370_mam4_num_a4_elev_2015-2100_c210216.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP370_ne30/cmip6_ssp370_mam4_pom_a4_elev_2015-2100_c210216.nc </pom_a4_ext_file>
+<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP370_ne30/cmip6_ssp370_mam4_so4_a1_elev_2015-2100_c210216.nc </so4_a1_ext_file>
+<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP370_ne30/cmip6_ssp370_mam4_so4_a2_elev_2015-2100_c210216.nc </so4_a2_ext_file>
+
+<!-- Surface emissions for MAM4.  CMIP6 input4mips data -->
+<srf_emis_type>INTERP_MISSING_MONTHS</srf_emis_type>
+<dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.1850-2100.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160727.nc</dms_emis_file>
+<so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP370_ne30/cmip6_ssp370_mam4_so2_surf_2015-2100_c210216.nc </so2_emis_file>
+<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP370_ne30/cmip6_ssp370_mam4_bc_a4_surf_2015-2100_c210216.nc </bc_a4_emis_file>
+<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP370_ne30/cmip6_ssp370_mam4_num_a1_surf_2015-2100_c210216.nc </mam7_num_a1_emis_file>
+<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP370_ne30/cmip6_ssp370_mam4_num_a2_surf_2015-2100_c210216.nc </num_a2_emis_file>
+<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP370_ne30/cmip6_ssp370_mam4_num_a4_surf_2015-2100_c210216.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP370_ne30/cmip6_ssp370_mam4_pom_a4_surf_2015-2100_c210216.nc </pom_a4_emis_file>
+<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP370_ne30/cmip6_ssp370_mam4_so4_a1_surf_2015-2100_c210216.nc </so4_a1_emis_file>
+<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP370_ne30/cmip6_ssp370_mam4_so4_a2_surf_2015-2100_c210216.nc </so4_a2_emis_file>
+
+<!-- Prescribed oxidants for aerosol chemistry.   Ozone is from CMIP6 input4MIPS file -->
+<tracer_cnst_type    >INTERP_MISSING_MONTHS</tracer_cnst_type>
+<tracer_cnst_datapath>atm/cam/chem/trop_mozart_aero/oxid</tracer_cnst_datapath>
+<tracer_cnst_file    >oxid_SSP370_1.9x2.5_L70_2015-2100_c20211006.nc</tracer_cnst_file>
+<tracer_cnst_filelist>''</tracer_cnst_filelist>
+
+<!-- <tracer_cnst_filelist>this_field_is_not_used</tracer_cnst_filelist> -->
+
+<!-- Marine organic aerosol namelist settings -->
+<mam_mom_mixing_state>3</mam_mom_mixing_state>
+<mam_mom_cycle_yr  >1                                                                                    </mam_mom_cycle_yr  >
+<mam_mom_datapath  >'atm/cam/chem/trop_mam/marine_BGC/'                                                  </mam_mom_datapath  >
+<mam_mom_datatype  >'CYCLICAL'										 </mam_mom_datatype  >
+<mam_mom_filename  >'monthly_macromolecules_0.1deg_bilinear_latlon_year01_merge_date.nc'                 </mam_mom_filename  > <!-- Using the 2000 file, for now -->
+<mam_mom_fixed_tod >0											 </mam_mom_fixed_tod >
+<mam_mom_fixed_ymd >0											 </mam_mom_fixed_ymd >
+<mam_mom_specifier >'chla:CHL1','mpoly:TRUEPOLYC','mprot:TRUEPROTC','mlip:TRUELIPC'			 </mam_mom_specifier >
+
+<!-- Stratospheric ozone (Linoz) updated using CMIP6 input4MIPS GHG concentrations -->
+<chlorine_loading_file      >atm/cam/chem/trop_mozart/ub/Linoz_Chlorine_Loading_CMIP6_Hist_SSP370_0003-2503_c20210202.nc</chlorine_loading_file>
+<chlorine_loading_type      >SERIAL</chlorine_loading_type>
+<linoz_data_file            >linoz_1850-2500_CMIP6_Hist_SSP370_10deg_58km_c20210202.nc</linoz_data_file>
+<linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
+<linoz_data_type            >INTERP_MISSING_MONTHS</linoz_data_type>
+
+<!-- Turn off ozone dry deposition, as Linoz O3v2 and ozone are not separated for now. Need to turn on ozone dry deposition when interactive tropospheric chemistry is implemented -->
+<drydep_list            >'H2O2', 'H2SO4', 'SO2'</drydep_list>
+
+<!-- sim_year used for CLM datasets and SSTs forcings -->
+<sim_year>2015-2100</sim_year>
+
+</namelist_defaults>

--- a/components/eam/bld/namelist_files/use_cases/SSP585_eam_CMIP6.xml
+++ b/components/eam/bld/namelist_files/use_cases/SSP585_eam_CMIP6.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0"?>
+<namelist_defaults>
+
+<!-- Set default output options for CMIP6 simulations -->
+<cosp_lite>.true.</cosp_lite>
+
+<!-- Solar constant from CMIP6 input4MIPS -->
+<solar_data_file>atm/cam/solar/Solar_1850-2299_input4MIPS_c20181106.nc</solar_data_file>
+<solar_data_type>SERIAL</solar_data_type>
+
+<!-- GHG values from CMIP6 input4MIPS -->
+<bndtvghg>atm/cam/ggas/GHG_CMIP_SSP585-1-2-1_Annual_Global_2015-2500_c20190310.nc</bndtvghg>
+<scenario_ghg>RAMPED</scenario_ghg>
+
+<!-- Stratospheric aerosols from CMIP6 input4MIPS -->
+<prescribed_volcaero_datapath>atm/cam/volc                                             </prescribed_volcaero_datapath>
+<prescribed_volcaero_file    >CMIP_DOE-ACME_radiation_average_1850-2014_v3_c20171204.nc</prescribed_volcaero_file    >
+<prescribed_volcaero_filetype>VOLC_CMIP6					       </prescribed_volcaero_filetype>
+<prescribed_volcaero_type    >CYCLICAL						       </prescribed_volcaero_type    >
+<prescribed_volcaero_cycle_yr>1                                                        </prescribed_volcaero_cycle_yr>
+
+<!-- For comprehensive history -->
+<history_amwg>.true.</history_amwg>
+<history_aerosol>.true.</history_aerosol>
+<history_aero_optics>.true.</history_aero_optics>
+
+<!-- External forcing for BAM or MAM.  CMIP6 input4mips data -->
+<ext_frc_type>INTERP_MISSING_MONTHS</ext_frc_type>
+<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_so2_elev_2015-2100_c190828.nc </so2_ext_file>
+<soag_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_soag_elev_2015-2100_c190828.nc </soag_ext_file>
+<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_bc_a4_elev_2015-2100_c190828.nc </bc_a4_ext_file>
+<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_num_a1_elev_2015-2100_c190828.nc </mam7_num_a1_ext_file>
+<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_num_a2_elev_2015-2100_c190828.nc </num_a2_ext_file>
+<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_num_a4_elev_2015-2100_c190828.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_pom_a4_elev_2015-2100_c190828.nc </pom_a4_ext_file>
+<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_so4_a1_elev_2015-2100_c190828.nc </so4_a1_ext_file>
+<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_so4_a2_elev_2015-2100_c190828.nc </so4_a2_ext_file>
+
+<!-- Surface emissions for MAM4.  CMIP6 input4mips data -->
+<srf_emis_type>INTERP_MISSING_MONTHS</srf_emis_type>
+<dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.1850-2100.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160727.nc</dms_emis_file>
+<so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_so2_surf_2015-2100_c190828.nc </so2_emis_file>
+<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_bc_a4_surf_2015-2100_c190828.nc </bc_a4_emis_file>
+<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_num_a1_surf_2015-2100_c190828.nc </mam7_num_a1_emis_file>
+<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_num_a2_surf_2015-2100_c190828.nc </num_a2_emis_file>
+<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_num_a4_surf_2015-2100_c190828.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_pom_a4_surf_2015-2100_c190828.nc </pom_a4_emis_file>
+<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_so4_a1_surf_2015-2100_c190828.nc </so4_a1_emis_file>
+<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_so4_a2_surf_2015-2100_c190828.nc </so4_a2_emis_file>
+
+<!-- Prescribed oxidants for aerosol chemistry.   Ozone is from CMIP6 input4MIPS file -->
+<tracer_cnst_type    >INTERP_MISSING_MONTHS</tracer_cnst_type>
+<tracer_cnst_datapath>atm/cam/chem/trop_mozart_aero/oxid</tracer_cnst_datapath>
+<tracer_cnst_file    >oxid_1.9x2.5_L70_2015-2100_c20190421.nc</tracer_cnst_file>
+<tracer_cnst_filelist>''</tracer_cnst_filelist>
+
+<!-- <tracer_cnst_filelist>this_field_is_not_used</tracer_cnst_filelist> -->
+
+<!-- Marine organic aerosol namelist settings -->
+<mam_mom_mixing_state>3</mam_mom_mixing_state>
+<mam_mom_cycle_yr  >1                                                                                    </mam_mom_cycle_yr  >
+<mam_mom_datapath  >'atm/cam/chem/trop_mam/marine_BGC/'                                                  </mam_mom_datapath  >
+<mam_mom_datatype  >'CYCLICAL'										 </mam_mom_datatype  >
+<mam_mom_filename  >'monthly_macromolecules_0.1deg_bilinear_latlon_year01_merge_date.nc'                 </mam_mom_filename  > <!-- Using the 2000 file, for now -->
+<mam_mom_fixed_tod >0											 </mam_mom_fixed_tod >
+<mam_mom_fixed_ymd >0											 </mam_mom_fixed_ymd >
+<mam_mom_specifier >'chla:CHL1','mpoly:TRUEPOLYC','mprot:TRUEPROTC','mlip:TRUELIPC'			 </mam_mom_specifier >
+
+<!-- Stratospheric ozone (Linoz) updated using CMIP6 input4MIPS GHG concentrations -->
+<chlorine_loading_file      >atm/cam/chem/trop_mozart/ub/Linoz_Chlorine_Loading_CMIP6_Hist_SSP585_0003-2503_c20190414.nc</chlorine_loading_file>
+<chlorine_loading_type      >SERIAL</chlorine_loading_type>
+<linoz_data_file            >linoz_1850-2500_CMIP6_Hist_SSP585_10deg_58km_c20190414.nc</linoz_data_file>
+<linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
+<linoz_data_type            >INTERP_MISSING_MONTHS</linoz_data_type>
+
+<!-- Turn off ozone dry deposition, as Linoz O3v2 and ozone are not separated for now. Need to turn on ozone dry deposition when interactive tropospheric chemistry is implemented -->
+<drydep_list            >'H2O2', 'H2SO4', 'SO2'</drydep_list>
+
+<!-- sim_year used for CLM datasets and SSTs forcings -->
+<sim_year>2015-2100</sim_year>
+
+</namelist_defaults>

--- a/components/eam/cime_config/config_component.xml
+++ b/components/eam/cime_config/config_component.xml
@@ -150,6 +150,9 @@
       <value compset="20TR(?:SOI)?_EAM.*AV1C-L.*_BGC%B">20TR_cam5_av1c-04p2_bgc</value>
       <value compset="20TR(?:SOI)?_EAM.*CMIP6"  >20TR_eam_CMIP6</value>
       <value compset="20TR(?:SOI)?_EAM.*CMIP6.*_BGC%B"  >20TR_cam5_CMIP6_bgc</value>
+      <value compset="SSP370(?:SOI)?_EAM.*CHEMUCI.*LINOZ">SSP370_eam_chemUCI-Linoz</value>
+      <value compset="SSP370(?:SOI)?_EAM.*CMIP6">SSP370_eam_CMIP6</value>
+      <value compset="SSP370(?:SOI)?_EAM.*CMIP6.*_BGC%B">SSP370_eam_CMIP6_bgc</value>
       <value compset="SSP585(?:SOI)?_EAM.*CMIP6">SSP585_cam5_CMIP6</value>
       <value compset="SSP585(?:SOI)?_EAM.*CMIP6.*_BGC%B">SSP585_cam5_CMIP6_bgc</value>
       <value compset="20TR(?:SOI)?_EAM.*AR5sf" >20TR_E3SMv1_superfast_ar5-emis</value>

--- a/components/eam/cime_config/config_compsets.xml
+++ b/components/eam/cime_config/config_compsets.xml
@@ -203,6 +203,21 @@
     <lname>2000_EAM%AQUA_SLND_SICE_DOCN%AQPFILE_SROF_SGLC_SWAV</lname>
   </compset>
 
+  <compset>
+    <alias>FSSP370_chemUCI-Linozv3</alias>
+    <lname>SSP370_EAM%CHEMUCI-LINOZV3_ELM%SPBC_MPASSI%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>FSSP370_chemUCI-Linozv2</alias>
+    <lname>SSP370_EAM%CHEMUCI-LINOZV2_ELM%SPBC_MPASSI%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>SSP370_eam_CMIP6</alias>
+    <lname>SSP370_EAM%CMIP6_ELM%SPBC_MPASSI%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
+  </compset>
+
   <!-- MMF aquaplanet compsets -->
   <compset>
     <alias>F-MMF1-AQP1</alias>
@@ -257,6 +272,8 @@
   <!-- *********************************** -->
   <!-- Radiative-Convective Equilibrium (RCE) -->
   <!-- *********************************** -->
+
+
   <compset>
     <alias>F-EAM-RCEMIP</alias>
     <lname>2000_EAM%RCE_SLND_SICE_DOCN%AQPCONST_SROF_SGLC_SWAV</lname>

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/ne4_v3atm_rtmoff/user_nl_eam
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/ne4_v3atm_rtmoff/user_nl_eam
@@ -1,0 +1,43 @@
+! The settings needed for chemUCI-Linozv3 in v3atm's 4th full smoke test
+! This is to ease testing with F20TR_chemUCI-Linozv3
+
+ ncdata = '$DIN_LOC_ROOT/atm/cam/inic/homme/20220906.v2.LR.bi-grid.amip.chemUCI_Linozv3.eam.i.2000-01-01-00000.mapped_to_ne4np4.nc'
+ tropopause_e90_thrd    = 80.0e-9
+ history_gaschmbudget_2D = .false.
+ history_gaschmbudget_2D_levels = .false.
+ history_UCIgaschmbudget_2D = .false.
+ history_UCIgaschmbudget_2D_levels = .false.
+ gaschmbudget_2D_L1_s =  1
+ gaschmbudget_2D_L1_e = 26
+ gaschmbudget_2D_L2_s = 27
+ gaschmbudget_2D_L2_e = 38
+ gaschmbudget_2D_L3_s = 39
+ gaschmbudget_2D_L3_e = 58
+ gaschmbudget_2D_L4_s = 59
+ gaschmbudget_2D_L4_e = 72
+! history_aero_optics    = .true.
+! history_aerosol        = .true.
+! history_amwg           = .true.
+! history_budget         = .true.
+! history_verbose        = .true.
+ cosp_lite = .true.
+
+ linoz_psc_t = 198.0
+
+! update species for using F20TR-chemUCI-Linozv3
+! follow https://acme-climate.atlassian.net/wiki/spaces/NGDAP/pages/3566043211/20220914.PAN.MZThet.v2.LR.bi-grid.amip.chemUCI+Linozv3
+
+ rad_climate            = 'A:H2OLNZ:H2O', 'N:O2:O2', 'N:CO2:CO2',
+         'A:O3:O3', 'A:N2OLNZ:N2O', 'A:CH4LNZ:CH4',
+         'N:CFC11:CFC11', 'N:CFC12:CFC12',
+         'M:mam4_mode1:$DIN_LOC_ROOT/atm/cam/physprops/mam4_mode1_rrtmg_aeronetdust_c141106.nc',
+         'M:mam4_mode2:$DIN_LOC_ROOT/atm/cam/physprops/mam4_mode2_rrtmg_c130628.nc',
+         'M:mam4_mode3:$DIN_LOC_ROOT/atm/cam/physprops/mam4_mode3_rrtmg_aeronetdust_c141106.nc',
+         'M:mam4_mode4:$DIN_LOC_ROOT/atm/cam/physprops/mam4_mode4_rrtmg_c130628.nc'
+
+! sad_file is needed for F20TR-chemUCI-Linozv3, not needed only after enabling MAM5
+
+ sad_file               = '$DIN_LOC_ROOT/atm/waccm/sulf/SAD_SULF_1849-2100_1.9x2.5_c090817.nc'
+
+! default using
+! sad_file               = '$DIN_LOC_ROOT/atm/waccm/sulf/SAD_SULF_1950-2011_1.9x2.5_c130102.nc'

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/ne4_v3atm_rtmoff/user_nl_elm
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/ne4_v3atm_rtmoff/user_nl_elm
@@ -1,0 +1,6 @@
+! Allow more tolerance by skipping all following consistency checks for testing purpose
+
+ check_finidat_year_consistency = .false.
+ check_dynpft_consistency = .false.
+ check_finidat_fsurdat_consistency = .false.
+ check_finidat_pct_consistency   = .false.

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/ne4_v3atm_rtmoff/user_nl_mosart
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/ne4_v3atm_rtmoff/user_nl_mosart
@@ -1,0 +1,7 @@
+! disable rtm to allow short ERS and ERP run to complete.
+! If rtm active, due to large rtm time step, restart pointer for ROF
+! is always ahead of that for atm at the end of the first run. And in
+! restart run, the restart point for ROF becomes later than the run stop time
+
+ do_rtm =.false.
+

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/v3atm_rtmoff/user_nl_eam
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/v3atm_rtmoff/user_nl_eam
@@ -1,0 +1,43 @@
+! The settings needed for chemUCI-Linozv3 in v3atm's 4th full smoke test
+! This is to ease testing with F20TR_chemUCI-Linozv3
+
+ ncdata = '$DIN_LOC_ROOT/atm/cam/inic/homme/NGD_v3atm.ne30pg2.eam.i.0001-01-01-00000.c20230106.nc'
+ tropopause_e90_thrd    = 80.0e-9
+ history_gaschmbudget_2D = .false.
+ history_gaschmbudget_2D_levels = .false.
+ history_UCIgaschmbudget_2D = .false.
+ history_UCIgaschmbudget_2D_levels = .false.
+ gaschmbudget_2D_L1_s =  1
+ gaschmbudget_2D_L1_e = 26
+ gaschmbudget_2D_L2_s = 27
+ gaschmbudget_2D_L2_e = 38
+ gaschmbudget_2D_L3_s = 39
+ gaschmbudget_2D_L3_e = 58
+ gaschmbudget_2D_L4_s = 59
+ gaschmbudget_2D_L4_e = 72
+! history_aero_optics    = .true.
+! history_aerosol        = .true.
+! history_amwg           = .true.
+! history_budget         = .true.
+! history_verbose        = .true.
+ cosp_lite = .true.
+
+ linoz_psc_t = 198.0
+
+! update species for using F20TR-chemUCI-Linozv3
+! follow https://acme-climate.atlassian.net/wiki/spaces/NGDAP/pages/3566043211/20220914.PAN.MZThet.v2.LR.bi-grid.amip.chemUCI+Linozv3
+
+ rad_climate            = 'A:H2OLNZ:H2O', 'N:O2:O2', 'N:CO2:CO2',
+         'A:O3:O3', 'A:N2OLNZ:N2O', 'A:CH4LNZ:CH4',
+         'N:CFC11:CFC11', 'N:CFC12:CFC12',
+         'M:mam4_mode1:$DIN_LOC_ROOT/atm/cam/physprops/mam4_mode1_rrtmg_aeronetdust_c141106.nc',
+         'M:mam4_mode2:$DIN_LOC_ROOT/atm/cam/physprops/mam4_mode2_rrtmg_c130628.nc',
+         'M:mam4_mode3:$DIN_LOC_ROOT/atm/cam/physprops/mam4_mode3_rrtmg_aeronetdust_c141106.nc',
+         'M:mam4_mode4:$DIN_LOC_ROOT/atm/cam/physprops/mam4_mode4_rrtmg_c130628.nc'
+
+! sad_file is needed for F20TR-chemUCI-Linozv3, not needed only after enabling MAM5
+
+ sad_file               = '$DIN_LOC_ROOT/atm/waccm/sulf/SAD_SULF_1849-2100_1.9x2.5_c090817.nc'
+
+! default using
+! sad_file               = '$DIN_LOC_ROOT/atm/waccm/sulf/SAD_SULF_1950-2011_1.9x2.5_c130102.nc'

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/v3atm_rtmoff/user_nl_elm
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/v3atm_rtmoff/user_nl_elm
@@ -1,0 +1,6 @@
+! Allow more tolerance by skipping all following consistency checks for testing purpose
+
+ check_finidat_year_consistency = .false.
+ check_dynpft_consistency = .false.
+ check_finidat_fsurdat_consistency = .false.
+ check_finidat_pct_consistency   = .false.

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/v3atm_rtmoff/user_nl_mosart
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/v3atm_rtmoff/user_nl_mosart
@@ -1,0 +1,7 @@
+! disable rtm to allow short ERS and ERP run to complete.
+! If rtm active, due to large rtm time step, restart pointer for ROF
+! is always ahead of that for atm at the end of the first run. And in
+! restart run, the restart point for ROF becomes later than the run stop time
+
+ do_rtm =.false.
+

--- a/components/eam/src/chemistry/mozart/lin_strat_chem.F90
+++ b/components/eam/src/chemistry/mozart/lin_strat_chem.F90
@@ -179,11 +179,12 @@ end subroutine linoz_readnl
     no2_ndx  =   get_spc_ndx('NO2')
     hno3_ndx =   get_spc_ndx('HNO3')
 
-   !if(masterproc)then
+   if(masterproc)then
    ! write(iulog,*)'in subroutine lin_strat_chem_inti'
    ! write(iulog,*)'O3LNZ=',o3lnz_ndx,'N2OLNZ=',n2olnz_ndx,'NOYLNZ=',noylnz_ndx,'H2OLNZ=',h2olnz_ndx
    ! write(iulog,*)'O3=',o3_ndx,'CH4=',ch4_ndx,'N2O=',n2o_ndx,'NO=',no_ndx,'NO2=',no2_ndx,'HNO3=',hno3_ndx
-   !end if
+   write(iulog,*)'inside lin_strat_solve for ndx o3, o3lnz, n2o, noylnz, ch4', o3_ndx, o3lnz_ndx, n2o_ndx, noylnz_ndx, ch4_ndx
+   end if
     
 !     
 !   initialize the linoz data
@@ -983,7 +984,14 @@ end subroutine linoz_readnl
        mw(1) =  adv_mass(o3lnz_ndx)
        sfc_const(1,:)= o3_sfc
        o3_lbl=4
+     elseif (o3_ndx > 0) then
+       ms=1
+       nx(1) =  o3_ndx
+       mw(1) =  adv_mass(o3_ndx)
+       sfc_const(1,:)= o3_sfc
+       o3_lbl=4
      else
+       write(iulog,*)'warning: linoz_v2 is on but no surface o3 loss'
        return
      endif
     endif

--- a/components/eam/src/chemistry/mozart/lin_strat_chem.F90
+++ b/components/eam/src/chemistry/mozart/lin_strat_chem.F90
@@ -159,12 +159,12 @@ end subroutine linoz_readnl
 
     uci1_ndx    = get_rxt_ndx('uci1')
 
-    if (uci1_ndx <=0 ) then
-       !write(iulog,*) 'skip Linoz, need to have tracer O3LNZ at least '
-       write(iulog,*) 'skip Linoz, temporally change '
-       do_lin_strat_chem = .false.
-       return
-    end if
+    !if (uci1_ndx <=0 ) then
+    !   !write(iulog,*) 'skip Linoz, need to have tracer O3LNZ at least '
+    !   write(iulog,*) 'skip Linoz, temporally change '
+    !   do_lin_strat_chem = .false.
+    !   return
+    !end if
 
     !linoz_v3= (o3lnz_ndx > 0 .and. n2olnz_ndx >0  .and. noylnz_ndx >0  .and. ch4lnz_ndx > 0)
     !linoz_v2= (o3lnz_ndx > 0 .and. n2olnz_ndx <0  .and. noylnz_ndx <0  .and. ch4lnz_ndx < 0)

--- a/components/eam/src/chemistry/mozart/lin_strat_chem.F90
+++ b/components/eam/src/chemistry/mozart/lin_strat_chem.F90
@@ -290,7 +290,7 @@ end subroutine linoz_readnl
     real(r8), intent(in)                           :: delta_t             ! timestep size (secs)
     real(r8), intent(in)                           :: rlats(ncol)         ! column latitudes (radians)
     integer,  intent(in)   , dimension(pcols)      :: ltrop               ! chunk index    
-    real(r8), intent(in)   , dimension(ncol ,pver) :: pdeldry             !  dry pressure delta about midpoints (Pa) 
+    real(r8), intent(in)   , dimension(pcols ,pver) :: pdeldry             !  dry pressure delta about midpoints (Pa) 
     logical, optional, intent(in)                  :: tropFlag(pcols,pver)! 3D tropospheric level flag
     !
     integer  :: i,k,n,ll,lt0,lt, n_dl !,index_lat,index_month

--- a/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -1020,15 +1020,15 @@ contains
          + het_rates(i,k,o3_ndx)) *vmr(i,k,o3_ndx)  
 
       ! closure check - non-closure due to non-convergent in implicit solver 
-         p_l_net = chem_prod(i,k,o3_ndx)-chem_loss(i,k,o3_ndx)
-         tmp_tdi = (vmr(i,k,o3_ndx)-vmr_old2(i,k,o3_ndx))/delt
-         tmp_a = (p_l_net - tmp_tdi) * (p_l_net - tmp_tdi)
-         tmp_b = tmp_tdi * tmp_tdi
-         if (sqrt(tmp_a/tmp_b) > 1.e-6) then
-            vmr(i,k,o3_ndx) = vmr_old2(i,k,o3_ndx)
-            chem_prod(i,k,o3_ndx) = 0. 
-            chem_loss(i,k,o3_ndx) = 0.
-         end if
+         !p_l_net = chem_prod(i,k,o3_ndx)-chem_loss(i,k,o3_ndx)
+         !tmp_tdi = (vmr(i,k,o3_ndx)-vmr_old2(i,k,o3_ndx))/delt
+         !tmp_a = (p_l_net - tmp_tdi) * (p_l_net - tmp_tdi)
+         !tmp_b = tmp_tdi * tmp_tdi
+         !if (sqrt(tmp_a/tmp_b) > 1.e-6) then
+         !   vmr(i,k,o3_ndx) = vmr_old2(i,k,o3_ndx)
+         !   chem_prod(i,k,o3_ndx) = 0. 
+         !   chem_loss(i,k,o3_ndx) = 0.
+         !end if
 
       end do column0_loop
       end do level0_loop
@@ -1570,18 +1570,20 @@ contains
        do m = 1,pcnst
           n = map2chm( m )
           if ( n > 0 ) then
-            if ( any( cflx(:ncol,m) /= 0._r8 ) ) then
+           do i=1,ncol
+            if ( cflx(i,m) /= 0._r8  ) then
               if ( .not. any( aer_species == n ) .and. adv_mass(n) /= 0._r8 ) then
                 do k = pver, pver-srf_emit_nlayer+1, -1 ! loop from bottom to top
                   ! kg/m2, tracer mass
-                  wrk(:ncol,k) = adv_mass(n)*vmr(:ncol,k,n)/mbar(:ncol,k) &
-                                    *pdeldry(:ncol,k)*rga
-                  tmp(:ncol) = wrk(:ncol,k) + cflx(:ncol,m)*delt/dble(srf_emit_nlayer)
-                  vmr(:ncol,k,n) = tmp(:ncol)*mbar(:ncol,k)/adv_mass(n)/pdeldry(:ncol,k)/rga
+                  wrk(i,k) = adv_mass(n)*vmr(i,k,n)/mbar(i,k) &
+                                    *pdeldry(i,k)*rga
+                  tmp(i) = wrk(i,k) + cflx(i,m)*delt/dble(srf_emit_nlayer)
+                  vmr(i,k,n) = tmp(i)*mbar(i,k)/adv_mass(n)/pdeldry(i,k)/rga
                 end do
-                cflx(:ncol,m) = 0._r8
+                cflx(i,m) = 0._r8
               endif
             endif
+           end do
           endif
        end do
     endif

--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -2040,6 +2040,9 @@ subroutine tphysbc (ztodt,               &
     real(r8) :: prec_sed_macmic(pcols)
     real(r8) :: snow_sed_macmic(pcols)
 
+    !for tropopause check when no E90 input
+    integer :: e90_ndx
+
     ! energy checking variables
     real(r8) :: zero(pcols)                    ! array of zeros
     real(r8) :: zero_sc(pcols*psubcols)        ! array of zeros
@@ -2766,7 +2769,10 @@ end if ! l_rad
     ! Diagnose the location of the tropopause and its location to the history file(s).
     call t_startf('tropopause')
     call tropopause_output(state)
+    e90_ndx = get_spc_ndx('E90')
+    if (e90_ndx > 0) then
     call tropopause_e90_3d_output(state)
+    endif
     call t_stopf('tropopause')
 
     ! Save atmospheric fields to force surface models

--- a/components/elm/bld/namelist_files/namelist_defaults_clm4_5_tools.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults_clm4_5_tools.xml
@@ -489,7 +489,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <mksrf_fvegtyp hgrid="0.5x0.5" sim_year="2015" crop="off" >lnd/clm2/rawdata/LUT_LUH2_HIST_LUH1f_07082020/LUT_LUH2_historical_2015_c07082020.nc</mksrf_fvegtyp>
 
 <!-- All RCPs start with the ending historical file in 2015 -->
-<!-- For transient LULCC only 2 RCPs are currently available: SSP2 RCP4.5 and SSP5 RCP8.5 (LUT files need to be created for the others) -->
+<!-- For transient LULCC only 2 RCPs are currently available: SSP2 RCP4.5, SSP3 RCP7.0, and SSP5 RCP8.5 (LUT files need to be created for the others) -->
 <!-- But include the start year for the others in case the files become available -->
 <!-- Recall that sim_year just denotes the creation of a file for that year; transient LULCC years processed are based on the list in the file noted in the namelist -->
 <!-- See below for the files for the other years (as available) -->

--- a/components/elm/bld/namelist_files/use_cases/2015-2100_SSP370_CMIP6bgc_transient.xml
+++ b/components/elm/bld/namelist_files/use_cases/2015-2100_SSP370_CMIP6bgc_transient.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+
+<namelist_defaults>
+
+<use_case_desc                 >Simulate transient land-use, and aerosol deposition changes from 2015 to 2100</use_case_desc>
+<use_case_desc bgc="cn"        >Simulate transient land-use, aerosol deposition, and Nitrogen deposition changes from 2015 to 2100</use_case_desc>
+<use_case_desc bgc="cndv"      >Simulate transient land-use, aerosol deposition, and Nitrogen deposition changes from 2015 to 2100</use_case_desc>
+<use_case_desc use_cn=".true." >Simulate transient land-use, aerosol deposition, and Nitrogen deposition changes from 2015 to 2100</use_case_desc>
+
+<!-- <sim_year>1850</sim_year> -->
+
+<sim_year_range>2015-2100</sim_year_range>
+
+<clm_start_type>arb_ic</clm_start_type>
+
+<clm_demand >flanduse_timeseries</clm_demand>
+
+<!-- *** NOT USED FOR SATELLITE PHENOLOGY ***
+<stream_year_first_ndep phys="elm" use_cn=".true."   >1850</stream_year_first_ndep>
+<stream_year_last_ndep  phys="elm" use_cn=".true."   >2101</stream_year_last_ndep>
+<model_year_align_ndep  phys="elm" use_cn=".true."   >1850</model_year_align_ndep>
+
+<stream_year_first_pdep phys="elm" use_cn=".true."   >2000</stream_year_first_pdep>
+<stream_year_last_pdep  phys="elm" use_cn=".true."   >2000</stream_year_last_pdep>
+<model_year_align_pdep  phys="elm" use_cn=".true."   >2000</model_year_align_pdep>
+
+<stream_year_first_popdens phys="elm" use_cn=".true."   >1850</stream_year_first_popdens>
+<stream_year_last_popdens  phys="elm" use_cn=".true."   >2100</stream_year_last_popdens>
+<model_year_align_popdens  phys="elm" use_cn=".true."   >1850</model_year_align_popdens>
+-->
+
+
+<!-- CMIP6 DECK compsets -->
+
+<fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4_simyr1850_2015_c171018.nc </fsurdat>
+<flanduse_timeseries>lnd/clm2/surfdata_map/landuse.timeseries_ne30np4_ssp3_rcp7.0_simyr2015-2100_c190411.nc</flanduse_timeseries>
+<stream_fldfilename_ndep>lnd/clm2/ndepdata/fndep_elm_cbgc_exp_simyr1849-2101_1.9x2.5_c190103.nc</stream_fldfilename_ndep>
+<stream_year_first_ndep>1850</stream_year_first_ndep>
+<stream_year_last_ndep>2101</stream_year_last_ndep>
+<model_year_align_ndep>1850</model_year_align_ndep>
+<stream_fldfilename_popdens>lnd/clm2/firedata/elmforc.ssp3_hdm_0.5x0.5_simyr1850-2100_c190109.nc</stream_fldfilename_popdens>
+<stream_year_first_popdens>1850</stream_year_first_popdens>
+<stream_year_last_popdens>2100</stream_year_last_popdens>
+<model_year_align_popdens>1850</model_year_align_popdens>
+<check_dynpft_consistency>.false.</check_dynpft_consistency>
+</namelist_defaults>

--- a/components/elm/bld/namelist_files/use_cases/2015-2100_SSP370_transient.xml
+++ b/components/elm/bld/namelist_files/use_cases/2015-2100_SSP370_transient.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+
+<namelist_defaults>
+
+<use_case_desc                 >Simulate transient land-use, and aerosol deposition changes from 2015 to 2100</use_case_desc>
+<use_case_desc bgc="cn"        >Simulate transient land-use, aerosol deposition, and Nitrogen deposition changes from 2015 to 2100</use_case_desc>
+<use_case_desc bgc="cndv"      >Simulate transient land-use, aerosol deposition, and Nitrogen deposition changes from 2015 to 2100</use_case_desc>
+<use_case_desc use_cn=".true." >Simulate transient land-use, aerosol deposition, and Nitrogen deposition changes from 2015 to 2100</use_case_desc>
+
+<!-- <sim_year>1850</sim_year> -->
+
+<sim_year_range>2015-2100</sim_year_range>
+
+<clm_start_type>arb_ic</clm_start_type>
+
+<clm_demand >flanduse_timeseries</clm_demand>
+
+<!-- *** NOT USED FOR SATELLITE PHENOLOGY ***
+<stream_year_first_ndep phys="elm" use_cn=".true."   >1850</stream_year_first_ndep>
+<stream_year_last_ndep  phys="elm" use_cn=".true."   >2005</stream_year_last_ndep>
+<model_year_align_ndep  phys="elm" use_cn=".true."   >1850</model_year_align_ndep>
+
+<stream_year_first_pdep phys="elm" use_cn=".true."   >2000</stream_year_first_pdep>
+<stream_year_last_pdep  phys="elm" use_cn=".true."   >2000</stream_year_last_pdep>
+<model_year_align_pdep  phys="elm" use_cn=".true."   >2000</model_year_align_pdep>
+
+<stream_year_first_popdens phys="elm" use_cn=".true."   >1850</stream_year_first_popdens>
+<stream_year_last_popdens  phys="elm" use_cn=".true."   >2010</stream_year_last_popdens>
+<model_year_align_popdens  phys="elm" use_cn=".true."   >1850</model_year_align_popdens>
+-->
+
+
+<!-- CMIP6 DECK compsets -->
+
+<fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4_simyr1850_2015_c171018.nc </fsurdat>
+<flanduse_timeseries>lnd/clm2/surfdata_map/landuse.timeseries_ne30np4_ssp3_rcp7.0_simyr2015-2100_c190411.nc</flanduse_timeseries>
+<check_dynpft_consistency>.false.</check_dynpft_consistency>
+
+</namelist_defaults>

--- a/components/elm/bld/namelist_files/use_cases/2015-2100_SSP370_transient.xml
+++ b/components/elm/bld/namelist_files/use_cases/2015-2100_SSP370_transient.xml
@@ -32,8 +32,14 @@
 
 <!-- CMIP6 DECK compsets -->
 
-<fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4_simyr1850_2015_c171018.nc </fsurdat>
-<flanduse_timeseries>lnd/clm2/surfdata_map/landuse.timeseries_ne30np4_ssp3_rcp7.0_simyr2015-2100_c190411.nc</flanduse_timeseries>
+<fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4.pg2_SSP3_RCP70_simyr2015_c220420.nc </fsurdat>
+<flanduse_timeseries>lnd/clm2/surfdata_map/landuse.timeseries_ne30pg2_SSP3_RCP70_simyr2015-2100_c211015.nc</flanduse_timeseries>
+
+<!-- Add following for hybrid run of SSP370 continuing from a historical simulation -->
+
+<check_finidat_fsurdat_consistency>.false.</check_finidat_fsurdat_consistency>
+<check_finidat_year_consistency>.true.</check_finidat_year_consistency>
+<check_finidat_pct_consistency>.true.</check_finidat_pct_consistency>
 <check_dynpft_consistency>.false.</check_dynpft_consistency>
 
 </namelist_defaults>

--- a/components/elm/bld/namelist_files/use_cases/2015-2100_SSP585_transient.xml
+++ b/components/elm/bld/namelist_files/use_cases/2015-2100_SSP585_transient.xml
@@ -32,8 +32,14 @@
 
 <!-- CMIP6 DECK compsets -->
 
-<fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4_simyr1850_2015_c171018.nc </fsurdat>
-<flanduse_timeseries>lnd/clm2/surfdata_map/landuse.timeseries_ne30np4_ssp5_rcp8.5_simyr2015-2100_c190411.nc</flanduse_timeseries>
+<fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4.pg2_SSP5_RCP85_simyr2015_c220420.nc </fsurdat>
+<flanduse_timeseries>lnd/clm2/surfdata_map/landuse.timeseries_ne30pg2_SSP5_RCP85_simyr2015-2100_c220310.nc</flanduse_timeseries>
+
+<!-- Add following for hybrid run of SSP370 continuing from a historical simulation -->
+
+<check_finidat_fsurdat_consistency>.false.</check_finidat_fsurdat_consistency>
+<check_finidat_year_consistency>.true.</check_finidat_year_consistency>
+<check_finidat_pct_consistency>.true.</check_finidat_pct_consistency>
 <check_dynpft_consistency>.false.</check_dynpft_consistency>
 
 </namelist_defaults>

--- a/components/elm/cime_config/config_component.xml
+++ b/components/elm/cime_config/config_component.xml
@@ -79,6 +79,8 @@
       <value compset="2010(?:SOI)?_EAM%CMIP6_ELM">2010_CMIP6_control</value>
       <value compset="2010(?:SOI)?_EAM%CHEMMZT_ELM">2010_CMIP6_control</value>
       <value compset="2010S.*_EAM%CMIP6_ELM">2010_CMIP6_control</value>
+      <value compset="SSP370(?:SOI)?_EAM%CMIP6_ELM">2015-2100_SSP370_transient</value>
+      <value compset="SSP370(?:SOI)?_EAM%CMIP6_ELM*_BGC%B">2015-2100_SSP370_CMIP6bgc_transient</value>
       <value compset="SSP585(?:SOI)?_EAM%CMIP6_ELM">2015-2100_SSP585_transient</value>
       <value compset="SSP585(?:SOI)?_EAM%CMIP6_ELM*_BGC%B">2015-2100_SSP585_CMIP6bgc_transient</value> 
       <value compset="2010(?:SOI)?_EAM%CMIP6-LR_ELM">2010_CMIP6LR_control</value>

--- a/driver-mct/cime_config/config_component_e3sm.xml
+++ b/driver-mct/cime_config/config_component_e3sm.xml
@@ -729,6 +729,7 @@
       <value compset="^1850.+CMIP6.+4xCO2"			>1137.268</value>
       <value compset="^1950.+CMIP6"                             >312.821</value>
       <value compset="^2010.+CMIP6"                             >388.717</value>
+      <value compset="^SSP370.+CMIP6"                           >0.000001</value>
       <value compset="^SSP585.+CMIP6"				>0.000001</value>
       <value compset="^20TR.*BGC%BCRC"                          >284.317</value>
       <value compset="^20TR.*BGC%BCRD"                          >284.317</value>


### PR DESCRIPTION
The current PR is a code base modified based on pull request #62 to run SSP370_eam_CMIP6 simulations with linoz-v2.
The modifications are mostly in components/eam/src/physics/cam/physpkg.F90 and components/eam/src/chemistry/mozart/lin_strat_chem.F90.