### PR TITLE
Sync NGD_v3atm with chemUCI decoupling and SO2/H2SO4 explicit solver bug fixes

### DIFF
--- a/components/eam/chem_proc/inputs/pp_chemUCI_linozv3_mam4_resus_mom_vbs.in
+++ b/components/eam/chem_proc/inputs/pp_chemUCI_linozv3_mam4_resus_mom_vbs.in
@@ -1,5 +1,4 @@
 Comments
-     "Changed to Chem-UCI-MAM5 by Ziming Ke"
      "last touch 20200326 - QT"
      "Modified by Juno Hsu and Qi Tang - 4/9/2020"
      "chemUCI + MAM4 for E3SM"
@@ -61,7 +60,6 @@ SPECIES
   so4_a1 -> NH4HSO4
   so4_a2 -> NH4HSO4
   so4_a3 -> NH4HSO4
-  so4_a5 -> NH4HSO4
   pom_a1 -> C
 * pom_a2 does not exist
   pom_a3 -> C
@@ -88,7 +86,6 @@ SPECIES
   num_a2 -> H
   num_a3 -> H
   num_a4 -> H
-  num_a5 -> H
  End Solution
 
  Fixed
@@ -109,13 +106,13 @@ Solution Classes
    CO, C2H6, C3H8, CH3COCH3
    E90, N2OLNZ, NOYLNZ, CH4LNZ, H2OLNZ
    DMS, SO2, H2SO4
-   so4_a1,  so4_a2,  so4_a3,  so4_a5
+   so4_a1,  so4_a2,  so4_a3
    pom_a1,           pom_a3,  pom_a4
    bc_a1,            bc_a3,   bc_a4
    dst_a1,           dst_a3
    ncl_a1,  ncl_a2,  ncl_a3
    mom_a1,  mom_a2,  mom_a3,  mom_a4
-   num_a1,  num_a2,  num_a3,  num_a4, num_a5
+   num_a1,  num_a2,  num_a3,  num_a4
  End Explicit
 
  Implicit

--- a/components/eam/src/chemistry/mozart/mo_exp_sol.F90
+++ b/components/eam/src/chemistry/mozart/mo_exp_sol.F90
@@ -147,6 +147,16 @@ contains
          end do 
 #endif         
        !kzm --
+       ! SO2 and H2SO4 can be dead zeros due to aerosol processes
+       ! use a different equation for them to avoid debug built issues
+       elseif (trim(solsym(l)) == 'H2SO4' .or. trim(solsym(l)) == 'SO2') then
+          do i = 1,ncol
+              do k = ltrop(i)+1,pver
+                 chem_loss(i,k,l) = -loss(i,k,m)
+                 chem_prod(i,k,l) = prod(i,k,m)+ind_prd(i,k,m) 
+                 base_sol(i,k,l) = base_sol(i,k,l) + delt * (prod(i,k,m) + ind_prd(i,k,m) - loss(i,k,m))
+              end do
+          end do
        else
           do i = 1,ncol
              do k = ltrop(i)+1,pver
@@ -164,17 +174,28 @@ contains
        
     end do
 !----------- for UCIchem diagnostics ------------
+    ! Note: base_sol_rest and diags_reaction_rates are passed to indprd and exp_prod_loss
+    !       so the reset tendency for tropopause folds (i.e., stratospheric boxes below the tropopause)
+    !       and the explicit solver tendency are included in chemmp_prod and chemmp_loss below.
     call indprd( 1, ind_prd, clscnt1, base_sol_reset, extfrc, &
          diags_reaction_rates, ncol )
     call exp_prod_loss( prod, loss, base_sol_reset, diags_reaction_rates, het_rates )
     do m = 1,clscnt1
        l = clsmap(m,1)
-        do i = 1,ncol
-           do k = ltrop(i)+1,pver
-              chemmp_prod(i,k,l) = prod(i,k,m)+ind_prd(i,k,m)
-              chemmp_loss(i,k,l) = (base_sol_reset(i,k,l)*exp(-delt*loss(i,k,m)/base_sol_reset(i,k,l)) - base_sol_reset(i,k,l))/delt
+       if (trim(solsym(l)) == 'H2SO4' .or. trim(solsym(l)) == 'SO2') then
+           do i = 1,ncol
+              do k = ltrop(i)+1,pver
+                 chemmp_prod(i,k,l) = prod(i,k,m)+ind_prd(i,k,m)
+                 chemmp_loss(i,k,l) = -loss(i,k,m)
+              end do
            end do
-        end do
+       else
+           do i = 1,ncol
+              do k = ltrop(i)+1,pver
+                 chemmp_prod(i,k,l) = prod(i,k,m)+ind_prd(i,k,m)
+                 chemmp_loss(i,k,l) = (base_sol_reset(i,k,l)*exp(-delt*loss(i,k,m)/base_sol_reset(i,k,l)) - base_sol_reset(i,k,l))/delt
+              end do
+       endif
     end do
 
   end subroutine exp_sol

--- a/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -1081,6 +1081,9 @@ contains
           do k = 1,pver
              if ( .not. tropFlag(i,k) ) then
                 vmr(i,k,:) = vmr_old2(i,k,:)
+                ! Zero out the reaction rates (only for diagnostic purpose) in the stratosphere
+                ! Only need to do this one time and diags_reaction_rates will be used below
+                ! in the exp_sol to diagnose the chemistry prod/loss rates.
                 diags_reaction_rates(i,k,:) = 0._r8
              endif
           enddo


### PR DESCRIPTION
This PR manually picks commits from E3SM upstream that are yet to be merged in order to synchronize the v3atm fork (the NGD_v3atm branch within the fork)

- decoupling SOA and ChemUCI (BFB - https://github.com/E3SM-Project/E3SM/pull/5719)
- changing explicit solver eqn for SO2 and H2SO4 (BFB - https://github.com/E3SM-Project/E3SM/pull/5718)

The identifies of the original authors are kept here, though it is unclear if necessary fixes are important:
1. https://github.com/E3SM-Project/E3SM/pull/5718 will conflict with the MAM5 PR (https://github.com/E3SM-Project/E3SM/pull/5703; which is already in NGD_v3atm is some fashion). I opted to put the edits after the MAM5 statements for SO2/H2SO4
2. Unclear if https://github.com/E3SM-Project/E3SM/pull/5719 is ready to be merged. Additionally, there seem to be two redundant files for the chem mech that may need editing (I opted to copy the ones from upstream verbatim, i.e., with the same file names as upstream)